### PR TITLE
Telemetry for which cloud services get used in Create and Configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,12 @@ Where `<your-image-prefix-here>` is something like `docker.io/brendanburns`.
 See the [change log](CHANGELOG.md).
 
 ## Telemetry
-This extension collects telemetry data to help us build a better experience for building applications with Kubernetes and VS Code. We only collect data on which commands are executed. We do not collect any information about image names, paths, etc. The extension respects the `telemetry.enableTelemetry` setting which you can learn more about in our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
+This extension collects telemetry data to help us build a better experience for building applications with Kubernetes and VS Code. We only collect the following data:
+
+* Which commands are executed
+* For the `Create Cluster` and `Configure from Cluster` commands, the cluster type selected.
+ 
+We do not collect any information about image names, paths, etc. The extension respects the `telemetry.enableTelemetry` setting which you can learn more about in our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
 
 # Contributing
 


### PR DESCRIPTION
We have a request from the business to measure how many users choose different cloud Kubernetes services in the Create Cluster and Configure From Cluster commands.  This PR adds telemetry for that, and updates the documentation to clearly identify this to users so they can opt out if they have concerns.  (I will add it to the changelog when I next cut a release.)