### PR TITLE
Adding support for kubectl dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ Where `<your-image-prefix-here>` is something like `docker.io/brendanburns`.
 
    * `Kubernetes Configure from Cluster` - Install and configure the Kubernetes command line tool (kubectl) from an Azure Container Service (ACS) or Azure Kubernetes Service (AKS) cluster
 
+
+### Miscellaneous commands
+
+   * `Kubernetes Open Dashboard` - Opens the Kubernetes Dashboard in your browser.
+
 ### Helm support
 
 [Helm](https://helm.sh/) is the package manager for Kubernetes and provides a way for you to define, install and upgrade applications using 'charts.'  This extension provides a set of tools for creating and testing Helm charts:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2288,6 +2288,11 @@
             "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
             "dev": true
         },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3315,6 +3320,14 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
                 "wrappy": "1.0.2"
+            }
+        },
+        "opn": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz",
+            "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
+            "requires": {
+                "is-wsl": "1.1.0"
             }
         },
         "orchestrator": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "onCommand:extension.vsKubernetesRemoveDebug",
         "onCommand:extension.vsKubernetesConfigureFromCluster",
         "onCommand:extension.vsKubernetesCreateCluster",
+        "onCommand:extension.vsKubernetesDashboard",
         "onCommand:extension.helmTemplate",
         "onCommand:extension.helmTemplatePreview",
         "onCommand:extension.helmLint",
