### PR TITLE
Add Copy command to copy the resource id from tree explorer to clipboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-kubernetes-tools",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -107,6 +107,11 @@
             "version": "0.18.0",
             "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.18.0.tgz",
             "integrity": "sha1-Fi67SKODQIvE3kTbMrQXMH9Fu8E="
+        },
+        "arch": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.0.tgz",
+            "integrity": "sha1-NhOqRhSQZLPB8GB5Gb8dR4boKIk="
         },
         "archy": {
             "version": "1.0.0",
@@ -494,6 +499,15 @@
                 }
             }
         },
+        "clipboardy": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
+            "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
+            "requires": {
+                "arch": "2.1.0",
+                "execa": "0.8.0"
+            }
+        },
         "clone": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
@@ -614,6 +628,27 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "cross-spawn": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "requires": {
+                "lru-cache": "4.1.2",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+                    "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+                    "requires": {
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
+                    }
+                }
+            }
         },
         "cryptiles": {
             "version": "3.1.2",
@@ -888,6 +923,20 @@
                 "assert-plus": "1.0.0"
             }
         },
+        "execa": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+            "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+            "requires": {
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+            }
+        },
         "expand-brackets": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -1121,6 +1170,11 @@
             "requires": {
                 "is-property": "1.0.2"
             }
+        },
+        "get-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
         "get-value": {
             "version": "2.0.6",
@@ -2400,8 +2454,7 @@
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-            "dev": true
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
         "is-supported-regexp-flag": {
             "version": "1.0.0",
@@ -2453,8 +2506,7 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
             "version": "2.1.0",
@@ -3361,6 +3413,14 @@
                 "remove-trailing-separator": "1.1.0"
             }
         },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "requires": {
+                "path-key": "2.0.1"
+            }
+        },
         "oauth-sign": {
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -3613,6 +3673,11 @@
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        },
         "parse-filepath": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
