### PR TITLE
Support debug attach to a running java pod

### DIFF
--- a/src/debug/debugProvider.ts
+++ b/src/debug/debugProvider.ts
@@ -6,7 +6,7 @@ import { IDockerfile } from "../docker/parser";
 
 export interface PortInfo {
     readonly debugPort: number;
-    readonly appPort: number;
+    readonly appPort?: number;
 }
 
 export interface IDebugProvider {

--- a/src/debug/debugProvider.ts
+++ b/src/debug/debugProvider.ts
@@ -46,4 +46,14 @@ export interface IDebugProvider {
      * @return the resolved debug port info.
      */
     resolvePortsFromFile(dockerfile: IDockerfile, env: {}): Promise<PortInfo>;
+
+    /**
+     * Resolve the debug port info from the container's shell environment.
+     *
+     * @param kubectl the kubectl client.
+     * @param pod the pod id.
+     * @param container the container id.
+     * @return the resolved port info.
+     */
+    resolvePortsFromContainer(kubectl: Kubectl, pod: string, container: string): Promise<PortInfo>;
 }

--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -23,6 +23,7 @@ interface ProxyResult {
 
 export interface IDebugSession {
     launch(workspaceFolder: vscode.WorkspaceFolder): Promise<void>;
+    attach(workspaceFolder: vscode.WorkspaceFolder, pod?: string): Promise<void>;
 }
 
 export class DebugSession implements IDebugSession {
@@ -104,6 +105,97 @@ export class DebugSession implements IDebugSession {
         });
     }
 
+    /**
+     * In attach mode, the user should choose the running pod first, then the debugger will attach to it.
+     *
+     * @param workspaceFolder the active workspace folder.
+     * @param pod the target pod name.
+     */
+    public async attach(workspaceFolder: vscode.WorkspaceFolder, pod?: string): Promise<void> {
+        if (!workspaceFolder) {
+            return;
+        }
+
+        // Select the image type to attach.
+        this.debugProvider = await providerRegistry.getDebugProvider();
+        if (!this.debugProvider) {
+            return;
+        } else if (!await this.debugProvider.isDebuggerInstalled()) {
+            return;
+        }
+
+        // Select the target pod to attach.
+        let targetPod, targetContainer, containers = [];
+        if (pod) {
+            targetPod = pod;
+            const shellResult = await this.kubectl.invokeAsync(`get pod/${pod} -o json`);
+            if (shellResult.code !== 0) {
+                vscode.window.showErrorMessage(shellResult.stderr);
+                return;
+            }
+            containers = JSON.parse(shellResult.stdout.trim()).spec.containers;
+        } else {
+            const shellResult = await this.kubectl.invokeAsync("get pods -o json");
+            if (shellResult.code !== 0) {
+                vscode.window.showErrorMessage(shellResult.stderr);
+                return;
+            }
+            const podObj = JSON.parse(shellResult.stdout.trim());
+            const podPickItems: vscode.QuickPickItem[] = podObj.items.map((pod) => {
+                return {
+                    label: `${pod.metadata.name} (${pod.spec.nodeName})`,
+                    description: "pod",
+                    name: pod.metadata.name,
+                    containers: pod.spec.containers
+                };
+            });
+            const selectedPod = await vscode.window.showQuickPick(podPickItems, { placeHolder: `Please select a pod to attach` });
+            if (!selectedPod) {
+                return;
+            }
+            targetPod = (<any> selectedPod).name;
+            containers = (<any> selectedPod).containers;
+        }
+
+        // Select the target container to attach.
+        if (containers.length > 1) {
+            const containerPickItems: vscode.QuickPickItem[] = containers.map((container) => {
+                return {
+                    label: `${container.name} (${container.image})`,
+                    description: "container",
+                    name: container.name
+                };
+            });
+            const selectedContainer = await vscode.window.showQuickPick(containerPickItems, { placeHolder: "Please select a container to attach" });
+            if (!selectedContainer) {
+                return;
+            }
+            targetContainer = (<any> selectedContainer).name;
+        }
+
+        // Find the debug port to attach.
+        const portInfo = await this.debugProvider.resolvePortsFromContainer(this.kubectl, targetPod, targetContainer);
+        if (!portInfo || !portInfo.debugPort) {
+            vscode.window.showErrorMessage("Cannot resolve the debug port to attach.");
+            return;
+        }
+
+        vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, async (p) => {
+            try {
+                // Setup port-forward.
+                p.report({ message: "Setting up port forwarding..."});
+                const proxyResult = await this.setupPortForward(targetPod, portInfo.debugPort);
+
+                // Start debug session.
+                p.report({ message: `Starting ${this.debugProvider.getDebuggerType()} debug session...`});
+                await this.startDebugSession(null, workspaceFolder.uri.fsPath, proxyResult);
+            } catch (error) {
+                vscode.window.showErrorMessage(error);
+                kubeChannel.showOutput(`Debug on Kubernetes failed. The errors were: ${error}.`);
+            }
+        });
+    }
+
     private async buildDockerImage(imagePrefix: string, shellOpts: any): Promise<string> {
         kubeChannel.showOutput("Starting to build/push Docker image...", "Docker build/push");
         if (!imagePrefix) {
@@ -145,10 +237,10 @@ export class DebugSession implements IDebugSession {
         kubeChannel.showOutput(`Finshed waiting.`);
     }
 
-    private async setupPortForward(podName: string, debugPort: number, appPort: number): Promise<ProxyResult> {
+    private async setupPortForward(podName: string, debugPort: number, appPort?: number): Promise<ProxyResult> {
         kubeChannel.showOutput(`Setting up port forwarding on pod ${podName}...`, "Set up port forwarding");
         const proxyResult = await this.createPortForward(this.kubectl, podName, debugPort, appPort);
-        kubeChannel.showOutput(`Created port-forward ${proxyResult.proxyDebugPort}:${debugPort} ${proxyResult.proxyAppPort}:${appPort}`);
+        kubeChannel.showOutput(`Created port-forward ${proxyResult.proxyDebugPort}:${debugPort} ${appPort ? proxyResult.proxyAppPort + ":" + appPort : ""}`);
         
         // Wait for the port-forward proxy to be ready.
         kubeChannel.showOutput("Waiting for port forwarding to be ready...");
@@ -181,7 +273,7 @@ export class DebugSession implements IDebugSession {
         }
     }
 
-    private async createPortForward(kubectl: Kubectl, podName: string, debugPort: number, appPort: number): Promise<ProxyResult> {
+    private async createPortForward(kubectl: Kubectl, podName: string, debugPort: number, appPort?: number): Promise<ProxyResult> {
         let portMapping = [];
         // Find a free local port for forwarding data to remote app port.
         let proxyAppPort = 0;

--- a/src/debug/debugUtils.ts
+++ b/src/debug/debugUtils.ts
@@ -1,0 +1,9 @@
+import * as vscode from 'vscode';
+
+export async function promptForDebugPort(defaultPort: string): Promise<string> {
+    const input = await vscode.window.showInputBox({
+        prompt: `Please specify debug port exposed for debugging (e.g. ${defaultPort})`,
+        placeHolder: defaultPort
+    });
+    return input && input.trim();
+}

--- a/src/debug/debugUtils.ts
+++ b/src/debug/debugUtils.ts
@@ -1,9 +1,71 @@
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
+
+import { Kubectl } from "../kubectl";
 
 export async function promptForDebugPort(defaultPort: string): Promise<string> {
     const input = await vscode.window.showInputBox({
         prompt: `Please specify debug port exposed for debugging (e.g. ${defaultPort})`,
         placeHolder: defaultPort
     });
+
     return input && input.trim();
+}
+
+export async function promptForAppPort(ports: string[], defaultPort: string, env: {}): Promise<string> {
+    let rawAppPortInfo: string;
+    if (ports.length === 1) {
+        rawAppPortInfo = ports[0];
+    } else if (ports.length > 1) {
+        rawAppPortInfo = await vscode.window.showQuickPick(ports, { placeHolder: "Choose the application port you want to expose for debugging." });
+    }
+
+    // If the choosed port is a variable, then need set it in environment variables.
+    const portRegExp = /\$\{?(\w+)\}?/;
+    if (portRegExp.test(rawAppPortInfo)) {
+        const varName = rawAppPortInfo.match(portRegExp)[1];
+        if (rawAppPortInfo.trim() === `$${varName}` || rawAppPortInfo.trim() === `\${${varName}}`) {
+            env[varName] = defaultPort;
+            rawAppPortInfo = defaultPort;
+        } else {
+            vscode.window.showErrorMessage(`Invalid port variable ${rawAppPortInfo} in the docker file.`);
+            return;
+        }
+    }
+
+    return rawAppPortInfo;
+}
+
+/**
+ * Get the command info associated with the processes in the target container.
+ *
+ * @param kubectl the kubectl client.
+ * @param pod the pod name.
+ * @param container the container name.
+ * @return the commands associated with the processes.
+ */
+export async function getCommandsOfProcesses(kubectl: Kubectl, pod: string, container: string): Promise<string[]> {
+    const commandLines: string[] = [];
+    const execCmd = `exec ${pod} ${container ? "-c ${selectedContainer}" : ""} -- ps -ef`;
+    const execResult = await kubectl.invokeAsync(execCmd);
+    if (execResult.code === 0) {
+        /**
+         * PID   USER     TIME   COMMAND
+         *  1    root     2:09   java -Djava.security.egd=file:/dev/./urandom -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1044,quiet=y -jar target/app.jar
+         * 44    root     0:00   sh
+         * 48    root     0:00   ps -ef
+         */
+        const rows = execResult.stdout.split("\n");
+        const columnCount = rows[0].trim().split(/\s+/).length;
+        // The 1st row is the header, loop from the 2nd row.
+        for (let i = 1; i < rows.length; i++) {
+            const cols = rows[i].trim().split(/\s+/);
+            if (cols.length < columnCount) {
+                continue;
+            }
+
+            commandLines.push(cols.slice(columnCount - 1, cols.length).join(" "));
+        }
+    }
+
+    return commandLines;
 }

--- a/src/debug/javaDebugProvider.ts
+++ b/src/debug/javaDebugProvider.ts
@@ -1,9 +1,10 @@
 import * as path from "path";
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
-import { IDebugProvider, PortInfo } from './debugProvider';
+import { IDebugProvider, PortInfo } from "./debugProvider";
+import * as debugUtils from "./debugUtils";
 import * as extensionUtils from "../extensionUtils";
-import { Kubectl } from '../kubectl';
+import { Kubectl } from "../kubectl";
 import { IDockerfile } from "../docker/parser";
 
 // Use the java debugger extension provided by microsoft team for java debugging.
@@ -69,11 +70,7 @@ export class JavaDebugProvider implements IDebugProvider {
         }
         // Cannot resolve the debug port from Dockerfile, then ask user to specify it.
         if (!rawDebugPortInfo) {
-            const input = await vscode.window.showInputBox({
-                prompt: `Please specify debug port exposed for debugging (e.g. 5005)`,
-                placeHolder: "5005"
-            });
-            rawDebugPortInfo = (input ? input.trim() : null);
+            rawDebugPortInfo = await debugUtils.promptForDebugPort(defaultJavaDebugPort);
         }
         if (!rawDebugPortInfo) {
             return;
@@ -140,11 +137,7 @@ export class JavaDebugProvider implements IDebugProvider {
         }
 
         if (!rawDebugPortInfo) {
-            const input = await vscode.window.showInputBox({
-                prompt: `Please specify debug port exposed for debugging (e.g. 5005)`,
-                placeHolder: defaultJavaDebugPort
-            });
-            rawDebugPortInfo = (input ? input.trim() : null);
+            rawDebugPortInfo = await debugUtils.promptForDebugPort(defaultJavaDebugPort);
         }
 
         return {

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -212,3 +212,19 @@ export async function waitForRunningPod(kubectl: Kubectl, podName: string): Prom
 function isTransientPodState(status: string): boolean {
     return status === "ContainerCreating" || status === "Pending" || status === "Succeeded";
 }
+
+/**
+ * Get the specified resource information.
+ *
+ * @param kubectl the kubectl client.
+ * @param resourceId the resource id.
+ * @return the result as a json object, or undefined if errors happen.
+ */
+export async function getResourceAsJson(kubectl: Kubectl, resourceId: string): Promise<any> {
+    const shellResult = await kubectl.invokeAsync(`get ${resourceId} -o json`);
+    if (shellResult.code !== 0) {
+        vscode.window.showErrorMessage(shellResult.stderr);
+        return;
+    }
+    return JSON.parse(shellResult.stdout.trim());
+}


### PR DESCRIPTION
Plan to split the local debug support to several PRs for review.

PR1: Define debug framework and add java debug implementation. (**merged**)
PR2: Add node debug implementation.
**PR3: Add debug (attach) support.**
PR4: Enable the new debug framework via kubernetes commands Debug(Launch) and Debug(Attach)
PR5: Support docker-compose.yml ?