### PR TITLE
Check the shell environment on pod to fix the terminal launch failure issue

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -998,10 +998,7 @@ function execTerminalOnPod(podName : string, terminalCmd : string) {
 
 async function isBashOnPod(podName : string): Promise<boolean> {
     const result = await kubectl.invokeAsync(`exec ${podName} -- ls -la /bin/bash`);
-    if (result.code !== 0) {
-        return false;
-    }
-    return true;
+    return !result.code;
 }
 
 function syncKubernetes() {

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -6,6 +6,7 @@ import * as binutil from './binutil';
 export interface Kubectl {
     checkPresent(errorMessageMode : CheckPresentMessageMode) : Promise<boolean>;
     invoke(command : string, handler? : ShellHandler) : Promise<void>;
+    invokeAsync(command : string) : Promise<ShellResult>;
     asLines(command : string): Promise<string[] | ShellResult>;
     path() : string;
 }
@@ -30,6 +31,9 @@ class KubectlImpl implements Kubectl {
     }
     invoke(command : string, handler? : ShellHandler) : Promise<void> {
         return invoke(this.context, command, handler);
+    }
+    invokeAsync(command : string) : Promise<ShellResult> {
+        return invokeAsync(this.context, command);
     }
     asLines(command : string) : Promise<string[] | ShellResult> {
         return asLines(this.context, command);
@@ -77,7 +81,7 @@ async function invoke(context : Context, command : string, handler? : ShellHandl
     await kubectlInternal(context, command, handler || kubectlDone(context));
 }
 
-async function invokeAsync(context : Context, command : string, handler? : ShellHandler) : Promise<ShellResult> {
+async function invokeAsync(context : Context, command : string) : Promise<ShellResult> {
     const bin = baseKubectlPath(context);
     let cmd = bin + ' ' + command;
     return await context.shell.exec(cmd);


### PR DESCRIPTION
When the pod is running on an image without bash installed, launching terminal would fail. See the bug https://github.com/Azure/vscode-kubernetes-tools/issues/15

Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>