@@ -3675,6 +3740,11 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         },
         "path-parse": {
             "version": "1.0.5",
@@ -4116,6 +4186,19 @@
                 }
             }
         },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "requires": {
+                "shebang-regex": "1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+        },
         "shelljs": {
             "version": "0.7.8",
             "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
@@ -4131,6 +4214,11 @@
             "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
             "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
             "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "snapdragon": {
             "version": "0.8.1",
@@ -4599,6 +4687,11 @@
                 "first-chunk-stream": "1.0.0",
                 "strip-bom": "2.0.0"
             }
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "supports-color": {
             "version": "1.2.0",
@@ -5401,7 +5494,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-            "dev": true,
             "requires": {
                 "isexe": "2.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -142,6 +142,11 @@
                     "group": "0@2"
                 },
                 {
+                    "command": "extension.vsKubernetesCopy",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.cluster.inactive",
+                    "group": "1"
+                },
+                {
                     "command": "extension.vsKubernetesClusterInfo",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.cluster",
                     "group": "0@1"
@@ -157,9 +162,24 @@
                     "group": "0@2"
                 },
                 {
+                    "command": "extension.vsKubernetesCopy",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.cluster",
+                    "group": "1"
+                },
+                {
                     "command": "extension.vsKubernetesUseNamespace",
                     "group": "0",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.namespace.inactive"
+                },
+                {
+                    "command": "extension.vsKubernetesCopy",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.namespace.inactive",
+                    "group": "1"
+                },
+                {
+                    "command": "extension.vsKubernetesCopy",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.namespace",
+                    "group": "1"
                 },
                 {
                     "command": "extension.vsKubernetesGet",
@@ -172,18 +192,23 @@
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource"
                 },
                 {
+                    "command": "extension.vsKubernetesCopy",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource",
+                    "group": "1"
+                },
+                {
                     "command": "extension.vsKubernetesGet",
-                    "group": "1@1",
+                    "group": "2@1",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource"
                 },
                 {
                     "command": "extension.vsKubernetesDelete",
-                    "group": "1@2",
+                    "group": "2@2",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource"
                 },
                 {
                     "command": "extension.vsKubernetesDescribe",
-                    "group": "2",
+                    "group": "3",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource"
                 },
                 {
@@ -192,33 +217,38 @@
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
                 },
                 {
+                    "command": "extension.vsKubernetesCopy",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod",
+                    "group": "1"
+                },
+                {
                     "command": "extension.vsKubernetesGet",
-                    "group": "1@1",
+                    "group": "2@1",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
                 },
                 {
                     "command": "extension.vsKubernetesDelete",
-                    "group": "1@2",
+                    "group": "2@2",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
                 },
                 {
                     "command": "extension.vsKubernetesTerminal",
-                    "group": "1@3",
+                    "group": "2@3",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
                 },
                 {
                     "command": "extension.vsKubernetesDebugAttach",
-                    "group": "1@4",
+                    "group": "2@4",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
                 },
                 {
                     "command": "extension.vsKubernetesDescribe",
-                    "group": "2",
+                    "group": "3",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
                 },
                 {
                     "command": "extension.vsKubernetesLogs",
-                    "group": "2",
+                    "group": "3",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
                 }
             ],
@@ -241,6 +271,10 @@
                 },
                 {
                     "command": "extension.vsKubernetesUseNamespace",
+                    "when": "view == extension.vsKubernetesExplorer"
+                },
+                {
+                    "command": "extension.vsKubernetesCopy",
                     "when": "view == extension.vsKubernetesExplorer"
                 },
                 {
@@ -373,6 +407,11 @@
             {
                 "command": "extension.vsKubernetesDashboard",
                 "title": "Open Dashboard",
+                "category": "Kubernetes"
+            },
+            {
+                "command": "extension.vsKubernetesCopy",
+                "title": "Copy",
                 "category": "Kubernetes"
             },
             {
@@ -509,6 +548,8 @@
         "redhat.vscode-yaml"
     ],
     "dependencies": {
+        "@types/restify": "^5.0.7",
+        "clipboardy": "^1.2.3",
         "compare-versions": "^3.1.0",
         "docker-file-parser": "^1.0.3",
         "dockerfile-parse": "^0.2.0",
@@ -520,7 +561,6 @@
         "pluralize": "^4.0.0",
         "portfinder": "^1.0.13",
         "restify": "^6.3.4",
-        "@types/restify": "^5.0.7",
         "shelljs": "^0.7.7",
         "tmp": "^0.0.31",
         "uuid": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -411,7 +411,7 @@
             },
             {
                 "command": "extension.vsKubernetesCopy",
-                "title": "Copy",
+                "title": "Copy Name",
                 "category": "Kubernetes"
             },
             {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import * as yaml from 'js-yaml';
 import * as dockerfileParse from 'dockerfile-parse';
 import * as tmp from 'tmp';
 import * as uuid from 'uuid';
+import * as clipboard from 'clipboardy';
 
 // Internal dependencies
 import { host } from './host';
@@ -121,6 +122,7 @@ export async function activate(context) : Promise<extensionapi.ExtensionAPI> {
         registerCommand('extension.vsKubernetesDeleteContext', deleteContextKubernetes),
         registerCommand('extension.vsKubernetesUseNamespace', useNamespaceKubernetes),
         registerCommand('extension.vsKubernetesDashboard', dashboardKubernetes),
+        registerCommand('extension.vsKubernetesCopy', copyKubernetes),
 
         // Commands - Helm
         registerCommand('extension.helmVersion', helmexec.helmVersion),
@@ -1456,6 +1458,10 @@ async function useNamespaceKubernetes(explorerNode: explorer.KubernetesObject) {
     if (await kubectlUtils.switchNamespace(kubectl, explorerNode.id)) {
         refreshExplorer();
     }
+}
+
+function copyKubernetes(explorerNode: explorer.KubernetesObject) {
+    clipboard.writeSync(explorerNode.id);
 }
 
 async function execDraftVersion() {


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Add `Copy` menu on Kubernetes Explorer. It will copy the resource id to the system clipboard. These menus are only visible for Kubernetes Resource (cluster/namespace/node/deployment/job/pod/service/configMap/secret).