### PR TITLE
Do not close terminal after draft up completes

### DIFF
--- a/src/draft.ts
+++ b/src/draft.ts
@@ -105,7 +105,7 @@ async function checkForDraftInternal(context : Context) : Promise<boolean> {
 
 function isFolderMapped(context: Context, path: string) : boolean {
     // Heuristic based on files created by 'draft create'
-    const tomlFile = syspath.join(path, '.draftignore');
-    const ignoreFile = syspath.join(path, 'draft.toml');
+    const tomlFile = syspath.join(path, 'draft.toml');
+    const ignoreFile = syspath.join(path, '.draftignore');
     return context.fs.existsSync(tomlFile) && context.fs.existsSync(ignoreFile);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1379,14 +1379,16 @@ async function execDraftUp() {
     if (!(await draft.checkPresent())) {
         return;
     }
-    // if it's already running... how can we tell?
 
-    // TODO: If non-watching then we should pipe the output to an Output window rather than using
-    // a terminal which exits when the command exits - but then do we have to manage the
-    // process?
+    // if it's already running... how can we tell?
     const draftPath = await draft.path();
-    const term = vscode.window.createTerminal(`draft up`, draftPath, [ 'up' ]);  // TODO: this doesn't show output colourised - how to do that in a safe portable way?
-    term.show(true);
+    if (shell.isUnix()) {
+        const term = vscode.window.createTerminal('draft up', `bash`, [ '-c', `${draftPath} up ; bash` ]);
+        term.show(true);
+    } else {
+        const term = vscode.window.createTerminal('draft up', `PowerShell`, [ '-NoExit', `${draftPath} up` ]);
+        term.show(true);
+    }
 }
 
 function editorIsActive(): boolean {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1386,7 +1386,7 @@ async function execDraftUp() {
         const term = vscode.window.createTerminal('draft up', `bash`, [ '-c', `${draftPath} up ; bash` ]);
         term.show(true);
     } else {
-        const term = vscode.window.createTerminal('draft up', `PowerShell`, [ '-NoExit', `${draftPath} up` ]);
+        const term = vscode.window.createTerminal('draft up', 'powershell.exe', [ '-NoExit', `${draftPath}`, `up` ]);
         term.show(true);
     }
 }


### PR DESCRIPTION
Fixes #25.  Note we want to use a terminal rather than the output window because:

1. `draft` uses escape sequences to display a spinner - if we send stdout to the output window then you get a series of lines like `Building Docker image... / Building Docker image... -- Building Docker image... \` which looks silly.  (Using the terminal also gains us colorisation, at least in bash.)

2. `draft up` can take a long time, and using the terminal means we can have the output displayed as draft runs instead of it going dark for ages and then dumping all the output at once.