### PR TITLE
Improved Sync command messages and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Where `<your-image-prefix-here>` is something like `docker.io/brendanburns`.
    * `Kubernetes: Debug (Launch)` - Run the current application as a Kubernetes Deployment and attach a debugging session to it (currently works only for Java/Node.js deployments)
    * `Kubernetes: Debug (Attach)` - Attach a debugging session to an existing Kubernetes Deployment (currently works only for Java deployments)
    * `Kubernetes: Remove Debug` - Remove the deployment and/or service created for a `Kubernetes Debug (Launch)` session
+   * `Kubernetes: Sync Working Copy to Cluster` - Checks out the version of the code that matches what is deployed in the cluster.  (This relies on Docker image versions also being Git commit IDs, which the extension does if you use the Run command to build the container, but which typically doesn't work for containers/deployments done by other means.)
 
 ### Configuration commands
 

--- a/package.json
+++ b/package.json
@@ -297,7 +297,7 @@
             },
             {
                 "command": "extension.vsKubernetesSync",
-                "title": "Sync",
+                "title": "Sync Working Copy to Cluster",
                 "category": "Kubernetes"
             },
             {

--- a/src/components/git/git.ts
+++ b/src/components/git/git.ts
@@ -1,0 +1,29 @@
+import { Shell, ShellResult } from '../../shell';
+import { Errorable } from '../../wizard';
+
+export class Git {
+    constructor(private readonly shell: Shell) {}
+
+    private async git(args: string) : Promise<ShellResult> {
+        const cmd = `git ${args}`;
+        const sr = await this.shell.execCore(cmd, this.shell.execOpts());
+        return sr;
+    }
+
+    public async whenCreated(commitId: string): Promise<string | null> {
+        const sr = await this.git(`log --pretty=%ar -n 1 ${commitId}`);
+        if (sr.code === 0) {
+            return sr.stdout;
+        }
+        return null;
+    }
+
+    public async checkout(commitId: string) : Promise<Errorable<void>> {
+        const sr = await this.git(`checkout ${commitId}`);
+        if (sr.code === 0) {
+            return { succeeded: true, result: null, error: [] };
+        }
+        return { succeeded: false, result: null, error: [ sr.stderr ] };
+    }
+}
+


### PR DESCRIPTION
It was not clear what the Sync command was doing, and the errors were often opaque.  This PR provides a confirmation message of what the command is about to do (check out a Git commit based on the image version), and provides clearer explanations when it fails.

It goes some way towards fixing #68, but we still need to join it up more clearly with other commands through process and/or documentation.