### PR TITLE
Add a user setting switch to control whether to auto clean up the created debug deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Where `<your-image-prefix-here>` is something like `docker.io/brendanburns`.
        * `vs-kubernetes.namespace` - The namespace to use for all commands
        * `vs-kubernetes.kubectl-path` - File path to the kubectl binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
        * `vs-kubernetes.draft-path` - File path to the draft binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
+       * `vs-kubernetes.autoCleanupOnDebugTerminate` - The flag to control whether to auto cleanup the created Deployment and associated Pod by the command "Kubernetes: Debug (Launch)". The cleanup action occurs when it failed to start debug session or debug session terminated. Default to `true`.
    * `vsdocker.imageUser` - Image prefix for docker images e.g. 'docker.io/brendanburns'
 
 ## Known Issues

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Where `<your-image-prefix-here>` is something like `docker.io/brendanburns`.
        * `vs-kubernetes.namespace` - The namespace to use for all commands
        * `vs-kubernetes.kubectl-path` - File path to the kubectl binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
        * `vs-kubernetes.draft-path` - File path to the draft binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
-       * `vs-kubernetes.autoCleanupOnDebugTerminate` - The flag to control whether to auto cleanup the created Deployment and associated Pod by the command "Kubernetes: Debug (Launch)". The cleanup action occurs when it failed to start debug session or debug session terminated. If not specified, the extension will prompt for `"Clean Up"` or not.
+       * `vs-kubernetes.autoCleanupOnDebugTerminate` - The flag to control whether to auto cleanup the created deployment and associated pod by the command "Kubernetes: Debug (Launch)". The cleanup action occurs when it failed to start debug session or debug session terminated. If not specified, the extension will prompt for whether to clean up or not. You might choose not to clean up if you wanted to view pod logs, etc.
    * `vsdocker.imageUser` - Image prefix for docker images e.g. 'docker.io/brendanburns'
 
 ## Known Issues

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Where `<your-image-prefix-here>` is something like `docker.io/brendanburns`.
        * `vs-kubernetes.namespace` - The namespace to use for all commands
        * `vs-kubernetes.kubectl-path` - File path to the kubectl binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
        * `vs-kubernetes.draft-path` - File path to the draft binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
-       * `vs-kubernetes.autoCleanupOnDebugTerminate` - The flag to control whether to auto cleanup the created Deployment and associated Pod by the command "Kubernetes: Debug (Launch)". The cleanup action occurs when it failed to start debug session or debug session terminated. Default to `true`.
+       * `vs-kubernetes.autoCleanupOnDebugTerminate` - The flag to control whether to auto cleanup the created Deployment and associated Pod by the command "Kubernetes: Debug (Launch)". The cleanup action occurs when it failed to start debug session or debug session terminated. If not specified, the extension will prompt for `"Clean Up"` or not.
    * `vsdocker.imageUser` - Image prefix for docker images e.g. 'docker.io/brendanburns'
 
 ## Known Issues

--- a/debug-on-kubernetes.md
+++ b/debug-on-kubernetes.md
@@ -12,7 +12,7 @@ One of the key features of VS Code Kubernetes Extension is its one-click debuggi
 
 ## 3. Extension Settings for debugging
    * `vs-kubernetes` - Parent for Kubernetes-related extension settings
-      * `vs-kubernetes.autoCleanupOnDebugTerminate` - The flag to control whether to auto cleanup the created Deployment and associated Pod by the command "Kubernetes: Debug (Launch)". The cleanup action occurs when it failed to start debug session or debug session terminated. If not specified, the extension will prompt for `"Clean Up"` or not.
+      * `vs-kubernetes.autoCleanupOnDebugTerminate` - The flag to control whether to auto cleanup the created Deployment and associated Pod by the command "Kubernetes: Debug (Launch)". The cleanup action occurs when it failed to start debug session or debug session terminated. If not specified, the extension will prompt for whether to clean up or not. You might choose not to clean up if you wanted to view pod logs, etc.
    * `vsdocker.imageUser` - Image prefix for docker images e.g. 'docker.io/brendanburns'.
 
 ## 4. How to use it for Java debugging

--- a/debug-on-kubernetes.md
+++ b/debug-on-kubernetes.md
@@ -10,8 +10,13 @@ One of the key features of VS Code Kubernetes Extension is its one-click debuggi
    * `Kubernetes: Debug (Launch)` - Run the current application as a Kubernetes Deployment and attach a debugging session to it (currently works only for Java/Node.js deployments)
    * `Kubernetes: Debug (Attach)` - Attach a debugging session to an existing Kubernetes Deployment (currently works only for Java deployments)
 
