### PR TITLE
Offer all pods for exec/terminal

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -914,30 +914,20 @@ async function selectPod(scope: PodSelectionScope, fallback: PodSelectionFallbac
     if (podList.length === 1) {
         return podList[0];
     }
-    let names = [];
 
-    for (const element of podList) {
-        names.push(`${element.metadata.namespace}/${element.metadata.name}`);
-    }
+    const pickItems = podList.map((element) => { return {
+        label: `${element.metadata.namespace}/${element.metadata.name}`,
+        description: '',
+        pod: element
+    };});
 
-    const value = await vscode.window.showQuickPick(names);
+    const value = await vscode.window.showQuickPick(pickItems);
 
     if (!value) {
         return null;
     }
 
-    let ix = value.indexOf('/');
-    let name = value.substring(ix + 1);
-
-    for (const element of podList) {
-        if (element.metadata.name !== name) {
-            continue;
-        }
-
-        return element;
-    }
-
-    return null;
+    return value.pod;
 }
 
 function logsKubernetes(explorerNode? : explorer.ResourceNode) {
@@ -1013,26 +1003,26 @@ async function selectContainerForPod(pod) : Promise<any | null> {
     if (!pod) {
         return null;
     }
-    if (pod.spec.containers.length === 1) {
+
+    const containers : any[] = pod.spec.containers;
+    
+    if (containers.length === 1) {
         return pod.spec.containers[0];
     }
-    let names = [];
+    
+    const pickItems = containers.map((element) => { return {
+        label: `${element.metadata.namespace}/${element.metadata.name}`,
+        description: '',
+        container: element
+    };});
 
-    for (const element of pod.spec.containers) {
-        names.push(element.name);
+    const value = await vscode.window.showQuickPick(pickItems);
+
+    if (!value) {
+        return null;
     }
 
-    const value = vscode.window.showQuickPick(names);
-
-    for (const element of pod.spec.containers) {
-        if (element.name !== value) {
-            continue;
-        }
-
-        return element;
-    }
-
-    return null;
+    return value.container;
 }
 
 function execKubernetes() {


### PR DESCRIPTION
When you run Exec or Terminal, the extension uses a label that it applies during Run to locate pods associated with the current application.  However, this causes an unhelpful error if the application was not deployed with the extension.  With this PR, if there are no pods identified for the current application, the extension displays a list of all pods, and the user can exec or open a terminal on any of them.

To simplify the functional change, I converted the original code from callback style to async/await.  Reviewers can see these two commits separately to check the fidelity of the conversion.  It would be nice to more strongly type the pod info after deserialisation (there was a latent bug if the app had more than one pod, which types would have caught), but I propose to defer this for now.

Fixes #65.