### PR TITLE
Command telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ Where `<your-image-prefix-here>` is something like `docker.io/brendanburns`.
 
 See the [change log](CHANGELOG.md).
 
+## Telemetry
+This extension collects telemetry data to help us build a better experience for building micro-service applications with Docker and VS Code. We only collect data on which commands are executed. We do not collect any information about image names, paths, etc. The extension respects the `telemetry.enableTelemetry` setting which you can learn more about in our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
+
 # Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Where `<your-image-prefix-here>` is something like `docker.io/brendanburns`.
 See the [change log](CHANGELOG.md).
 
 ## Telemetry
-This extension collects telemetry data to help us build a better experience for building micro-service applications with Docker and VS Code. We only collect data on which commands are executed. We do not collect any information about image names, paths, etc. The extension respects the `telemetry.enableTelemetry` setting which you can learn more about in our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
+This extension collects telemetry data to help us build a better experience for building applications with Kubernetes and VS Code. We only collect data on which commands are executed. We do not collect any information about image names, paths, etc. The extension respects the `telemetry.enableTelemetry` setting which you can learn more about in our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
 
 # Contributing
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "draft",
         "azure"
     ],
+    "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "icon": "images/k8s-logo.png",
     "activationEvents": [
         "onCommand:extension.vsKubernetesCreate",
@@ -485,7 +486,8 @@
         "uuid": "^3.1.0",
         "yamljs": "0.2.10",
         "compare-versions": "^3.1.0",
-        "lodash": ">3"
+        "lodash": ">3",
+        "vscode-extension-telemetry": "^0.0.6"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.32",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -153,7 +153,7 @@ export function activate(context) {
         vscode.languages.registerCodeLensProvider(HELM_REQ_MODE, new HelmRequirementsCodeLensProvider()),
 
         // Telemetry
-        new Reporter(context)
+        registerTelemetry(context)
     ];
 
     // On save, refresh the Helm YAML preview.
@@ -195,6 +195,10 @@ export const deactivate = () => { };
 function registerCommand(command: string, callback: (...args: any[]) => any): vscode.Disposable {
     const wrappedCallback = telemetry.telemetrise(command, callback);
     return vscode.commands.registerCommand(command, wrappedCallback);
+}
+
+function registerTelemetry(context: vscode.ExtensionContext) : vscode.Disposable {
+    return new Reporter(context);
 }
 
 function provideHover(document, position, token, syntax) : Promise<vscode.Hover> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,8 @@ import { HelmRequirementsCodeLensProvider } from './helm.requirementsCodeLens';
 import { HelmTemplateHoverProvider } from './helm.hoverProvider';
 import { HelmTemplatePreviewDocumentProvider, HelmInspectDocumentProvider } from './helm.documentProvider';
 import { HelmTemplateCompletionProvider } from './helm.completionProvider';
+import { Reporter } from './telemetry';
+import * as telemetry from './telemetry-helper';
 
 let explainActive = false;
 let swaggerSpecPromise = null;
