### PR TITLE
Add more context menus for kubernetes explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,16 +117,60 @@
                     "command": "extension.vsKubernetesRefreshExplorer",
                     "when": "view == extension.vsKubernetesExplorer",
                     "group": "navigation"
+                },
+                {
+                    "command": "extension.vsKubernetesCreateCluster",
+                    "when": "view == extension.vsKubernetesExplorer"
+                },
+                {
+                    "command": "extension.vsKubernetesConfigureFromCluster",
+                    "when": "view == extension.vsKubernetesExplorer"
                 }
             ],
             "view/item/context": [
                 {
                     "command": "extension.vsKubernetesUseContext",
-                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.cluster.inactive"
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.cluster.inactive",
+                    "group": "0@1"
+                },
+                {
+                    "command": "extension.vsKubernetesDeleteContext",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.cluster.inactive",
+                    "group": "0@2"
+                },
+                {
+                    "command": "extension.vsKubernetesClusterInfo",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.cluster",
+                    "group": "0@1"
+                },
+                {
+                    "command": "extension.vsKubernetesDeleteContext",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.cluster",
+                    "group": "0@2"
+                },
+                {
+                    "command": "extension.vsKubernetesUseNamespace",
+                    "group": "0",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.namespace.inactive"
+                },
+                {
+                    "command": "extension.vsKubernetesGet",
+                    "group": "1@1",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.kind"
                 },
                 {
                     "command": "extension.vsKubernetesLoad",
                     "group": "0",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource"
+                },
+                {
+                    "command": "extension.vsKubernetesGet",
+                    "group": "1@1",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource"
+                },
+                {
+                    "command": "extension.vsKubernetesDelete",
+                    "group": "1@2",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource"
                 },
                 {
@@ -140,8 +184,18 @@
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
                 },
                 {
+                    "command": "extension.vsKubernetesGet",
+                    "group": "1@1",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
+                },
+                {
+                    "command": "extension.vsKubernetesDelete",
+                    "group": "1@2",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
+                },
+                {
                     "command": "extension.vsKubernetesTerminal",
-                    "group": "1",
+                    "group": "1@3",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
                 },
                 {
@@ -162,6 +216,18 @@
                 },
                 {
                     "command": "extension.vsKubernetesUseContext",
+                    "when": "view == extension.vsKubernetesExplorer"
+                },
+                {
+                    "command": "extension.vsKubernetesClusterInfo",
+                    "when": "view == extension.vsKubernetesExplorer"
+                },
+                {
+                    "command": "extension.vsKubernetesDeleteContext",
+                    "when": "view == extension.vsKubernetesExplorer"
+                },
+                {
+                    "command": "extension.vsKubernetesUseNamespace",
                     "when": "view == extension.vsKubernetesExplorer"
                 }
             ]
