### PR TITLE
Fixed change log link

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Where `<your-image-prefix-here>` is something like `docker.io/brendanburns`.
 
 ## Release Notes
 
-See the [change log](changelog.md).
+See the [change log](CHANGELOG.md).
 
 # Contributing
 


### PR DESCRIPTION
The change log link in the README was lower-cased, but the file name was upper-case.  This resulted in a 404 when clicking the link in the README.