@@ -81,48 +83,48 @@ export function activate(context) {
     const subscriptions = [
 
         // Commands - Kubernetes
-        vscode.commands.registerCommand('extension.vsKubernetesCreate',
+        registerCommand('extension.vsKubernetesCreate',
             maybeRunKubernetesCommandForActiveWindow.bind(this, 'create -f')
         ),
-        vscode.commands.registerCommand('extension.vsKubernetesDelete', deleteKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesApply', applyKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesExplain', explainActiveWindow),
-        vscode.commands.registerCommand('extension.vsKubernetesLoad', loadKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesGet', getKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesRun', runKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesLogs', logsKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesExpose', exposeKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesDescribe', describeKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesSync', syncKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesExec', execKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesTerminal', terminalKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesDiff', diffKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesScale', scaleKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesDebug', debugKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesRemoveDebug', removeDebugKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesConfigureFromCluster', configureFromClusterKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesCreateCluster', createClusterKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesRefreshExplorer', () => treeProvider.refresh()),
-        vscode.commands.registerCommand('extension.vsKubernetesUseContext', useContextKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesClusterInfo', clusterInfoKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesDeleteContext', deleteContextKubernetes),
-        vscode.commands.registerCommand('extension.vsKubernetesUseNamespace', useNamespaceKubernetes),
+        registerCommand('extension.vsKubernetesDelete', deleteKubernetes),
+        registerCommand('extension.vsKubernetesApply', applyKubernetes),
+        registerCommand('extension.vsKubernetesExplain', explainActiveWindow),
+        registerCommand('extension.vsKubernetesLoad', loadKubernetes),
+        registerCommand('extension.vsKubernetesGet', getKubernetes),
+        registerCommand('extension.vsKubernetesRun', runKubernetes),
+        registerCommand('extension.vsKubernetesLogs', logsKubernetes),
+        registerCommand('extension.vsKubernetesExpose', exposeKubernetes),
+        registerCommand('extension.vsKubernetesDescribe', describeKubernetes),
+        registerCommand('extension.vsKubernetesSync', syncKubernetes),
+        registerCommand('extension.vsKubernetesExec', execKubernetes),
+        registerCommand('extension.vsKubernetesTerminal', terminalKubernetes),
+        registerCommand('extension.vsKubernetesDiff', diffKubernetes),
+        registerCommand('extension.vsKubernetesScale', scaleKubernetes),
+        registerCommand('extension.vsKubernetesDebug', debugKubernetes),
+        registerCommand('extension.vsKubernetesRemoveDebug', removeDebugKubernetes),
+        registerCommand('extension.vsKubernetesConfigureFromCluster', configureFromClusterKubernetes),
+        registerCommand('extension.vsKubernetesCreateCluster', createClusterKubernetes),
+        registerCommand('extension.vsKubernetesRefreshExplorer', () => treeProvider.refresh()),
+        registerCommand('extension.vsKubernetesUseContext', useContextKubernetes),
+        registerCommand('extension.vsKubernetesClusterInfo', clusterInfoKubernetes),
+        registerCommand('extension.vsKubernetesDeleteContext', deleteContextKubernetes),
+        registerCommand('extension.vsKubernetesUseNamespace', useNamespaceKubernetes),
 
         // Commands - Helm
-        vscode.commands.registerCommand('extension.helmVersion', helmexec.helmVersion),
-        vscode.commands.registerCommand('extension.helmTemplate', helmexec.helmTemplate),
-        vscode.commands.registerCommand('extension.helmTemplatePreview', helmexec.helmTemplatePreview),
-        vscode.commands.registerCommand('extension.helmLint', helmexec.helmLint),
-        vscode.commands.registerCommand('extension.helmInspectValues', helmexec.helmInspectValues),
-        vscode.commands.registerCommand('extension.helmDryRun', helmexec.helmDryRun),
-        vscode.commands.registerCommand('extension.helmDepUp', helmexec.helmDepUp),
-        vscode.commands.registerCommand('extension.helmInsertReq', helmexec.insertRequirement),
-        vscode.commands.registerCommand('extension.helmCreate', helmexec.helmCreate),
+        registerCommand('extension.helmVersion', helmexec.helmVersion),
+        registerCommand('extension.helmTemplate', helmexec.helmTemplate),
+        registerCommand('extension.helmTemplatePreview', helmexec.helmTemplatePreview),
+        registerCommand('extension.helmLint', helmexec.helmLint),
+        registerCommand('extension.helmInspectValues', helmexec.helmInspectValues),
+        registerCommand('extension.helmDryRun', helmexec.helmDryRun),
+        registerCommand('extension.helmDepUp', helmexec.helmDepUp),
+        registerCommand('extension.helmInsertReq', helmexec.insertRequirement),
+        registerCommand('extension.helmCreate', helmexec.helmCreate),
 
         // Commands - Draft
-        vscode.commands.registerCommand('extension.draftVersion', execDraftVersion),
-        vscode.commands.registerCommand('extension.draftCreate', execDraftCreate),
-        vscode.commands.registerCommand('extension.draftUp', execDraftUp),
+        registerCommand('extension.draftVersion', execDraftVersion),
+        registerCommand('extension.draftCreate', execDraftCreate),
+        registerCommand('extension.draftUp', execDraftUp),
 
         // HTML renderers
         vscode.workspace.registerTextDocumentContentProvider(configureFromCluster.uriScheme, configureFromClusterUI),
@@ -148,7 +150,10 @@ export function activate(context) {
         vscode.window.registerTreeDataProvider('extension.vsKubernetesExplorer', treeProvider),
 
         // Code lenses
-        vscode.languages.registerCodeLensProvider(HELM_REQ_MODE, new HelmRequirementsCodeLensProvider())
+        vscode.languages.registerCodeLensProvider(HELM_REQ_MODE, new HelmRequirementsCodeLensProvider()),
+
+        // Telemetry
+        new Reporter(context)
     ];
 
     // On save, refresh the Helm YAML preview.
@@ -186,6 +191,11 @@ export function activate(context) {
 
 // this method is called when your extension is deactivated
 export const deactivate = () => { };
+
+function registerCommand(command: string, callback: (...args: any[]) => any): vscode.Disposable {
+    const wrappedCallback = telemetry.telemetrise(command, callback);
+    return vscode.commands.registerCommand(command, wrappedCallback);
+}
 
 function provideHover(document, position, token, syntax) : Promise<vscode.Hover> {
     return new Promise(async (resolve) => {
@@ -1031,7 +1041,13 @@ async function isBashOnPod(podName : string): Promise<boolean> {
 
 function syncKubernetes() {
     selectPodForApp((pod) => {
+        if (!pod) {
+            return;
+        }
         selectContainerForPod(pod, (container) => {
+            if (!container) {
+                return;
+            }
             let pieces = container.image.split(':');
             if (pieces.length !== 2) {
                 vscode.window.showErrorMessage(`unexpected image name: ${container.image}`);

--- a/src/telemetry-helper.ts
+++ b/src/telemetry-helper.ts
@@ -1,0 +1,9 @@
+import TelemetryReporter from 'vscode-extension-telemetry';
+import { reporter } from './telemetry';
+
+export function telemetrise(command: string, callback: (...args: any[]) => any) : (...args: any[]) => any {
+    return (a) => {
+        reporter.sendTelemetryEvent("command", { command: command });
+        return callback(a);
+    };
+}

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,32 @@
+import TelemetryReporter from 'vscode-extension-telemetry';
+import vscode = require('vscode');
+
+export let reporter: TelemetryReporter;
+
+export class Reporter extends vscode.Disposable {
+
+    constructor(ctx: vscode.ExtensionContext) {
+        super(() => reporter.dispose());
+        let packageInfo = getPackageInfo(ctx);
+        reporter = packageInfo && new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+
+    }
+}
+
+interface IPackageInfo {
+    name: string;
+    version: string;
+    aiKey: string;
+}
+
+function getPackageInfo(context: vscode.ExtensionContext): IPackageInfo {
+    let extensionPackage = require(context.asAbsolutePath('./package.json'));
+    if (extensionPackage) {
+        return {
+            name: extensionPackage.name,
+            version: extensionPackage.version,
+            aiKey: extensionPackage.aiKey
+        };
+    }
+    return;
+}


### PR DESCRIPTION
This PR provides limited telemetry on extension usage.  It collects data about which commands are requested, but not about the inputs or results of those commands, nor about the use of other features such as intellisense or the tree view.