### PR TITLE
Use JVM environment variables to enable java debug options

### DIFF
--- a/src/debug/debugUtils.ts
+++ b/src/debug/debugUtils.ts
@@ -13,13 +13,13 @@ async function promptForPort(promptMessage: string, defaultPort: string): Promis
 }
 
 export async function promptForDebugPort(defaultPort: string): Promise<string> {
-    return await promptForPort("What debug port your app is enabled on?", defaultPort);
+    return await promptForPort("Please specify debug port exposed for debugging", defaultPort);
 }
 
 export async function promptForAppPort(ports: string[], defaultPort: string, env: {}): Promise<string> {
     let rawAppPortInfo: string;
     if (ports.length === 0) {
-        return await promptForPort("What port your app listens on?", defaultPort);
+        return await promptForPort("What port does your application listen on?", defaultPort);
     } if (ports.length === 1) {
         rawAppPortInfo = ports[0];
     } else if (ports.length > 1) {

--- a/src/debug/debugUtils.ts
+++ b/src/debug/debugUtils.ts
@@ -2,21 +2,28 @@ import * as vscode from "vscode";
 
 import { Kubectl } from "../kubectl";
 
-export async function promptForDebugPort(defaultPort: string): Promise<string> {
+async function promptForPort(promptMessage: string, defaultPort: string): Promise<string> {
     const input = await vscode.window.showInputBox({
-        prompt: `Please specify debug port exposed for debugging (e.g. ${defaultPort})`,
-        placeHolder: defaultPort
+        prompt: promptMessage,
+        placeHolder: defaultPort,
+        value: defaultPort
     });
 
     return input && input.trim();
 }
 
+export async function promptForDebugPort(defaultPort: string): Promise<string> {
+    return await promptForPort("What debug port your app is enabled on?", defaultPort);
+}
+
 export async function promptForAppPort(ports: string[], defaultPort: string, env: {}): Promise<string> {
     let rawAppPortInfo: string;
-    if (ports.length === 1) {
+    if (ports.length === 0) {
+        return await promptForPort("What port your app listens on?", defaultPort);
+    } if (ports.length === 1) {
         rawAppPortInfo = ports[0];
     } else if (ports.length > 1) {
-        rawAppPortInfo = await vscode.window.showQuickPick(ports, { placeHolder: "Choose the application port you want to expose for debugging." });
+        rawAppPortInfo = await vscode.window.showQuickPick(ports, { placeHolder: "Choose the port your app listens on." });
     }
 
     // If the choosed port is a variable, then need set it in environment variables.
@@ -24,8 +31,9 @@ export async function promptForAppPort(ports: string[], defaultPort: string, env
     if (portRegExp.test(rawAppPortInfo)) {
         const varName = rawAppPortInfo.match(portRegExp)[1];
         if (rawAppPortInfo.trim() === `$${varName}` || rawAppPortInfo.trim() === `\${${varName}}`) {
-            env[varName] = defaultPort;
-            rawAppPortInfo = defaultPort;
+            const defaultAppPort = "50006"; // Configure an unusual port number for the variable.
+            env[varName] = defaultAppPort;
+            rawAppPortInfo = defaultAppPort;
         } else {
             vscode.window.showErrorMessage(`Invalid port variable ${rawAppPortInfo} in the docker file.`);
             return;

--- a/src/debug/javaDebugProvider.ts
+++ b/src/debug/javaDebugProvider.ts
@@ -72,8 +72,6 @@ export class JavaDebugProvider implements IDebugProvider {
             // https://stackoverflow.com/questions/28327620/difference-between-java-options-java-tool-options-and-java-opts,
             // JAVA_TOOL_OPTIONS and _JAVA_OPTIONS are ways to specify JVM arguments as an environment variable instead of command line parameters.
             // _JAVA_OPTIONS trumps command-line arguments, which in turn trump JAVA_TOOL_OPTIONS.
-            env["_JAVA_OPTIONS"] = defaultJavaDebugOpts;
-            // For the JVMs that don't support _JAVA_OPTIONS, let them to fall back to JAVA_TOOL_OPTIONS.
             env["JAVA_TOOL_OPTIONS"] = defaultJavaDebugOpts;
             rawDebugPortInfo = defaultJavaDebugPort;
         }

--- a/src/debug/javaDebugProvider.ts
+++ b/src/debug/javaDebugProvider.ts
@@ -71,6 +71,7 @@ export class JavaDebugProvider implements IDebugProvider {
             // According to the documents https://bugs.openjdk.java.net/browse/JDK-4971166 and
             // https://stackoverflow.com/questions/28327620/difference-between-java-options-java-tool-options-and-java-opts,
             // JAVA_TOOL_OPTIONS and _JAVA_OPTIONS are ways to specify JVM arguments as an environment variable instead of command line parameters.
+            // JAVA_TOOL_OPTIONS is included in standard JVMTI specification and is the recommended way.
             // _JAVA_OPTIONS trumps command-line arguments, which in turn trump JAVA_TOOL_OPTIONS.
             env["JAVA_TOOL_OPTIONS"] = defaultJavaDebugOpts;
             rawDebugPortInfo = defaultJavaDebugPort;


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

This PR provides a third-way to enable java debug options, and also a workaround for the bug https://github.com/Azure/vscode-kubernetes-tools/issues/83