-## 3. How to use it for Java debugging
-### 3.1 Launch a Spring Boot application on Kubernetes and debug it
+## 3. Extension Settings for debugging
+   * `vs-kubernetes` - Parent for Kubernetes-related extension settings
+      * `vs-kubernetes.autoCleanupOnDebugTerminate` - The flag to control whether to auto cleanup the created Deployment and associated Pod by the command "Kubernetes: Debug (Launch)". The cleanup action occurs when it failed to start debug session or debug session terminated. If not specified, the extension will prompt for `"Clean Up"` or not.
+   * `vsdocker.imageUser` - Image prefix for docker images e.g. 'docker.io/brendanburns'.
+
+## 4. How to use it for Java debugging
+### 4.1 Launch a Spring Boot application on Kubernetes and debug it
    * Launch VS Code.
    * Open a Spring Boot application.
    * If your application doesn't already have a Dockerfile, create one for it.
@@ -42,7 +47,7 @@ Here is a GIF showing the full workflow:
 
 ![launch java debug on minikube](https://raw.githubusercontent.com/Azure/vscode-kubernetes-tools/master/images/screenshots/launch-java-debug.gif)
 
-### 3.2 Attach debugger to a running Kubernetes Java Deployment
+### 4.2 Attach debugger to a running Kubernetes Java Deployment
    * Launch VS Code.
    * Open a Spring Boot application.
    * Install [Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) extension (if not already installed).

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
                         "vs-kubernetes.namespace": "",
                         "vs-kubernetes.kubectl-path": "",
                         "vs-kubernetes.draft-path": "",
-                        "vs-kubernetes.autoCleanupOnDebugTerminate": true
+                        "vs-kubernetes.autoCleanupOnDebugTerminate": false
                     }
                 },
                 "vsdocker.imageUser": {

--- a/package.json
+++ b/package.json
@@ -71,22 +71,18 @@
                     "properties": {
                         "vs-kubernetes.namespace": {
                             "type": "string",
-                            "default": "default",
                             "description": "The namespace to use for all commands"
                         },
                         "vs-kubernetes.kubectl-path": {
                             "type": "string",
-                            "default": null,
                             "description": "File path to a kubectl binary."
                         },
                         "vs-kubernetes.draft-path": {
                             "type": "string",
-                            "default": null,
                             "description": "File path to a draft binary."
                         },
                         "vs-kubernetes.autoCleanupOnDebugTerminate": {
                             "type": "boolean",
-                            "default": true,
                             "description": "Once the debug session is terminated, automatically clean up the created Deployment and associated Pod by the command \"Kubernetes: Debug (Launch)\"."
                         }
                     },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,18 @@
                             "type": "string",
                             "default": null,
                             "description": "File path to a draft binary."
+                        },
+                        "vs-kubernetes.autoCleanupOnDebugTerminate": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "Once the debug session is terminated, automatically clean up the created Deployment and associated Pod by the command \"Kubernetes: Debug (Launch)\"."
                         }
+                    },
+                    "default": {
+                        "vs-kubernetes.namespace": "",
+                        "vs-kubernetes.kubectl-path": "",
+                        "vs-kubernetes.draft-path": "",
+                        "vs-kubernetes.autoCleanupOnDebugTerminate": true
                     }
                 },
                 "vsdocker.imageUser": {

--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -287,10 +287,7 @@ export class DebugSession implements IDebugSession {
         } else if (answer === "Always Clean Up") {
             // The object returned by VS Code API is readonly, clone it first.
             const oldConfig = vscode.workspace.getConfiguration("vs-kubernetes");
-            const newConfig = {};
-            for (const key of Object.keys(oldConfig)) {
-                newConfig[key] = oldConfig[key];
-            }
+            const newConfig = <any> Object.assign({}, oldConfig);
             newConfig["vs-kubernetes.autoCleanupOnDebugTerminate"] = true;
             await vscode.workspace.getConfiguration().update("vs-kubernetes", newConfig);
             return await this.cleanupResource(resourceId);


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Sometimes the debugger cannot be launched successfully, and auto cleanup mechanism will cause the user to have no chance to show the logs of the pod to diagnose what happens.  Add a switch to disable the cleanup policy for failure diagnostics.