### PR TITLE
Don't show Helm Inspect Values in palette, only in context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,6 +242,10 @@
                 {
                     "command": "extension.vsKubernetesUseNamespace",
                     "when": "view == extension.vsKubernetesExplorer"
+                },
+                {
+                    "command": "extension.helmInspectValues",
+                    "when": "filesExplorerFocus"
                 }
             ]
         },


### PR DESCRIPTION
Fixes #116.