### PR TITLE
Option to configure extension with a newly created cluster

### DIFF
--- a/src/azure.ts
+++ b/src/azure.ts
@@ -104,10 +104,10 @@ export async function setSubscriptionAsync(context: Context, subscription: strin
 }
 
 export async function configureCluster(context: Context, clusterType: string, clusterName: string, clusterGroup: string) : Promise<StageData> {
-    const downloadCliPromise = downloadCli(context, clusterType);
+    const downloadKubectlCliPromise = downloadKubectlCli(context, clusterType);
     const getCredentialsPromise = getCredentials(context, clusterType, clusterName, clusterGroup, 5);
 
-    const [cliResult, credsResult] = await Promise.all([downloadCliPromise, getCredentialsPromise]);
+    const [cliResult, credsResult] = await Promise.all([downloadKubectlCliPromise, getCredentialsPromise]);
 
     const result = {
         gotCli: cliResult.succeeded,
@@ -124,8 +124,8 @@ export async function configureCluster(context: Context, clusterType: string, cl
     };
 }
 
-async function downloadCli(context: Context, clusterType: string) : Promise<any> {
-    const cliInfo = installCliInfo(context, clusterType);
+async function downloadKubectlCli(context: Context, clusterType: string) : Promise<any> {
+    const cliInfo = installKubectlCliInfo(context, clusterType);
 
     const sr = await context.shell.exec(cliInfo.commandLine);
     if (sr.code === 0) {
@@ -164,7 +164,7 @@ async function getCredentials(context: Context, clusterType: string, clusterName
     }
 }
 
-function installCliInfo(context: Context, clusterType: string) {
+function installKubectlCliInfo(context: Context, clusterType: string) {
     const cmdCore = `az ${getClusterCommandAndSubcommand(clusterType)} install-cli`;
     const isWindows = context.shell.isWindows();
     if (isWindows) {

--- a/src/azure.ts
+++ b/src/azure.ts
@@ -101,3 +101,96 @@ export async function setSubscriptionAsync(context: Context, subscription: strin
         return { succeeded: false, result: null, error: [sr.stderr] };
     }
 }
+
+export async function configureCluster(context: Context, clusterType: string, clusterName: string, clusterGroup: string) : Promise<StageData> {
+    const downloadCliPromise = downloadCli(context, clusterType);
+    const getCredentialsPromise = getCredentials(context, clusterType, clusterName, clusterGroup);
+
+    const [cliResult, credsResult] = await Promise.all([downloadCliPromise, getCredentialsPromise]);
+
+    const result = {
+        gotCli: cliResult.succeeded,
+        cliInstallFile: cliResult.installFile,
+        cliOnDefaultPath: cliResult.onDefaultPath,
+        cliError: cliResult.error,
+        gotCredentials: credsResult.succeeded,
+        credentialsError: credsResult.error
+    };
+    
+    return {
+        actionDescription: 'configuring Kubernetes',
+        result: { succeeded: cliResult.succeeded && credsResult.succeeded, result: result, error: [] }  // TODO: this ends up not fitting our structure very well - fix?
+    };
+}
+
+async function downloadCli(context: Context, clusterType: string) : Promise<any> {
+    const cliInfo = installCliInfo(context, clusterType);
+
+    const sr = await context.shell.exec(cliInfo.commandLine);
+    if (sr.code === 0) {
+        return {
+            succeeded: true,
+            installFile: cliInfo.installFile,
+            onDefaultPath: !context.shell.isWindows()
+        };
+    } else {
+        return {
+            succeeded: false,
+            error: sr.stderr
+        };
+    }
+}
+
+async function getCredentials(context: Context, clusterType: string, clusterName: string, clusterGroup: string) : Promise<any> {
+    const cmd = `az ${getClusterCommandAndSubcommand(clusterType)} get-credentials -n ${clusterName} -g ${clusterGroup}`;
+    const sr = await context.shell.exec(cmd);
+
+    if (sr.code === 0 && !sr.stderr) {
+        return {
+            succeeded: true
+        };
+    } else {
+        return {
+            succeeded: false,
+            error: sr.stderr
+        };
+    }
+}
+
+function installCliInfo(context: Context, clusterType: string) {
+    const cmdCore = `az ${getClusterCommandAndSubcommand(clusterType)} install-cli`;
+    const isWindows = context.shell.isWindows();
+    if (isWindows) {
+        // The default Windows install location requires admin permissions; install
+        // into a user profile directory instead. We process the path explicitly
+        // instead of using %LOCALAPPDATA% in the command, so that we can render the
+        // physical path when notifying the user.
+        const appDataDir = process.env['LOCALAPPDATA'];
+        const installDir = appDataDir + '\\kubectl';
+        const installFile = installDir + '\\kubectl.exe';
+        const cmd = `(if not exist "${installDir}" md "${installDir}") & ${cmdCore} --install-location="${installFile}"`;
+        return { installFile: installFile, commandLine: cmd };
+    } else {
+        // Bah, the default Linux install location requires admin permissions too!
+        // Fortunately, $HOME/bin is on the path albeit not created by default.
+        const homeDir = process.env['HOME'];
+        const installDir = homeDir + '/bin';
+        const installFile = installDir + '/kubectl';
+        const cmd = `mkdir -p "${installDir}" ; ${cmdCore} --install-location="${installFile}"`;
+        return { installFile: installFile, commandLine: cmd };
+    }
+}
+
+export function getClusterCommand(clusterType: string) : string {
+    if (clusterType == 'Azure Container Service') {
+        return 'acs';
+    }
+    return 'aks';
+}
+
+export function getClusterCommandAndSubcommand(clusterType: string) : string {
+    if (clusterType == 'Azure Container Service') {
+        return 'acs kubernetes';
+    }
+    return 'aks';
+}

--- a/src/createcluster.ts
+++ b/src/createcluster.ts
@@ -140,7 +140,7 @@ async function next(context: Context, sourceState: OperationState<OperationStage
                 return {
                     last: creationResult,
                     stage: OperationStage.Complete
-                }
+                };
             }
             return {
                 last: { actionDescription: 'creating cluster', result: creationInfo },

--- a/src/sleep.ts
+++ b/src/sleep.ts
@@ -1,0 +1,5 @@
+export function sleep(ms: number) : Promise<void> {
+    return new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}


### PR DESCRIPTION
After creating a cluster, the user can now opt to wait for the cluster to come up, and configure kubectl (and thereby the extension) to point to the new cluster.

Fixes #33, except for the TLS handshake timeout issue which seems more fundamental... Also fixes an issue where if the `create` command failed synchronously (e.g. SSH configuration issues) then this was silently ignored and the extension reported that cluster creation was under way.
