### PR TITLE
Fixes for Apply command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1147,7 +1147,7 @@ const diffKubernetes = (callback) => {
             fileName = file;
             if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document) {
                 const langId = vscode.window.activeTextEditor.document.languageId.toLowerCase();
-                if (langId == "yaml" || langId == "helm") {
+                if (langId === "yaml" || langId === "helm") {
                     fileFormat = "yaml";
                 }
             }
@@ -1164,7 +1164,7 @@ const diffKubernetes = (callback) => {
         kubectl.invoke(` get -o ${fileFormat} ${kindName}`, (result, stdout, stderr) => {
             if (result == 1 && stderr.indexOf('NotFound') >= 0) {
                 vscode.window.showWarningMessage(`Resource ${kindName} does not exist - this will create a new resource.`, 'Create').then((choice) => {
-                    if (choice == 'Create') {
+                    if (choice === 'Create') {
                         maybeRunKubernetesCommandForActiveWindow('create -f');
                     }
                 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -462,12 +462,10 @@ function getTextForActiveWindow(callback) {
     if (editor.selection) {
         text = editor.document.getText(editor.selection);
 
-        if (text.length === 0) {
+        if (text.length > 0) {
+            callback(text, null);
             return;
         }
-
-        callback(text, null);
-        return;
     }
 
     if (editor.document.isUntitled) {
@@ -1137,13 +1135,22 @@ const diffKubernetes = (callback) => {
         let kindName = null;
         let fileName = null;
 
+        let fileFormat = "json";
+
         if (data) {
+            fileFormat = (data.trim().length > 0 && data.trim()[0] == '{') ? "json" : "yaml";
             kindName = findKindNameForText(data);
-            fileName = path.join(os.tmpdir(), 'local.json');
+            fileName = path.join(os.tmpdir(), `local.${fileFormat}`);
             fs.writeFile(fileName, data, handleError);
         } else if (file) {
             kindName = findKindName();
             fileName = file;
+            if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document) {
+                const langId = vscode.window.activeTextEditor.document.languageId.toLowerCase();
+                if (langId == "yaml" || langId == "helm") {
+                    fileFormat = "yaml";
+                }
+            }
         } else {
             vscode.window.showInformationMessage('Nothing to diff.');
             return;
@@ -1154,19 +1161,27 @@ const diffKubernetes = (callback) => {
             return;
         }
 
-        kubectl.invoke(` get -o json ${kindName}`, (result, stdout, stderr) => {
-            if (result !== 0) {
+        kubectl.invoke(` get -o ${fileFormat} ${kindName}`, (result, stdout, stderr) => {
+            if (result == 1 && stderr.indexOf('NotFound') >= 0) {
+                vscode.window.showWarningMessage(`Resource ${kindName} does not exist - this will create a new resource.`, 'Create').then((choice) => {
+                    if (choice == 'Create') {
+                        maybeRunKubernetesCommandForActiveWindow('create -f');
+                    }
+                });
+                return;
+            }
+            else if (result !== 0) {
                 vscode.window.showErrorMessage('Error running command: ' + stderr);
                 return;
             }
 
-            let otherFile = path.join(os.tmpdir(), 'server.json');
-            fs.writeFile(otherFile, stdout, handleError);
+            let serverFile = path.join(os.tmpdir(), `server.${fileFormat}`);
+            fs.writeFile(serverFile, stdout, handleError);
 
             vscode.commands.executeCommand(
                 'vscode.diff',
-                vscode.Uri.parse('file://' + otherFile),
-                vscode.Uri.parse('file://' + fileName)).then((result) => {
+                shell.fileUri(serverFile),
+                shell.fileUri(fileName)).then((result) => {
                     console.log(result);
                     if (!callback) {
                         return;

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -8,6 +8,7 @@ export interface Shell {
     isUnix() : boolean;
     home() : string;
     combinePath(basePath : string, relativePath : string);
+    fileUri(filePath) : vscode.Uri;
     execOpts() : any;
     exec(cmd : string) : Promise<ShellResult>;
     execCore(cmd : string, opts : any) : Promise<ShellResult>;
@@ -18,6 +19,7 @@ export const shell : Shell = {
     isUnix : isUnix,
     home : home,
     combinePath : combinePath,
+    fileUri : fileUri,
     execOpts : execOpts,
     exec : exec,
     execCore : execCore
@@ -53,6 +55,13 @@ function combinePath(basePath : string, relativePath : string) {
         separator = '\\';
     }
     return basePath + separator + relativePath;
+}
+
+function fileUri(filePath : string) : vscode.Uri {
+    if (isWindows()) {
+        return vscode.Uri.parse('file:///' + filePath.replace(/\\/g, '/'));
+    }
+    return vscode.Uri.parse('file://' + filePath);
 }
 
 function execOpts() : any {


### PR DESCRIPTION
This fixes a couple of glitches in the Apply command:

1. If the user had not selected any text, it silently exited.  It now applies the whole content of the active document.

2. If the resource did not exist, it exited with a 'resource not found' error.  This is inconsistent with `kubectl apply` which will create the resource if it doesn't exist.  It now warns that this will create a new resource instead of modifying an existing one.

3. If the resource existed, it displayed a diff of the active document against a JSON representation of the resource.  If the active document was YAML, it was hard to spot the differences.  It now detects the type of the active document, and diffs against the appropriate representation.

Fixes #60.