@@ -350,6 +351,11 @@
                 "category": "Kubernetes"
             },
             {
+                "command": "extension.vsKubernetesDashboard",
+                "title": "Open Dashboard",
+                "category": "Kubernetes"
+            },
+            {
                 "command": "extension.draftVersion",
                 "title": "Version",
                 "description": "Get the version of the local Draft client.",
@@ -477,17 +483,18 @@
         "test": "node ./node_modules/vscode/bin/test"
     },
     "dependencies": {
-        "shelljs": "^0.7.7",
-        "js-yaml": "^3.8.2",
-        "dockerfile-parse": "^0.2.0",
-        "k8s": "^0.4.12",
-        "tmp": "^0.0.31",
-        "pluralize": "^4.0.0",
-        "uuid": "^3.1.0",
-        "yamljs": "0.2.10",
         "compare-versions": "^3.1.0",
+        "dockerfile-parse": "^0.2.0",
+        "js-yaml": "^3.8.2",
+        "k8s": "^0.4.12",
         "lodash": ">3",
-        "vscode-extension-telemetry": "^0.0.6"
+        "opn": "^5.2.0",
+        "pluralize": "^4.0.0",
+        "shelljs": "^0.7.7",
+        "tmp": "^0.0.31",
+        "uuid": "^3.1.0",
+        "vscode-extension-telemetry": "^0.0.6",
+        "yamljs": "0.2.10"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.32",

--- a/src/components/kubectl/proxy.ts
+++ b/src/components/kubectl/proxy.ts
@@ -1,0 +1,95 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as opn from 'opn';
+
+import {createReadStream} from 'fs';
+import {resolve} from 'path';
+import {fs} from '../../fs';
+
+const KUBE_DASHBOARD_URL = "http://localhost:8001/ui/";
+const TERMINAL_NAME = "Kubernetes Proxy";
+const PROXY_OUTPUT_FILE = resolve(__dirname, 'proxy.out');
+
+// The instance of the terminal running Kubectl Proxy.
+let terminal:vscode.Terminal;
+
+/**
+ * Runs `kubectl proxy` in a terminal process spawned by the extension, and opens the Kubernetes
+ * dashboard in the user's preferred browser.
+ */
+export async function dashboardKubernetes ():Promise<void> {
+    // If we've already got a terminal instance, just open the dashboard.
+    if (terminal) {
+        opn(KUBE_DASHBOARD_URL);
+        return;
+    }
+
+    let outputExists;
+
+    try {
+        outputExists = await fs.existsAsync(PROXY_OUTPUT_FILE);
+        if (!outputExists) {
+            await fs.openAsync(PROXY_OUTPUT_FILE, 'w+');
+        }
+    } catch (e) {
+        vscode.window.showErrorMessage("Something went wrong when ensuring the Kubernetes API Proxy output stream existed");
+        return;
+    }
+
+    // Read kubectl proxy's stdout as a stream.
+    const proxyStream = createReadStream(
+        PROXY_OUTPUT_FILE,
+        {encoding: 'utf8'}
+    ).on('data', onStreamData);
+
+    terminal = vscode.window.createTerminal(TERMINAL_NAME);
+    vscode.window.onDidCloseTerminal(onClosedTerminal);
+
+    // stdout is also written to a file via `tee`. We read this file as a stream
+    // to listen for when the server is ready.
+    terminal.sendText(`kubectl proxy | tee ${PROXY_OUTPUT_FILE}`);
+    terminal.show(true);
+}
+
+/**
+ * Called when the terminal window is closed by the user.
+ * @param proxyTerminal
+ */
+const onClosedTerminal = async (proxyTerminal:vscode.Terminal) => {
+    // Make sure we only dispose when it's *our* terminal we want gone.
+    if (proxyTerminal.name !== TERMINAL_NAME) {
+        return;
+    }
+
+    terminal = null;
+    console.log("Closing Kubernetes API Proxy");
+
+    try {
+        await fs.unlinkAsync(PROXY_OUTPUT_FILE);
+        console.log('Kubernetes API Proxy stream removed');
+    } catch (e) {
+        console.log('Could not remove Kubernetes API Proxy stream');
+    }
+};
+
+/**
+ * Callback to read data written to the Kubernetes API Proxy output stream.
+ * @param data
+ */
+const onStreamData = (data:String) => {
+    // Everything's alright…
+    if (data.startsWith("Starting to serve")) {
+        // Let the proxy warm up a bit… otherwise we might hit a browser's error page.
+        setTimeout(() => {
+            opn(KUBE_DASHBOARD_URL);
+        }, 2500);
+
+        vscode.window.showInformationMessage(`Kubernetes Dashboard running at ${KUBE_DASHBOARD_URL}`);
+        return;
+    }
+
+    // Maybe we've bound to the port already outside of the extension?
+    vscode.window.showErrorMessage("Could not start the Kubernetes Dashboard. Is it already running?");
+    terminal.dispose();
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,7 @@ import { HelmTemplatePreviewDocumentProvider, HelmInspectDocumentProvider } from
 import { HelmTemplateCompletionProvider } from './helm.completionProvider';
 import { Reporter } from './telemetry';
 import * as telemetry from './telemetry-helper';
+import {dashboardKubernetes} from './components/kubectl/proxy';
 
 let explainActive = false;
 let swaggerSpecPromise = null;
@@ -109,6 +110,7 @@ export function activate(context) {
         registerCommand('extension.vsKubernetesClusterInfo', clusterInfoKubernetes),
         registerCommand('extension.vsKubernetesDeleteContext', deleteContextKubernetes),
         registerCommand('extension.vsKubernetesUseNamespace', useNamespaceKubernetes),
+        registerCommand('extension.vsKubernetesDashboard', dashboardKubernetes),
 
         // Commands - Helm
         registerCommand('extension.helmVersion', helmexec.helmVersion),
@@ -1224,7 +1226,7 @@ const _doDebug = (name, image, cmd) => {
                     localRoot: vscode.workspace.rootPath,
                     remoteRoot: '/'
                 };
-                
+
                 vscode.debug.startDebugging(
                     undefined,
                     debugConfiguration

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -7,6 +7,9 @@ export interface FS {
     writeFile(filename : string, data : any, callback? : (err : NodeJS.ErrnoException) => void) : void;
     writeFileSync(filename : string, data : any) : void;
     dirSync(path: string) : string[];
+    unlinkAsync(path: string) : Promise<void>;
+    existsAsync(path:string) : Promise<boolean>;
+    openAsync(path:string, flags:string) : Promise<void>;
 }
 
 export const fs : FS = {
@@ -16,4 +19,38 @@ export const fs : FS = {
     writeFile: (filename, data, callback) => sysfs.writeFile(filename, data, callback),
     writeFileSync: (filename, data) => sysfs.writeFileSync(filename, data),
     dirSync: (path) => sysfs.readdirSync(path),
+
+    unlinkAsync: (path) => {
+        return new Promise((resolve, reject) => {
+            sysfs.unlink(path, (error) => {
+                if (error) {
+                    reject();
+                    return;
+                }
+
+                resolve();
+            });
+        });
+    },
+
+    existsAsync: (path) => {
+        return new Promise((resolve) => {
+            sysfs.exists(path, (exists) => {
+                resolve(exists);
+            });
+        });
+    },
+
+    openAsync: (path, flags) => {
+        return new Promise((resolve, reject) => {
+            sysfs.open(path, flags, (error, fd) => {
+                if (error) {
+                    reject();
+                    return;
+                }
+
+                resolve();
+            });
+        });
+    }
 };


### PR DESCRIPTION
See below for demo:

![kubeproxy](https://user-images.githubusercontent.com/87996/35949411-28849100-0c26-11e8-8ae2-1fd54c786a3c.gif)

Runs `kubectl proxy` in a terminal window created by the extension, and then attempts to open the Kubernetes dashboard in the user's browser. 

Fixes #9 