### PR TITLE
Support configuring the extension from AKS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## The 'Create Cluster' and 'Configure From Cluster' Commands
+
+The 'Create Cluster' and 'Configure from Cluster' commands rely on provider-specific tools or APIs for interacting with the cloud or cluster.  Unfortunately, we don't have a general-purpose, API-style extension point for implementing new cloud providers, because we don't know enough about how configuring different cluster types might work in different environments.
+
+At the moment, the extension provides a generic (albeit fiddly) mechanism for managing a series of pages in a UI (example: displaying a list of accounts for the user to choose from), invoking tools or APIs for populating state to be used in constructing those pages (example: invoking the Azure CLI to get a list of subscriptions), and flowing choices and state between those pages (example: returning the selected account so that another tool can list the clusters in that account).  However, the cloud-specific pages and logic have to be built using artisanal TypeScript and built into this extension via pull request - we don't provide a nice way for you to externalise different providers.
+
+We'd be _really really happy_ to work with anyone wanting to implement providers for e.g. minikube, GKE, EKS, etc., both to help you understand how the existing implementation works, and to collaborate on simplifying and stabilising an extension mechanism.

--- a/README.md
+++ b/README.md
@@ -144,3 +144,5 @@ provided by the bot. You will only need to do this once across all repos using o
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+For technical information about contributing, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ unexpected ways.
 For setting up `kubectl` you have a couple of additional options:
 
    * If `kubectl` is not on your PATH then you can tell the extension its location using the `vs-kubernetes.kubectl-path` workspace setting. This should be the full file name and path of the kubectl binary.
-   * If you are using the extension to work with an Azure Container Service then you can install and configure `kubectl` using the `Kubernetes Configure from ACS` command.
+   * If you are using the extension to work with Azure Container Services or Azure Kubernetes Services then you can install and configure `kubectl` using the `Kubernetes Configure from Cluster` command.
 
 ### Setting up your environment for Helm and Draft
 
@@ -83,7 +83,7 @@ Where `<your-image-prefix-here>` is something like `docker.io/brendanburns`.
 
 ### Configuration commands
 
-   * `Kubernetes: Configure from ACS` - Install and configure the Kubernetes command line tool (kubectl) from an Azure Container Service
+   * `Kubernetes Configure from Cluster` - Install and configure the Kubernetes command line tool (kubectl) from an Azure Container Service (ACS) or Azure Kubernetes Service (AKS) cluster
 
 ### Helm support
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "onCommand:extension.vsKubernetesScale",
         "onCommand:extension.vsKubernetesDebug",
         "onCommand:extension.vsKubernetesRemoveDebug",
-        "onCommand:extension.vsKubernetesConfigureFromAcs",
+        "onCommand:extension.vsKubernetesConfigureFromCluster",
         "onCommand:extension.vsKubernetesCreateCluster",
         "onCommand:extension.helmTemplate",
         "onCommand:extension.helmTemplatePreview",
