### PR TITLE
Fix Helm "no active editor, nothing saved" warning

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -159,7 +159,9 @@ export function activate(context) {
     // On save, refresh the Helm YAML preview.
     vscode.workspace.onDidSaveTextDocument((e: vscode.TextDocument) => {
         if (!editorIsActive()) {
-            logger.helm.log("WARNING: No active editor during save. Nothing saved.");
+            if (helm.hasPreviewBeenShown()) {
+                logger.helm.log("WARNING: No active editor during save. Helm preview was not updated.");
+            }
             return;
         }
         if (e === vscode.window.activeTextEditor.document) {

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -5,9 +5,7 @@ import { helm as logger } from './logger';
 import * as YAML from 'yamljs';
 import * as _ from 'lodash';
 import * as fs from "fs";
-
-export const HELM_PREVIEW_SCHEME = 'helm-template-preview';
-export const HELM_PREVIEW_URI = HELM_PREVIEW_SCHEME + '://preview';
+import * as helm from './helm';
 
 export interface PickChartUIOptions {
     readonly warnIfNoCharts : boolean;
@@ -58,9 +56,10 @@ export function helmTemplatePreview() {
         return;
     }
 
-    let u = vscode.Uri.parse(HELM_PREVIEW_URI);
+    let u = vscode.Uri.parse(helm.PREVIEW_URI);
     let f = filepath.basename(filePath);
     vscode.commands.executeCommand("vscode.previewHtml", u, vscode.ViewColumn.Two, `Preview ${ f }`);
+    helm.recordPreviewHasBeenShown();
 }
 
 export function helmDepUp() {

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -1,3 +1,13 @@
 export const PREVIEW_SCHEME = 'helm-template-preview';
 export const PREVIEW_URI = PREVIEW_SCHEME + '://preview';
 export const INSPECT_SCHEME = 'helm-inspect-values';
+
+let previewShown = false;
+
+export function hasPreviewBeenShown() : boolean {
+    return previewShown;
+}
+
+export function recordPreviewHasBeenShown() : void {
+    previewShown = true;
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -17,7 +17,7 @@ class LoggingConsole implements Logger {
     log(msg: string) {
         this.channel.append(msg);
         this.channel.append("\n");
-        this.channel.show();
+        this.channel.show(true);
     }
     dispose() {
         this.channel.dispose();


### PR DESCRIPTION
At the moment, if any file is saved while a non-editor window is active (e.g. if you do a Ctrl+Shift+S while a preview window is showing), we display a 'Nothing saved' message from Helm and steal focus for that message.  This is both misleading and rude.  This PR changes the behaviour as follows:

* The message is displayed only if the Helm preview feature has been used.  (Would be good to do it only if the Helm preview was still up, but that will take more investigating.)
* The message does not steal focus.
* The message now says "Helm preview will not be updated" instead of "Nothing saved."

Fixes https://github.com/Azure/vscode-kubernetes-tools/issues/51.