### PR TITLE
Use the new VS Code debug API

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "0.1.0",
     "publisher": "Microsoft",
     "engines": {
-        "vscode": "^1.13.0"
+        "vscode": "^1.19.0"
     },
     "license": "MIT",
     "categories": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1157,16 +1157,18 @@ const _doDebug = (name, image, cmd) => {
             waitForRunningPod(podName, () => {
                 kubectl.invoke(` port-forward ${podName} 5858:5858 8000:8000`);
 
-                vscode.commands.executeCommand(
-                    'vscode.startDebug',
-                    {
-                        type: 'node',
-                        request: 'attach',
-                        name: 'Attach to Process',
-                        port: 5858,
-                        localRoot: vscode.workspace.rootPath,
-                        remoteRoot: '/'
-                    }
+                const debugConfiguration = {
+                    type: 'node',
+                    request: 'attach',
+                    name: 'Attach to Process',
+                    port: 5858,
+                    localRoot: vscode.workspace.rootPath,
+                    remoteRoot: '/'
+                };
+                
+                vscode.debug.startDebugging(
+                    undefined,
+                    debugConfiguration
                 ).then(() => {
                     vscode.window.showInformationMessage('Debug session established', 'Expose Service').then((opt) => {
                         if (opt !== 'Expose Service') {


### PR DESCRIPTION
The old VS Code API for launching a debug session was removed a couple of releases ago, which broke our Kubernetes Debug command.  With this change we invoke the new API and it works again (at least, it works as well as it ever did!).