@@ -244,8 +244,8 @@
                 "category": "Kubernetes"
             },
             {
-                "command": "extension.vsKubernetesConfigureFromAcs",
-                "title": "Configure from ACS",
+                "command": "extension.vsKubernetesConfigureFromCluster",
+                "title": "Configure from Cluster",
                 "category": "Kubernetes"
             },
             {

--- a/src/configurefromcluster.ts
+++ b/src/configurefromcluster.ts
@@ -212,7 +212,7 @@ async function downloadCli(context: Context, clusterType: string) : Promise<any>
 }
 
 async function getCredentials(context: Context, clusterType: string, clusterName: string, clusterGroup: string) : Promise<any> {
-    const cmd = `az ${getClusterCommandAndSubcommand(clusterType)} get-credentials -n ` + clusterName + ' -g ' + clusterGroup;
+    const cmd = `az ${getClusterCommandAndSubcommand(clusterType)} get-credentials -n ${clusterName} -g ${clusterGroup}`;
     const sr = await context.shell.exec(cmd);
 
     if (sr.code === 0 && !sr.stderr) {
@@ -446,7 +446,7 @@ function listClustersFilter(clusterType: string): string {
 
 function getListClustersCommand(context: Context, clusterType: string) : string {
     let filter = listClustersFilter(clusterType);
-    let query = '[' + filter + '].{name:name,resourceGroup:resourceGroup}';
+    let query = `[${filter}].{name:name,resourceGroup:resourceGroup}`;
     if (context.shell.isUnix()) {
         query = `'${query}'`;
     }

--- a/src/configurefromcluster.ts
+++ b/src/configurefromcluster.ts
@@ -106,20 +106,6 @@ async function next(context: Context, sourceState: OperationState<OperationStage
                 stage: OperationStage.PromptForCluster
             };
             return psStageData;
-            // if (!clusterList.result.succeeded) {
-            //     return {
-            //         last: clusterList,
-            //         stage: OperationStage.PromptForCluster
-            //     };
-            // }
-            // const psStateInfo = {clusterType: clusterType, clusterList: clusterList.result.result};
-            // return {
-            //     last: {
-            //         actionDescription: clusterList.actionDescription,
-            //         result: { succeeded: true, result: psStateInfo, error: [] }
-            //     },
-            //     stage: OperationStage.PromptForCluster
-            // };
         case OperationStage.PromptForCluster:
             const selectedCluster = parseCluster(requestData);
             const clusterTypeEncore : string = sourceState.last.result.result.clusterType;  // TODO: rename

--- a/src/createcluster.ts
+++ b/src/createcluster.ts
@@ -332,7 +332,7 @@ function render(operationId: string, state: OperationState<OperationStage>) : st
             return renderPromptForAgentSettings(operationId, state.last);
         case OperationStage.InternalError:
            return renderInternalError(state.last);
-        case OperationStage.InternalError:
+        case OperationStage.ExternalError:
            return renderExternalError(state.last);
         case OperationStage.Complete:
             return renderComplete(state.last);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ import * as uuid from 'uuid';
 import { host } from './host';
 import * as explainer from './explainer';
 import { shell, ShellResult } from './shell';
-import * as acs from './acs';
+import * as configureFromCluster from './acs';
 import * as createCluster from './createcluster';
 import { UIRequest as WizardUIRequest } from './wizard';
 import * as kuberesources from './kuberesources';
@@ -41,7 +41,7 @@ let swaggerSpecPromise = null;
 
 const kubectl = kubectlCreate(host, fs, shell);
 const draft = draftCreate(host, fs, shell);
-const acsui = acs.uiProvider(fs, shell);
+const configureFromClusterUI = configureFromCluster.uiProvider(fs, shell);
 const createClusterUI = createCluster.uiProvider(fs, shell);
 
 // Filters for different Helm file types.
@@ -88,7 +88,7 @@ export function activate(context) {
         vscode.commands.registerCommand('extension.vsKubernetesScale', scaleKubernetes),
         vscode.commands.registerCommand('extension.vsKubernetesDebug', debugKubernetes),
         vscode.commands.registerCommand('extension.vsKubernetesRemoveDebug', removeDebugKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesConfigureFromAcs', configureFromAcsKubernetes),
+        vscode.commands.registerCommand('extension.vsKubernetesConfigureFromCluster', configureFromClusterKubernetes),
         vscode.commands.registerCommand('extension.vsKubernetesCreateCluster', createClusterKubernetes),
         vscode.commands.registerCommand('extension.vsKubernetesRefreshExplorer', () => treeProvider.refresh()),
 
@@ -109,7 +109,7 @@ export function activate(context) {
         vscode.commands.registerCommand('extension.draftUp', execDraftUp),
 
         // HTML renderers
-        vscode.workspace.registerTextDocumentContentProvider(acs.uriScheme, acsui),
+        vscode.workspace.registerTextDocumentContentProvider(configureFromCluster.uriScheme, configureFromClusterUI),
         vscode.workspace.registerTextDocumentContentProvider(createCluster.uriScheme, createClusterUI),
         vscode.workspace.registerTextDocumentContentProvider(helm.PREVIEW_SCHEME, previewProvider),
         vscode.workspace.registerTextDocumentContentProvider(helm.INSPECT_SCHEME, inspectProvider),
@@ -1260,14 +1260,14 @@ function removeDebugKubernetes() {
     });
 }
 
-async function configureFromAcsKubernetes(request? : WizardUIRequest) {
+async function configureFromClusterKubernetes(request? : WizardUIRequest) {
     if (request) {
-        await acsui.next(request);
+        await configureFromClusterUI.next(request);
     } else {
         const newId : string = uuid.v4();
-        acsui.start(newId);
-        vscode.commands.executeCommand('vscode.previewHtml', acs.operationUri(newId), 2, "Configure Kubernetes");
-        await acsui.next({ operationId: newId, requestData: undefined });
+        configureFromClusterUI.start(newId);
+        vscode.commands.executeCommand('vscode.previewHtml', configureFromCluster.operationUri(newId), 2, "Configure Kubernetes");
+        await configureFromClusterUI.next({ operationId: newId, requestData: undefined });
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ import * as uuid from 'uuid';
 import { host } from './host';
 import * as explainer from './explainer';
 import { shell, ShellResult } from './shell';
-import * as configureFromCluster from './acs';
+import * as configureFromCluster from './configurefromcluster';
 import * as createCluster from './createcluster';
 import { UIRequest as WizardUIRequest } from './wizard';
 import * as kuberesources from './kuberesources';

--- a/test/configurefromcluster.test.ts
+++ b/test/configurefromcluster.test.ts
@@ -4,7 +4,7 @@ import * as assert from 'assert';
 import * as textassert from './textassert';
 import * as fakes from './fakes';
 
-import * as acs from '../src/acs';
+import * as configureFromCluster from '../src/configurefromcluster';
 
 const cancellationToken = new vscode.CancellationTokenSource().token;
 
@@ -13,8 +13,8 @@ interface FakeContext {
     shell? : any;
 }
 
-function acsuiCreateWithFakes(ctx: FakeContext) {
-    return acs.uiProvider(
+function cfcuiCreateWithFakes(ctx: FakeContext) {
+    return configureFromCluster.uiProvider(
         ctx.fs || fakes.fs(),
         ctx.shell || fakes.shell()
     );
@@ -32,9 +32,9 @@ suite("acs tests", () => {
     suite("uiProvider method", () => {
 
         test("Can create UI provider", () => {
-            const acsui = acsuiCreateWithFakes({});
-            assert.notEqual(acsui, undefined);
-            assert.notEqual(acsui, null);
+            const cfcui = cfcuiCreateWithFakes({});
+            assert.notEqual(cfcui, undefined);
+            assert.notEqual(cfcui, null);
         });
 
     });
@@ -42,52 +42,60 @@ suite("acs tests", () => {
     suite("UIProvider class", () => {
 
         test("UI provider raises change event on start", () => {
-            const acsui = acsuiCreateWithFakes({});
+            const cfcui = cfcuiCreateWithFakes({});
             let uris : vscode.Uri[] = [];
-            acsui.onDidChange((uri) => uris.push(uri));
-            acsui.start('foo');
+            cfcui.onDidChange((uri) => uris.push(uri));
+            cfcui.start('foo');
             assert.equal(1, uris.length);
-            assert.equal('acsconfigure://operations/foo', uris[0].toString());
+            assert.equal('k8sconfigure://operations/foo', uris[0].toString());
         });
 
         test("UI provider raises change event on next", async () => {
-            const acsui = acsuiCreateWithFakes({});
+            const cfcui = cfcuiCreateWithFakes({});
             let uris : vscode.Uri[] = [];
-            acsui.start('bar');
-            acsui.onDidChange((uri) => uris.push(uri));
-            await acsui.next({ operationId: 'bar', requestData: null });
+            cfcui.start('bar');
+            cfcui.onDidChange((uri) => uris.push(uri));
+            await cfcui.next({ operationId: 'bar', requestData: null });
             assert.equal(1, uris.length);
-            assert.equal('acsconfigure://operations/bar', uris[0].toString());
+            assert.equal('k8sconfigure://operations/bar', uris[0].toString());
         });
 
         test("Initiating an operation puts it at the initial stage", async () => {
-            const acsui = acsuiCreateWithFakes({});
-            acsui.start('foo');
-            const text = await acsui.provideTextDocumentContent(acs.operationUri('foo'), cancellationToken);
+            const cfcui = cfcuiCreateWithFakes({});
+            cfcui.start('foo');
+            const text = await cfcui.provideTextDocumentContent(configureFromCluster.operationUri('foo'), cancellationToken);
             textassert.startsWith('<!-- Initial -->', text);
         });
 
         test("Advancing an operation puts it through the stages", async () => {
-            const acsui = acsuiCreateWithFakes({});
-            acsui.start('foo');
-            await acsui.next({ operationId: 'foo', requestData: null });
-            const text1 = await acsui.provideTextDocumentContent(acs.operationUri('foo'), cancellationToken);
+            const cfcui = cfcuiCreateWithFakes({
+                fs: fakes.fs({ existentPaths: ['z:\\home\\.ssh/id_rsa'] }),
+                shell: fakes.shell({ isWindows: true, recognisedCommands: [
+                    { command: 'az --version', code: 0, stdout: "azure-cli (2.0.23)" },
+                ] })
+            });
+            cfcui.start('foo');
+            await cfcui.next({ operationId: 'foo', requestData: null });
+            const text0 = await cfcui.provideTextDocumentContent(configureFromCluster.operationUri('foo'), cancellationToken);
+            textassert.startsWith('<!-- PromptForClusterType -->', text0);
+            await cfcui.next({ operationId: 'foo', requestData: 'Azure Container Service' });
+            const text1 = await cfcui.provideTextDocumentContent(configureFromCluster.operationUri('foo'), cancellationToken);
             textassert.startsWith('<!-- PromptForSubscription -->', text1);
-            await acsui.next({ operationId: 'foo', requestData: null });
-            const text2 = await acsui.provideTextDocumentContent(acs.operationUri('foo'), cancellationToken);
+            await cfcui.next({ operationId: 'foo', requestData: 'Sub1' });
+            const text2 = await cfcui.provideTextDocumentContent(configureFromCluster.operationUri('foo'), cancellationToken);
             textassert.startsWith('<!-- PromptForCluster -->', text2);
-            await acsui.next({ operationId: 'foo', requestData: null });
-            const text3 = await acsui.provideTextDocumentContent(acs.operationUri('foo'), cancellationToken);
+            await cfcui.next({ operationId: 'foo', requestData: 'Group1/Clus1' });
+            const text3 = await cfcui.provideTextDocumentContent(configureFromCluster.operationUri('foo'), cancellationToken);
             textassert.startsWith('<!-- Complete -->', text3);
         });
 
         test("Advancing an operation does not affect other operations", async () => {
-            const acsui = acsuiCreateWithFakes({});
-            acsui.start('foo');
-            acsui.start('bar');
-            await acsui.next({ operationId: 'bar', requestData: null });
-            await acsui.next({ operationId: 'bar', requestData: null });
-            const text = await acsui.provideTextDocumentContent(acs.operationUri('foo'), cancellationToken);
+            const cfcui = cfcuiCreateWithFakes({});
+            cfcui.start('foo');
+            cfcui.start('bar');
+            await cfcui.next({ operationId: 'bar', requestData: null });
+            await cfcui.next({ operationId: 'bar', requestData: 'Azure Container Service' });
+            const text = await cfcui.provideTextDocumentContent(configureFromCluster.operationUri('foo'), cancellationToken);
             textassert.startsWith('<!-- Initial -->', text);
         });
 
@@ -96,71 +104,76 @@ suite("acs tests", () => {
     suite("Operation workflow", () => {
 
         test("If the SSH keys are present and the CLI is installed, then it tries to list subscriptions", async () => {
-            const acsui = acsuiCreateWithFakes({
+            const cfcui = cfcuiCreateWithFakes({
                 fs: fakes.fs({ existentPaths: ['z:\\home\\.ssh/id_rsa'] }),
                 shell: fakes.shell({ isWindows: true, recognisedCommands: [
-                    { command: 'az --help', code: 0 },
+                    { command: 'az --version', code: 0, stdout: "azure-cli (2.0.23)" },
                     { command: 'az account list --all --query [*].name -ojson', code: 0, stdout: '["S1", "S2", "S3"]' },
                 ] })
             });
-            acsui.start('foo');
-            await acsui.next({ operationId: 'foo', requestData: null });
-            const state = lastResult(acsui, 'foo');
+            cfcui.start('foo');
+            await cfcui.next({ operationId: 'foo', requestData: null });
+            await cfcui.next({ operationId: 'foo', requestData: 'Azure Container Service' });
+            const state = lastResult(cfcui, 'foo');
             assert.equal(state.result.succeeded, true);
-            assert.equal(state.result.result.length, 3);
-            assert.equal(state.result.result[0], 'S1');
+            assert.equal(state.result.result.subscriptions.length, 3);
+            assert.equal(state.result.result.subscriptions[0], 'S1');
         });
 
         test("If the SSH keys are not present, it is reported", async () => {
-            const acsui = acsuiCreateWithFakes({
+            const cfcui = cfcuiCreateWithFakes({
                 fs: fakes.fs({ existentPaths: [] }),
                 shell: fakes.shell({ isWindows: true, recognisedCommands: [{ command: 'az --help', code: 0 }] })
             });
-            acsui.start('foo');
-            await acsui.next({ operationId: 'foo', requestData: null });
-            const state = lastResult(acsui, 'foo');
+            cfcui.start('foo');
+            await cfcui.next({ operationId: 'foo', requestData: null });
+            await cfcui.next({ operationId: 'foo', requestData: 'Azure Kubernetes Service' });
+            const state = lastResult(cfcui, 'foo');
             assert.equal('checking prerequisites', state.actionDescription);
             assert.equal(state.result.succeeded, false);
             assert.equal(state.result.error.length, 1);
         });
 
         test("If the Azure CLI is not installed, it is reported", async () => {
-            const acsui = acsuiCreateWithFakes({
+            const cfcui = cfcuiCreateWithFakes({
                 fs: fakes.fs({ existentPaths: ['z:\\home\\.ssh/id_rsa'] }),
                 shell: fakes.shell({ isWindows: true })
             });
-            acsui.start('foo');
-            await acsui.next({ operationId: 'foo', requestData: null });
-            const state = lastResult(acsui, 'foo');
+            cfcui.start('foo');
+            await cfcui.next({ operationId: 'foo', requestData: null });
+            await cfcui.next({ operationId: 'foo', requestData: 'Azure Kubernetes Service' });
+            const state = lastResult(cfcui, 'foo');
             assert.equal('checking prerequisites', state.actionDescription);
             assert.equal(state.result.succeeded, false);
             assert.equal(state.result.error.length, 1);
         });
 
         test("If the SSH keys are not present *and* the CLI is not installed, both are reported", async () => {
-            const acsui = acsuiCreateWithFakes({
+            const cfcui = cfcuiCreateWithFakes({
                 fs: fakes.fs({ existentPaths: [] }),
                 shell: fakes.shell({ isWindows: true })
             });
-            acsui.start('foo');
-            await acsui.next({ operationId: 'foo', requestData: null });
-            const state = lastResult(acsui, 'foo');
+            cfcui.start('foo');
+            await cfcui.next({ operationId: 'foo', requestData: null });
+            await cfcui.next({ operationId: 'foo', requestData: 'Azure Container Service' });
+            const state = lastResult(cfcui, 'foo');
             assert.equal('checking prerequisites', state.actionDescription);
             assert.equal(state.result.succeeded, false);
             assert.equal(state.result.error.length, 2);
         });
 
         test("If the SSH keys are present and the CLI is installed, but listing subscriptions fails, the error is reported", async () => {
-            const acsui = acsuiCreateWithFakes({
+            const cfcui = cfcuiCreateWithFakes({
                 fs: fakes.fs({ existentPaths: ['z:\\home\\.ssh/id_rsa'] }),
                 shell: fakes.shell({ isWindows: true, recognisedCommands: [
-                    { command: 'az --help', code: 0 },
+                    { command: 'az --version', code: 0, stdout: "azure-cli (2.0.23)" },
                     { command: 'az account list --all --query [*].name -ojson', code: 2, stderr: 'network error' },
                 ] })
             });
-            acsui.start('foo');
-            await acsui.next({ operationId: 'foo', requestData: null });
-            const state = lastResult(acsui, 'foo');
+            cfcui.start('foo');
+            await cfcui.next({ operationId: 'foo', requestData: null });
+            await cfcui.next({ operationId: 'foo', requestData: 'Azure Container Service' });
+            const state = lastResult(cfcui, 'foo');
             assert.equal('listing subscriptions', state.actionDescription);
             assert.equal(state.result.succeeded, false);
             assert.equal(state.result.error.length, 1);
@@ -169,20 +182,21 @@ suite("acs tests", () => {
 
         test("After listing subscriptions, it selects the subscription returned in the next request", async () => {
             let commands = [];
-            const acsui = acsuiCreateWithFakes({
+            const cfcui = cfcuiCreateWithFakes({
                 fs: fakes.fs({ existentPaths: ['z:\\home\\.ssh/id_rsa'] }),
                 shell: fakes.shell({
                     isWindows: true,
                     recognisedCommands: [
-                        { command: 'az --help', code: 0 },
+                        { command: 'az --version', code: 0, stdout: "azure-cli (2.0.23)" },
                         { command: 'az account list --all --query [*].name -ojson', code: 0, stdout: '["S1", "S2", "S3"]' }
                     ],
                     execCallback: (cmd) => { commands.push(cmd); return { code: 1 /* stop it before it goes on to exec other commands */, stdout: '[]', stderr: ''}; }
                 })
             });
-            acsui.start('foo');
-            await acsui.next({ operationId: 'foo', requestData: null });
-            await acsui.next({ operationId: 'foo', requestData: 'S2' });
+            cfcui.start('foo');
+            await cfcui.next({ operationId: 'foo', requestData: null });
+            await cfcui.next({ operationId: 'foo', requestData: 'Azure Kubernetes Service' });
+            await cfcui.next({ operationId: 'foo', requestData: 'S2' });
             assert.equal(commands.length, 1);
             assert.equal(commands[0], 'az account set --subscription "S2"');
         });

--- a/test/fakes.ts
+++ b/test/fakes.ts
@@ -55,14 +55,14 @@ export function host(settings : FakeHostSettings = {}) : any {
             }
             return settings.configuration || { };
         }
-    }
+    };
 }
 
 export function fs(settings : FakeFSSettings = {}) : any {
     return {
         existsSync: (path) => (settings.existentPaths || []).indexOf(path) >= 0,
         dirSync: (path) => (settings.onDirSync || nop)(path),
-    }
+    };
 }
 
 export function shell(settings : FakeShellSettings = {}) : any {
@@ -73,7 +73,7 @@ export function shell(settings : FakeShellSettings = {}) : any {
         combinePath: (b: string, r: string) => (settings.isWindows ? `${b}\\${r}` : `${b}/${r}`),
         execCore: (cmd, opts) => fakeShellExec(settings, cmd),
         exec: (cmd) => fakeShellExec(settings, cmd),
-    }
+    };
 }
 
 function fakeShellExec(settings : FakeShellSettings, cmd : string) : Promise<ShellResult> {
@@ -91,5 +91,5 @@ export function kubectl(settings : FakeKubectlSettings = {}) : any {
     const asLines = settings.asLines || ((s : string) => []);
     return {
         asLines: (cmd) => new Promise((resolve, reject) => resolve(asLines(cmd)))
-    }
+    };
 }


### PR DESCRIPTION
We already had a 'Configure from ACS' command which would list ACS clusters in the user's Azure account and download and configure kubectl for a selected cluster.  This adds a choice of 'what cluster type do you want to point kubectl at', with options currently of AKS and ACS.  As with 'create cluster', it is intended that this should be extensible to custom clusters, GKE, EKS, etc. but this will currently be quite clunky - we will work with anyone who wants to implement this support, though, rather than speculatively refactoring now.

Fixes #3.