@@ -265,6 +331,21 @@
             {
                 "command": "extension.vsKubernetesUseContext",
                 "title": "Set to Current Cluster",
+                "category": "Kubernetes"
+            },
+            {
+                "command": "extension.vsKubernetesClusterInfo",
+                "title": "Show Cluster Info",
+                "category": "Kubernetes"
+            },
+            {
+                "command": "extension.vsKubernetesDeleteContext",
+                "title": "Delete from kubeconfig",
+                "category": "Kubernetes"
+            },
+            {
+                "command": "extension.vsKubernetesUseNamespace",
+                "title": "Set to Current Namespace",
                 "category": "Kubernetes"
             },
             {

--- a/package.json
+++ b/package.json
@@ -130,22 +130,22 @@
             "view/item/context": [
                 {
                     "command": "extension.vsKubernetesUseContext",
-                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.cluster.inactive",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.cluster.inactive",
                     "group": "0@1"
                 },
                 {
                     "command": "extension.vsKubernetesDeleteContext",
-                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.cluster.inactive",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.cluster.inactive",
                     "group": "0@2"
                 },
                 {
                     "command": "extension.vsKubernetesClusterInfo",
-                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.cluster",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.cluster",
                     "group": "0@1"
                 },
                 {
                     "command": "extension.vsKubernetesDeleteContext",
-                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.cluster",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.cluster",
                     "group": "0@2"
                 },
                 {
@@ -330,7 +330,7 @@
             },
             {
                 "command": "extension.vsKubernetesUseContext",
-                "title": "Set to Current Cluster",
+                "title": "Set as Current Cluster",
                 "category": "Kubernetes"
             },
             {
@@ -345,7 +345,7 @@
             },
             {
                 "command": "extension.vsKubernetesUseNamespace",
-                "title": "Set to Current Namespace",
+                "title": "Set as Current Namespace",
                 "category": "Kubernetes"
             },
             {

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -11,11 +11,11 @@ export function create(kubectl : Kubectl, host : Host) : KubernetesExplorer {
     return new KubernetesExplorer(kubectl, host);
 }
 
-export function createKindTreeNode(kind: kuberesources.ResourceKind) : TreeNode {
+export function createKindTreeNode(kind: kuberesources.ResourceKind) : KubernetesTreeNode {
     return new KubernetesKind(kind);
 }
 
-export function createResourceTreeNode(kind: kuberesources.ResourceKind, id: string, metadata?: any) : TreeNode {
+export function createResourceTreeNode(kind: kuberesources.ResourceKind, id: string, metadata?: any) : KubernetesTreeNode {
     return new KubernetesResource(kind, id, metadata);
 }
 
@@ -36,7 +36,7 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<KubernetesObj
     constructor(private readonly kubectl : Kubectl, private readonly host : Host) {}
 
     getTreeItem(element: KubernetesObject) : vscode.TreeItem | Thenable<vscode.TreeItem> {
-        if (element instanceof TreeNode) {
+        if (element instanceof KubernetesTreeNode) {
             return element.getTreeItem();
         }
         return new vscode.TreeItem(element.id, vscode.TreeItemCollapsibleState.None);
@@ -44,7 +44,7 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<KubernetesObj
 
     getChildren(parent? : KubernetesObject) : vscode.ProviderResult<KubernetesObject[]> {
         if (parent) {
-            return (parent instanceof TreeNode) ? parent.getChildren(this.kubectl, this.host) : [];
+            return (parent instanceof KubernetesTreeNode) ? parent.getChildren(this.kubectl, this.host) : [];
         }
         return this.getClusters(this.kubectl);
     }
@@ -59,14 +59,14 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<KubernetesObj
     }
 }
 
-abstract class TreeNode implements KubernetesObject {
+abstract class KubernetesTreeNode implements KubernetesObject {
     constructor(readonly id: string) {
     }
     abstract getChildren(kubectl: Kubectl, host : Host) : vscode.ProviderResult<KubernetesObject[]>;
     abstract getTreeItem() : vscode.TreeItem | Thenable<vscode.TreeItem>;
 }
 
-class KubernetesKind extends TreeNode {
+class KubernetesKind extends KubernetesTreeNode {
     constructor(readonly kind: kuberesources.ResourceKind) {
         super(kind.abbreviation);
     }
@@ -96,7 +96,7 @@ class KubernetesKind extends TreeNode {
     }
 }
 
-class KubernetesResource extends TreeNode implements ResourceNode {
+class KubernetesResource extends KubernetesTreeNode implements ResourceNode {
     readonly resourceId: string;
     constructor(readonly kind: kuberesources.ResourceKind, readonly id: string, readonly metadata?: any) {
         super(id);
@@ -129,7 +129,7 @@ class KubernetesResource extends TreeNode implements ResourceNode {
     }
 }
 
-class VirtualKubernetesResource extends TreeNode implements ResourceNode {
+class VirtualKubernetesResource extends KubernetesTreeNode implements ResourceNode {
     readonly resourceId: string;
 
     constructor (readonly id: string, readonly kind: string, readonly metadata?: any) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1320,7 +1320,7 @@ async function createClusterKubernetes(request? : WizardUIRequest) {
     }
 }
 
-async function useContextKubernetes(explorerNode: explorer.ResourceNode) {
+async function useContextKubernetes(explorerNode: explorer.KubernetesObject) {
     const targetContext = explorerNode.metadata.context;
     const shellResult = await kubectl.invokeAsync(`config use-context ${targetContext}`);
     if (shellResult.code === 0) {
@@ -1330,18 +1330,18 @@ async function useContextKubernetes(explorerNode: explorer.ResourceNode) {
     }
 }
 
-async function clusterInfoKubernetes(explorerNode: explorer.ResourceNode) {
+async function clusterInfoKubernetes(explorerNode: explorer.KubernetesObject) {
     const targetContext = explorerNode.metadata.context;
     const shellResult = await kubectl.invokeAsync(`cluster-info`);
     if (shellResult.code === 0) {
-        kubeChannel.showOutput(shellResult.stdout, `cluster-info for ${explorerNode.resourceId}`);
+        kubeChannel.showOutput(shellResult.stdout, `cluster-info for ${explorerNode.id}`);
     } else {
         vscode.window.showErrorMessage(`Failed to get cluster info: ${shellResult.stderr}`);
     }
 }
 
-async function deleteContextKubernetes(explorerNode: explorer.ResourceNode) {
-    const answer = await vscode.window.showWarningMessage(`Do you want to delete the cluser '${explorerNode.id}' from the kubeconfig?`, ...deleteMessageItems);
+async function deleteContextKubernetes(explorerNode: explorer.KubernetesObject) {
+    const answer = await vscode.window.showWarningMessage(`Do you want to delete the cluster '${explorerNode.id}' from the kubeconfig?`, ...deleteMessageItems);
     if (answer.isCloseAffordance) {
         return;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1306,7 +1306,7 @@ async function useContextKubernetes(explorerNode: explorer.ResourceNode) {
     const targetContext = explorerNode.metadata.context;
     const shellResult = await kubectl.invokeAsync(`config use-context ${targetContext}`);
     if (shellResult.code === 0) {
-        vscode.commands.executeCommand("extension.vsKubernetesRefreshExplorer");
+        return vscode.commands.executeCommand("extension.vsKubernetesRefreshExplorer");
     } else {
         vscode.window.showErrorMessage(`Failed to set '${targetContext}' as current cluster: ${shellResult.stderr}`);
     }
@@ -1325,13 +1325,13 @@ async function clusterInfoKubernetes(explorerNode: explorer.ResourceNode) {
 async function deleteContextKubernetes(explorerNode: explorer.ResourceNode) {
     const answer = await vscode.window.showInformationMessage(`Do you want to delete the cluser '${explorerNode.id}' from the kubeconfig?`, "NO", "YES");
     if (answer === "YES" && (await kubectlUtils.deleteCluster(kubectl, explorerNode.metadata))) {
-        vscode.commands.executeCommand("extension.vsKubernetesRefreshExplorer");
+        return vscode.commands.executeCommand("extension.vsKubernetesRefreshExplorer");
     }
 }
 
 async function useNamespaceKubernetes(explorerNode: explorer.KubernetesObject) {
     if (await kubectlUtils.switchNamespace(kubectl, explorerNode.id)) {
-        vscode.commands.executeCommand("extension.vsKubernetesRefreshExplorer");
+        return vscode.commands.executeCommand("extension.vsKubernetesRefreshExplorer");
     }
 }
 

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -44,21 +44,21 @@ export async function deleteCluster(kubectl: Kubectl, cluster: Cluster): Promise
     const deleteClusterResult = await kubectl.invokeAsyncWithProgress(`config delete-cluster ${cluster.name}`, "Deleting cluster...");
     if (deleteClusterResult.code !== 0) {
         kubeChannel.showOutput(`Failed to delete the specified cluster ${cluster.name} from the kubeconfig: ${deleteClusterResult.stderr}`, `Delete-${cluster.name}`);
-        vscode.window.showErrorMessage("Failed. See the output window for more details.");
+        vscode.window.showErrorMessage(`Delete ${cluster.name} failed. See Output window for more details.`);
         return false;
     }
 
     const deleteUserResult = await kubectl.invokeAsyncWithProgress(`config unset users.${cluster.user}`, "Deleting user...");
     if (deleteUserResult.code !== 0) {
         kubeChannel.showOutput(`Failed to delete user info for cluster ${cluster.name} from the kubeconfig: ${deleteUserResult.stderr}`);
-        vscode.window.showErrorMessage("Failed. See the output window for more details.");
+        vscode.window.showErrorMessage(`Delete ${cluster.name} Failed. See Output window for more details.`);
         return false;
     }
 
     const deleteContextResult = await kubectl.invokeAsyncWithProgress(`config delete-context ${cluster.context}`, "Deleting context...");
     if (deleteContextResult.code !== 0) {
         kubeChannel.showOutput(`Failed to delete the specified cluster's context ${cluster.context} from the kubeconfig: ${deleteContextResult.stderr}`);
-        vscode.window.showErrorMessage("Failed. See the output window for more details.");
+        vscode.window.showErrorMessage(`Delete ${cluster.name} Failed. See Output window for more details.`);
         return false;
     }
 
@@ -98,15 +98,15 @@ async function currentNamespace(kubectl: Kubectl): Promise<string> {
 export async function switchNamespace(kubectl: Kubectl, namespace: string): Promise<boolean> {
     const shellResult = await kubectl.invokeAsync("config current-context");
     if (shellResult.code !== 0) {
-        kubeChannel.showOutput(`Failed. Cannot get the current context: ${shellResult.stderr}`, `Switch-namespace-${namespace}`);
-        vscode.window.showErrorMessage("Failed. See the output window for more details.");
+        kubeChannel.showOutput(`Failed. Cannot get the current context: ${shellResult.stderr}`, `Switch namespace ${namespace}`);
+        vscode.window.showErrorMessage("Switch namespace failed. See Output window for more details.");
         return false;
     }
     const updateResult = await kubectl.invokeAsyncWithProgress(`config set-context ${shellResult.stdout.trim()} --namespace="${namespace}"`,
         "Switching namespace...");
     if (updateResult.code !== 0) {
-        kubeChannel.showOutput(`Failed to switch the namespace: ${shellResult.stderr}`, `Switch-namespace-${namespace}`);
-        vscode.window.showErrorMessage("Failed. See the output window for more details.");
+        kubeChannel.showOutput(`Failed to switch the namespace: ${shellResult.stderr}`, `Switch namespace ${namespace}`);
+        vscode.window.showErrorMessage("Switch namespace failed. See Output window for more details.");
         return false;
     }
     return true;

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -1,0 +1,107 @@
+import * as vscode from "vscode";
+import { Kubectl } from "./kubectl";
+
+export type Cluster = {
+    name: string;
+    context: string;
+    user: string;
+    active: boolean;
+};
+
+export type Namespace = {
+    name: string;
+    active: boolean;
+};
+
+async function getKubeconfig(kubectl: Kubectl): Promise<any> {
+    const shellResult = await kubectl.invokeAsync("config view -o json");
+    if (shellResult.code !== 0) {
+        vscode.window.showErrorMessage(shellResult.stderr);
+        return null;
+    }
+    return JSON.parse(shellResult.stdout);
+}
+
+export async function getClusters(kubectl: Kubectl): Promise<Cluster[]> {
+    const kubectlConfig = await getKubeconfig(kubectl);
+    if (!kubectlConfig) {
+        return;
+    }
+    const currentContext = kubectlConfig["current-context"];
+    const contexts = kubectlConfig.contexts;
+    return contexts.map((c) => {
+        return {
+            name: c.context.cluster,
+            context: c.name,
+            user: c.context.user,
+            active: c.name === currentContext
+        };
+    });
+}
+
+export async function deleteCluster(kubectl: Kubectl, cluster: Cluster): Promise<boolean> {
+    const deleteClusterResult = await kubectl.invokeAsyncWithProgress(`config delete-cluster ${cluster.name}`, "Deleting cluster...");
+    if (deleteClusterResult.code !== 0) {
+        await vscode.window.showErrorMessage(`Failed to delete the specified cluster ${cluster.name} from the kubeconfig: ${deleteClusterResult.stderr}`);
+        return false;
+    }
+
+    const deleteUserResult = await kubectl.invokeAsyncWithProgress(`config unset users.${cluster.user}`, "Deleting user...");
+    if (deleteUserResult.code !== 0) {
+        await vscode.window.showErrorMessage(`Failed to delete user info for cluster ${cluster.name} from the kubeconfig: ${deleteUserResult.stderr}`);
+        return false;
+    }
+
+    const deleteContextResult = await kubectl.invokeAsyncWithProgress(`config delete-context ${cluster.context}`, "Deleting context...");
+    if (deleteContextResult.code !== 0) {
+        vscode.window.showErrorMessage(`Failed to delete the specified cluster's context ${cluster.context} from the kubeconfig: ${deleteContextResult.stderr}`);
+        return false;
+    }
+
+    vscode.window.showInformationMessage(`Successfully delete the associated cluster/context/user for cluster '${cluster.name}' from the kubeconfig.`);
+    return true;
+}
+
+export async function getNamespaces(kubectl: Kubectl): Promise<Namespace[]> {
+    const shellResult = await kubectl.invokeAsync("get namespaces -o json");
+    if (shellResult.code !== 0) {
+        vscode.window.showErrorMessage(shellResult.stderr);
+        return [];
+    }
+    const nsObj = JSON.parse(shellResult.stdout);
+    const cns = await currentNamespace(kubectl);
+    return nsObj.items.map((item) => {
+        return {
+            name: item.metadata.name,
+            active: item.metadata.name === cns
+        };
+    });
+}
+
+export async function currentNamespace(kubectl: Kubectl): Promise<string> {
+    const kubectlConfig = await getKubeconfig(kubectl);
+    if (!kubectlConfig) {
+        return "";
+    }
+    const ctxName = kubectlConfig["current-context"];
+    const currentContext = kubectlConfig.contexts.find((ctx) => ctx.name === ctxName);
+    if(!currentContext) {
+        return "";
+    }
+    return currentContext.context.namespace || "default";
+}
+
+export async function switchNamespace(kubectl: Kubectl, namespace: string): Promise<boolean> {
+    const shellResult = await kubectl.invokeAsync("config current-context");
+    if (shellResult.code !== 0) {
+        vscode.window.showErrorMessage(shellResult.stderr);
+        return false;
+    }
+    const updateResult = await kubectl.invokeAsyncWithProgress(`config set-context ${shellResult.stdout.trim()} --namespace="${namespace}"`,
+        "Switching namespace...");
+    if (updateResult.code !== 0) {
+        vscode.window.showErrorMessage(updateResult.stderr);
+        return false;
+    }
+    return true;
+}

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -62,7 +62,7 @@ export async function deleteCluster(kubectl: Kubectl, cluster: Cluster): Promise
         return false;
     }
 
-    vscode.window.showInformationMessage(`Delete cluster '${cluster.name}' and associated data from the kubeconfig.`);
+    vscode.window.showInformationMessage(`Deleted cluster '${cluster.name}' and associated data from the kubeconfig.`);
     return true;
 }
 

--- a/src/kuberesources.ts
+++ b/src/kuberesources.ts
@@ -9,6 +9,7 @@ export class ResourceKind implements vscode.QuickPickItem {
 }
 
 export const allKinds = {
+    namespace: new ResourceKind("Namespace", "Namespaces", "namespace"),
     node: new ResourceKind("Node", "Nodes", "node"),
     deployment: new ResourceKind("Deployment", "Deployments", "deployment"),
     replicaSet: new ResourceKind("ReplicaSet", "ReplicaSets", "rs"),

--- a/test/explorer.test.ts
+++ b/test/explorer.test.ts
@@ -61,7 +61,7 @@ suite("Explorer tests", () => {
                 const explorer = explorerCreateWithFakes({
                     kubectl: fakes.kubectl({ asLines: (c) => { command = c; return ["a"]; } })
                 });
-                const parent : any = kubeExplorer.createKindTreeNode(kuberesources.allKinds.pod);
+                const parent : any = kubeExplorer.createKubernetesResourceFolder(kuberesources.allKinds.pod);
                 const nodes = await explorer.getChildren(parent);
                 assert.equal(command, "get pod");
             });
@@ -70,7 +70,7 @@ suite("Explorer tests", () => {
                 const explorer = explorerCreateWithFakes({
                     kubectl: fakes.kubectl({ asLines: (_) => ["a b c", "d e f"]})
                 });
-                const parent : any = kubeExplorer.createKindTreeNode(kuberesources.allKinds.pod);
+                const parent : any = kubeExplorer.createKubernetesResourceFolder(kuberesources.allKinds.pod);
                 const nodes = await explorer.getChildren(parent);
                 assert.equal(nodes.length, 2);
             });
@@ -79,7 +79,7 @@ suite("Explorer tests", () => {
                 const explorer = explorerCreateWithFakes({
                     kubectl: fakes.kubectl({ asLines: (_) => ["a b c", "d e f"]})
                 });
-                const parent : any = kubeExplorer.createKindTreeNode(kuberesources.allKinds.pod);
+                const parent : any = kubeExplorer.createKubernetesResourceFolder(kuberesources.allKinds.pod);
                 const nodes = await explorer.getChildren(parent);
                 assert.equal(nodes[0].id, 'a');
                 assert.equal(nodes[1].id, 'd');
@@ -89,7 +89,7 @@ suite("Explorer tests", () => {
                 const explorer = explorerCreateWithFakes({
                     kubectl: fakes.kubectl({ asLines: (_) => { return { code: 1, stdout: "", stderr: "Oh no!"}; } })
                 });
-                const parent : any = kubeExplorer.createKindTreeNode(kuberesources.allKinds.pod);
+                const parent : any = kubeExplorer.createKubernetesResourceFolder(kuberesources.allKinds.pod);
                 const nodes = await explorer.getChildren(parent);
                 assert.equal(nodes.length, 1);
                 assert.equal(nodes[0].id, "Error");
@@ -101,16 +101,10 @@ suite("Explorer tests", () => {
                     kubectl: fakes.kubectl({ asLines: (_) => { return { code: 1, stdout: "", stderr: "Oh no!"}; } }),
                     host: fakes.host({errors: errors})
                 });
-                const parent : any = kubeExplorer.createKindTreeNode(kuberesources.allKinds.pod);
+                const parent : any = kubeExplorer.createKubernetesResourceFolder(kuberesources.allKinds.pod);
                 const nodes = await explorer.getChildren(parent);
                 assert.equal(errors.length, 1);
                 assert.equal(errors[0], "Oh no!");
-            });
-
-            test("...and the parent is not a Kubernetes kind, it returns an empty list", async () => {
-                const explorer = explorerCreateWithFakes({});
-                const nodes = await explorer.getChildren({ id: 'my-pod' });
-                assert.equal(nodes.length, 0);
             });
         });
     });
@@ -121,14 +115,14 @@ suite("Explorer tests", () => {
 
             test("...it is expandable", async () => {
                 const explorer = explorerCreateWithFakes({});
-                const obj : any = kubeExplorer.createKindTreeNode(kuberesources.allKinds.pod);
+                const obj : any = kubeExplorer.createKubernetesResourceFolder(kuberesources.allKinds.pod);
                 const treeItem = await explorer.getTreeItem(obj);
                 assert.equal(treeItem.collapsibleState, vscode.TreeItemCollapsibleState.Collapsed);
             });
 
             test("...its label is the kind plural name", async () => {
                 const explorer = explorerCreateWithFakes({});
-                const obj : any = kubeExplorer.createKindTreeNode(kuberesources.allKinds.deployment);
+                const obj : any = kubeExplorer.createKubernetesResourceFolder(kuberesources.allKinds.deployment);
                 const treeItem = await explorer.getTreeItem(obj);
                 assert.equal(treeItem.label, 'Deployments');
             });
@@ -138,14 +132,14 @@ suite("Explorer tests", () => {
 
             test("...it is not expandable", async () => {
                 const explorer = explorerCreateWithFakes({});
-                const obj : any = kubeExplorer.createResourceTreeNode(kuberesources.allKinds.pod, "my-pod");
+                const obj : any = kubeExplorer.createKubernetesResource(kuberesources.allKinds.pod, "my-pod");
                 const treeItem = await explorer.getTreeItem(obj);
                 assert.equal(treeItem.collapsibleState, vscode.TreeItemCollapsibleState.None);
             });
 
             test("...its label is the ID", async () => {
                 const explorer = explorerCreateWithFakes({});
-                const obj : any = kubeExplorer.createResourceTreeNode(kuberesources.allKinds.pod, "my-pod");
+                const obj : any = kubeExplorer.createKubernetesResource(kuberesources.allKinds.pod, "my-pod");
                 const treeItem = await explorer.getTreeItem(obj);
                 assert.equal(treeItem.label, 'my-pod');
             });

--- a/test/explorer.test.ts
+++ b/test/explorer.test.ts
@@ -1,3 +1,4 @@
+import * as sysfs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 
@@ -7,7 +8,6 @@ import * as fakes from './fakes';
 
 import { Host } from '../src/host';
 import { Shell, ShellResult } from '../src/shell';
-import { fs } from '../src/fs';
 import * as kubeExplorer from '../src/explorer';
 import * as kuberesources from '../src/kuberesources';
 
@@ -36,7 +36,7 @@ suite("Explorer tests", () => {
                             if (cmd === "config view -o json") {
                                 return {
                                     code: 0,
-                                    stdout: fs.readFileSync(path.join(__dirname, "../../test/kube-config.json"), 'utf-8'),
+                                    stdout: sysfs.readFileSync(path.join(__dirname, "../../test/kube-config.json"), 'utf-8'),
                                     stderr: ""
                                 };
                             }

--- a/test/fakes.ts
+++ b/test/fakes.ts
@@ -92,11 +92,7 @@ export function kubectl(settings : FakeKubectlSettings = {}) : any {
     const asLines = settings.asLines || ((s : string) => []);
     const invokeAsync = settings.invokeAsync || ((s : string) => ({ code: 0, stderr: "", stdout: ""}));
     return {
-        asLines: (cmd) => wrapAsPromise(asLines(cmd)),
-        invokeAsync: (cmd) => wrapAsPromise(invokeAsync(cmd)),
+        asLines: async (cmd) => asLines(cmd),
+        invokeAsync: async (cmd) => invokeAsync(cmd),
     };
-}
-
-export function wrapAsPromise(result: any): Promise<any> {
-    return new Promise((resolve, reject) => resolve(result));
 }

--- a/test/fakes.ts
+++ b/test/fakes.ts
@@ -33,6 +33,7 @@ export interface FakeShellSettings {
 
 export interface FakeKubectlSettings {
     asLines? : (cmd: string) => string[] | ShellResult;
+    invokeAsync? : (cmd: string) => ShellResult;
 }
 
 export function host(settings : FakeHostSettings = {}) : any {
@@ -89,7 +90,13 @@ function fakeShellExec(settings : FakeShellSettings, cmd : string) : Promise<She
 
 export function kubectl(settings : FakeKubectlSettings = {}) : any {
     const asLines = settings.asLines || ((s : string) => []);
+    const invokeAsync = settings.invokeAsync || ((s : string) => ({ code: 0, stderr: "", stdout: ""}));
     return {
-        asLines: (cmd) => new Promise((resolve, reject) => resolve(asLines(cmd)))
+        asLines: (cmd) => wrapAsPromise(asLines(cmd)),
+        invokeAsync: (cmd) => wrapAsPromise(invokeAsync(cmd)),
     };
+}
+
+export function wrapAsPromise(result: any): Promise<any> {
+    return new Promise((resolve, reject) => resolve(result));
 }

--- a/test/kube-config.json
+++ b/test/kube-config.json
@@ -1,0 +1,34 @@
+{
+    "kind": "Config",
+    "apiVersion": "v1",
+    "preferences": {},
+    "clusters": [
+        {
+            "name": "minikube",
+            "cluster": {
+                "server": "https://10.172.15.57:8443",
+                "certificate-authority": "C:\\Users\\devdivcn\\.minikube\\ca.crt"
+            }
+        }
+    ],
+    "users": [
+        {
+            "name": "minikube",
+            "user": {
+                "client-certificate": "C:\\Users\\devdivcn\\.minikube\\client.crt",
+                "client-key": "C:\\Users\\devdivcn\\.minikube\\client.key"
+            }
+        }
+    ],
+    "contexts": [
+        {
+            "name": "minikube",
+            "context": {
+                "cluster": "minikube",
+                "user": "minikube",
+                "namespace": "default"
+            }
+        }
+    ],
+    "current-context": "minikube"
+}


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Add more context menus for kubernetes explorer.
- Add icon for Cluster nodes
- Add `Create Cluster` and `Configure from Cluster` entries in tree navigation bar.
- For cluster node: 
  + Show Cluster Info
  + Delete from kubeconfig
- For namespace:
  + Set to Current Namespace
  + Get
(Namespace is newly added to tree, it lets user to easily switch namespace)
- For Node/Deployment/Pod/Services:
  + Get
  + Delete

See the gif below for preview.
![k8s_explorer](https://user-images.githubusercontent.com/14052197/35315910-d5ef9272-0109-11e8-97b5-c9114211983b.gif)





