### PR TITLE
Fix Helm "No charts found" error when opening arbitrary folder

### DIFF
--- a/src/helm.completionProvider.ts
+++ b/src/helm.completionProvider.ts
@@ -16,17 +16,20 @@ export class HelmTemplateCompletionProvider implements vscode.CompletionItemProv
     private valuesCache;
 
     public constructor() {
-        this.refreshValues();
+        this.refreshValues({ warnIfNoCharts: false });
     }
 
-    public refreshValues() {
+    public refreshValues(options: UIOptions) {
         let ed = vscode.window.activeTextEditor;
         if (!ed) {
             return;
         }
 
+        // The user may have opened an unrelated YAML file, so don't warn
+        // about a lack of charts unless we have reason to believe they really
+        // are doing Helm stuff.
         let self = this;
-        exec.pickChartForFile(ed.document.fileName, (f) => {
+        exec.pickChartForFile(ed.document.fileName, options.warnIfNoCharts || false, (f) => {
             let valsYaml = path.join(f, "values.yaml");
             if (!existsSync(valsYaml)) {
                 return;
@@ -161,4 +164,8 @@ export class HelmTemplateCompletionProvider implements vscode.CompletionItemProv
         });
     }
     */
+}
+
+interface UIOptions {
+    readonly warnIfNoCharts? : boolean;
 }

--- a/src/helm.completionProvider.ts
+++ b/src/helm.completionProvider.ts
@@ -16,20 +16,22 @@ export class HelmTemplateCompletionProvider implements vscode.CompletionItemProv
     private valuesCache;
 
     public constructor() {
+        // The extension activates on things like 'Kubernetes tree visible',
+        // which can occur on any project (not just projects containing k8s
+        // manifests or Helm charts). So we don't want the mere initialisation
+        // of the completion provider to trigger an error message if there are
+        // no charts - this will actually be the *probable* case.
         this.refreshValues({ warnIfNoCharts: false });
     }
 
-    public refreshValues(options: UIOptions) {
+    public refreshValues(options: exec.PickChartUIOptions) {
         let ed = vscode.window.activeTextEditor;
         if (!ed) {
             return;
         }
 
-        // The user may have opened an unrelated YAML file, so don't warn
-        // about a lack of charts unless we have reason to believe they really
-        // are doing Helm stuff.
         let self = this;
-        exec.pickChartForFile(ed.document.fileName, options.warnIfNoCharts || false, (f) => {
+        exec.pickChartForFile(ed.document.fileName, options, (f) => {
             let valsYaml = path.join(f, "values.yaml");
             if (!existsSync(valsYaml)) {
                 return;

--- a/src/helm.documentProvider.ts
+++ b/src/helm.documentProvider.ts
@@ -36,7 +36,7 @@ export class HelmInspectDocumentProvider implements vscode.TextDocumentContentPr
                 exec.helmExec("inspect values " + file, printer);
                 return;
             }
-            exec.pickChartForFile(file, true, (path) => {
+            exec.pickChartForFile(file, { warnIfNoCharts: true }, (path) => {
                 exec.helmExec("inspect values "+ path, printer);
             });
         });
@@ -67,7 +67,7 @@ export class HelmTemplatePreviewDocumentProvider implements vscode.TextDocumentC
             let tpl = vscode.window.activeTextEditor.document.fileName;
 
             // First, we need to get the top-most chart:
-            exec.pickChartForFile(tpl, true, (chartPath) => {
+            exec.pickChartForFile(tpl, { warnIfNoCharts: true }, (chartPath) => {
                 // We need the relative path for 'helm template'
                 let reltpl = filepath.relative(filepath.dirname(chartPath), tpl);
                 exec.helmExec("template " + chartPath + " --execute " + reltpl, (code, out, err) => {

--- a/src/helm.documentProvider.ts
+++ b/src/helm.documentProvider.ts
@@ -36,7 +36,7 @@ export class HelmInspectDocumentProvider implements vscode.TextDocumentContentPr
                 exec.helmExec("inspect values " + file, printer);
                 return;
             }
-            exec.pickChartForFile(file, (path) => {
+            exec.pickChartForFile(file, true, (path) => {
                 exec.helmExec("inspect values "+ path, printer);
             });
         });
@@ -67,7 +67,7 @@ export class HelmTemplatePreviewDocumentProvider implements vscode.TextDocumentC
             let tpl = vscode.window.activeTextEditor.document.fileName;
 
             // First, we need to get the top-most chart:
-            exec.pickChartForFile(tpl, (chartPath) => {
+            exec.pickChartForFile(tpl, true, (chartPath) => {
                 // We need the relative path for 'helm template'
                 let reltpl = filepath.relative(filepath.dirname(chartPath), tpl);
                 exec.helmExec("template " + chartPath + " --execute " + reltpl, (code, out, err) => {

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -9,6 +9,10 @@ import * as fs from "fs";
 export const HELM_PREVIEW_SCHEME = 'helm-template-preview';
 export const HELM_PREVIEW_URI = HELM_PREVIEW_SCHEME + '://preview';
 
+export interface PickChartUIOptions {
+    readonly warnIfNoCharts : boolean;
+}
+
 // This file contains utilities for executing command line tools, notably Helm.
 
 export function helmVersion() {
@@ -180,15 +184,12 @@ export function loadChartMetadata(chartDir: string): Chart {
 }
 
 // Given a file, show any charts that this file belongs to.
-export function pickChartForFile(file: string, warnIfNoCharts: boolean, fn) {
+export function pickChartForFile(file: string, options: PickChartUIOptions, fn) {
     vscode.workspace.findFiles("**/Chart.yaml", "", 1024).then((matches) => {
         //logger.log(`Found ${ matches.length } charts`)
         switch(matches.length) {
             case 0:
-                // It's quite possible the user has opened an unrelated YAML file,
-                // such as a k8s resource file.  We don't want to bother the user
-                // unless they're specifically invoking a Helm command on that file.
-                if (warnIfNoCharts) {
+                if (options.warnIfNoCharts) {
                     vscode.window.showErrorMessage("No charts found");
                 }
                 return;

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -180,12 +180,17 @@ export function loadChartMetadata(chartDir: string): Chart {
 }
 
 // Given a file, show any charts that this file belongs to.
-export function pickChartForFile(file: string, fn) {
+export function pickChartForFile(file: string, warnIfNoCharts: boolean, fn) {
     vscode.workspace.findFiles("**/Chart.yaml", "", 1024).then((matches) => {
         //logger.log(`Found ${ matches.length } charts`)
         switch(matches.length) {
             case 0:
-                vscode.window.showErrorMessage("No charts found");
+                // It's quite possible the user has opened an unrelated YAML file,
+                // such as a k8s resource file.  We don't want to bother the user
+                // unless they're specifically invoking a Helm command on that file.
+                if (warnIfNoCharts) {
+                    vscode.window.showErrorMessage("No charts found");
+                }
                 return;
             case 1:
                 // Assume that if there is only one chart, that's the one to run.


### PR DESCRIPTION
The Kubernetes extension will tend to activate in most VS Code sessions, e.g. to populate the Kubernetes tree view.  Because of the way the Helm completion provider initialises, this means it will look for charts whenever the user opens a new folder.  At the moment, if there are no charts, the extension displays a "No charts found" error.  As most folders have nothing to do with k8s or Helm, this results in a lot of spurious errors!

This PR suppresses the "No charts found" prompt during completion provider initialisation.  It will still be seen if the user attempts to execute a Helm command in a non-Helm directory.