### PR TITLE
Fix duplicate intermediate directory in Helm preview path

### DIFF
--- a/src/helm.documentProvider.ts
+++ b/src/helm.documentProvider.ts
@@ -69,8 +69,11 @@ export class HelmTemplatePreviewDocumentProvider implements vscode.TextDocumentC
             // First, we need to get the top-most chart:
             exec.pickChartForFile(tpl, { warnIfNoCharts: true }, (chartPath) => {
                 // We need the relative path for 'helm template'
-                let reltpl = filepath.relative(filepath.dirname(chartPath), tpl);
-                exec.helmExec("template " + chartPath + " --execute " + reltpl, (code, out, err) => {
+                if (!fs.statSync(chartPath).isDirectory) {
+                    chartPath = filepath.dirname(chartPath);
+                }
+                const reltpl = filepath.relative(chartPath, tpl);
+                exec.helmExec(`template "${chartPath}" --execute "${reltpl}"`, (code, out, err) => {
                     if (code != 0) {
                         resolve(previewBody("Chart Preview", "Failed template call." + err, true));
                         return;

--- a/src/helm.documentProvider.ts
+++ b/src/helm.documentProvider.ts
@@ -30,14 +30,14 @@ export class HelmInspectDocumentProvider implements vscode.TextDocumentContentPr
             const file = uri.fsPath || uri.authority;
             const fi = fs.statSync(file);
             if (!fi.isDirectory() && filepath.extname(file) == ".tgz") {
-                exec.helmExec("inspect values " + file, printer);
+                exec.helmExec(`inspect values "${file}"`, printer);
                 return;
             } else if (fi.isDirectory() && fs.existsSync(filepath.join(file, "Chart.yaml"))) {
-                exec.helmExec("inspect values " + file, printer);
+                exec.helmExec(`inspect values "${file}"`, printer);
                 return;
             }
             exec.pickChartForFile(file, { warnIfNoCharts: true }, (path) => {
-                exec.helmExec("inspect values "+ path, printer);
+                exec.helmExec(`inspect values "${path}"`, printer);
             });
         });
         

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -28,7 +28,7 @@ export function helmVersion() {
 // runs 'helm template' on it. If multiples are found, it prompts the user to select one.
 export function helmTemplate() {
     pickChart((path) => {
-        helmExec("template "+ path, (code, out, err) => {
+        helmExec(`template "${path}"`, (code, out, err) => {
             if (code != 0) {
                 vscode.window.showErrorMessage(err);
                 return;
@@ -65,7 +65,7 @@ export function helmTemplatePreview() {
 export function helmDepUp() {
     pickChart((path) => {
         logger.log("⎈⎈⎈ Updating dependencies for " + path);
-        helmExec("dep up " + path, (code, out, err) => {
+        helmExec(`dep up "${path}"`, (code, out, err) => {
             logger.log(out);
             logger.log(err);
             if (code != 0) {
@@ -81,7 +81,7 @@ export function helmCreate() {
         placeHolder: "mychart"
     }).then((name) => {
         let fullpath = filepath.join(vscode.workspace.rootPath, name);
-        helmExec("create " + fullpath, (code, out, err) => {
+        helmExec(`create "${fullpath}"`, (code, out, err) => {
             if (code != 0) {
                 vscode.window.showErrorMessage(err);
             }
@@ -93,7 +93,7 @@ export function helmCreate() {
 export function helmLint() {
     pickChart((path) => {
         logger.log("⎈⎈⎈ Linting " + path);
-        helmExec("lint "+ path, (code, out, err) => {
+        helmExec(`lint "${path}"`, (code, out, err) => {
             logger.log(out);
             logger.log(err);
             if (code != 0) {
@@ -121,7 +121,7 @@ export function helmInspectValues(u: vscode.Uri) {
 export function helmDryRun() {
     pickChart((path) => {
         logger.log("⎈⎈⎈ Installing (dry-run) " + path);
-        helmExec("install --dry-run --debug "+ path, (code, out, err) => {
+        helmExec(`install --dry-run --debug "${path}"`, (code, out, err) => {
             logger.log(out);
             logger.log(err);
             if (code != 0) {
@@ -239,11 +239,6 @@ export function helmExec(args: string, fn) {
     }
     let cmd = "helm " + args;
     shell.exec(cmd, fn);
-}
-
-// isHelmChart tests whether the given path has a Chart.yaml file
-export function isHelmChart(path: string): boolean {
-    return shell.test("-e", path + "/Chart.yaml");
 }
 
 export function ensureHelm() {


### PR DESCRIPTION
There was an issue where the Helm template preview was attempting to execute a template using a path where one of the segments was doubled, e.g. `c:\test\project\mychart\mychart\templates\foo.yaml`.  This occurred because we took the chart path (e.g. `c:\test\project\mychart`, then took the relative path of the template _relative to the containing directory_ (e.g. relative to `c:\test\project` => `mychart\templates\foo.yaml`), then executed the template using the chart directory and the mismatching relative path.

This PR checks if the chart path is a directory (which it should always be), and if so uses _that_ as the relative-to directory, rather than its containing directory.

It also addresses a possible error if a path name contained spaces.

Fixes #98.