### PR TITLE
Support config maps and secrets

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -130,7 +130,7 @@ class KubernetesWorkloadFolder extends KubernetesFolder {
 
 class KubernetesConfigFolder extends KubernetesFolder {
     constructor() {
-        super("config", "Configs");
+        super("config", "Configuration");
     }
 
     getChildren(kubectl: Kubectl, host : Host) : vscode.ProviderResult<KubernetesObject[]> {

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -84,7 +84,8 @@ class KubernetesCluster implements KubernetesObject {
             new KubernetesNamespaceFolder(),
             new KubernetesResourceFolder(kuberesources.allKinds.node),
             new KubernetesWorkloadFolder(),
-            new KubernetesResourceFolder(kuberesources.allKinds.service)
+            new KubernetesResourceFolder(kuberesources.allKinds.service),
+            new KubernetesConfigFolder()
         ];
     }
 
@@ -123,6 +124,19 @@ class KubernetesWorkloadFolder extends KubernetesFolder {
             new KubernetesResourceFolder(kuberesources.allKinds.deployment),
             new KubernetesResourceFolder(kuberesources.allKinds.job),
             new KubernetesResourceFolder(kuberesources.allKinds.pod)
+        ];
+    }
+}
+
+class KubernetesConfigFolder extends KubernetesFolder {
+    constructor() {
+        super("config", "Configs");
+    }
+
+    getChildren(kubectl: Kubectl, host : Host) : vscode.ProviderResult<KubernetesObject[]> {
+        return [
+            new KubernetesResourceFolder(kuberesources.allKinds.configMap),
+            new KubernetesResourceFolder(kuberesources.allKinds.secret)
         ];
     }
 }

--- a/src/kuberesources.ts
+++ b/src/kuberesources.ts
@@ -17,6 +17,8 @@ export const allKinds = {
     job: new ResourceKind("Job", "Jobs", "job"),
     pod: new ResourceKind("Pod", "Pods", "pod"),
     service: new ResourceKind("Service", "Services", "service"),
+    configMap: new ResourceKind("ConfigMap", "ConfigMaps", "configmap"),
+    secret: new ResourceKind("Secret", "Secrets", "secret"),
 };
 
 export const commonKinds = [


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Feature https://github.com/Azure/vscode-kubernetes-tools/issues/30 to support Config Maps and Secrets on tree explorer. @kyliel @squillace

![k8s_explorer_configmap](https://user-images.githubusercontent.com/14052197/35840916-0d84f05e-0b34-11e8-8ad6-787a0d611aeb.gif)
