### PR TITLE
Automatically install missing kubectl, Helm and Draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,18 @@ This extension assumes that you have a `Dockerfile` in the root directory of
 your project.
 
 It also assumes that you have the following binaries on your `PATH`:
+
    * `kubectl`
    * `docker`
    * `git`
    * `helm` (optional)
    * `draft` (optional)
 
-If you don't have those on your PATH then the extension will fail in
-unexpected ways.
+For `kubectl`, `helm` and `draft` the binaries need not be on the system PATH, provided you tell the extension their locations using the appropriate `vs-kubernetes -> vs-kubernetes.${tool}-path` configuration setting.  See "Extension Settings" below.
 
-For setting up `kubectl` you have a couple of additional options:
+The extension can install `kubectl`, `helm` and `draft` for you if they are missing - choose **Install dependencies** when you see an error notification for the missing tool.  This will set `kubectl-path`, `helm-path` and `draft-path` entries in your configuration - the programs will *not* be installed on the system PATH, but this will be sufficient for them to work with the extension.
 
-   * If `kubectl` is not on your PATH then you can tell the extension its location using the `vs-kubernetes.kubectl-path` workspace setting. This should be the full file name and path of the kubectl binary.
-   * If you are using the extension to work with Azure Container Services or Azure Kubernetes Services then you can install and configure `kubectl` using the `Kubernetes: Add Existing Cluster` command.
+If you are working with Azure Container Services or Azure Kubernetes Services, then you can install and configure `kubectl` using the `Kubernetes: Add Existing Cluster` command.
 
 If you plan to create managed clusters using Microsoft Azure (ACS or AKS), or to add clusters in those environments to your kubeconfig, then you will need Azure CLI 2.0.23 or above.  You do not need Azure CLI if you do not use Azure, or to interact with Azure clusters that are already in your kubeconfig.
 
@@ -126,13 +125,14 @@ Where `<your-image-prefix-here>` is something like `docker.io/brendanburns`.
    * `vs-kubernetes` - Parent for Kubernetes-related extension settings
        * `vs-kubernetes.namespace` - The namespace to use for all commands
        * `vs-kubernetes.kubectl-path` - File path to the kubectl binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
-       * `vs-kubernetes.draft-path` - File path to the draft binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
+       * `vs-kubernetes.helm-path` - File path to the helm binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
+       * `vs-kubernetes.draft-path` - File path to the draft binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension (note current versions of Draft are not supported on Windows).
        * `vs-kubernetes.autoCleanupOnDebugTerminate` - The flag to control whether to auto cleanup the created deployment and associated pod by the command "Kubernetes: Debug (Launch)". The cleanup action occurs when it failed to start debug session or debug session terminated. If not specified, the extension will prompt for whether to clean up or not. You might choose not to clean up if you wanted to view pod logs, etc.
    * `vsdocker.imageUser` - Image prefix for docker images e.g. 'docker.io/brendanburns'
 
 ## Known Issues
 
-  * `Kubernetes: Debug` command currently works only with Node.js applications
+  * `Kubernetes: Debug` command currently works only with Node.js and Java applications
   * For deeply nested Helm charts, template previews are generated against highest (umbrella) chart values (though for `Helm: Template` calls you can pick your chart)
 
 ## Release Notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
                 "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
+                "fast-deep-equal": "1.1.0",
                 "fast-json-stable-stringify": "2.0.0",
                 "json-schema-traverse": "0.3.1"
             }
@@ -304,6 +304,11 @@
                 }
             }
         },
+        "base64-js": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+            "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+        },
         "bcrypt-pbkdf": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -319,6 +324,36 @@
             "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
             "dev": true
         },
+        "bl": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+            "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+            "requires": {
+                "readable-stream": "2.3.5",
+                "safe-buffer": "5.1.1"
+            },
+            "dependencies": {
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+                },
+                "readable-stream": {
+                    "version": "2.3.5",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+                    "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                    }
+                }
+            }
+        },
         "block-stream": {
             "version": "0.0.9",
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -333,7 +368,7 @@
             "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
             "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
             "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.2.1"
             }
         },
         "brace-expansion": {
@@ -362,11 +397,20 @@
             "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
             "dev": true
         },
+        "buffer": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+            "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
+            "requires": {
+                "base64-js": "0.0.8",
+                "ieee754": "1.1.11",
+                "isarray": "1.0.0"
+            }
+        },
         "buffer-crc32": {
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-            "dev": true
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
         },
         "builtin-modules": {
             "version": "1.1.1",
@@ -415,6 +459,17 @@
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
+        "caw": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
+            "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
+            "requires": {
+                "get-proxy": "2.1.0",
+                "isurl": "1.0.0",
+                "tunnel-agent": "0.6.0",
+                "url-to-options": "1.0.1"
+            }
+        },
         "chalk": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -435,6 +490,11 @@
                     "dev": true
                 }
             }
+        },
+        "chownr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+            "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
         },
         "class-utils": {
             "version": "0.3.6",
@@ -641,6 +701,20 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
+        "config-chain": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+            "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+            "requires": {
+                "ini": "1.3.5",
+                "proto-list": "1.2.4"
+            }
+        },
+        "content-disposition": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+            "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+        },
         "convert-source-map": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
@@ -692,7 +766,7 @@
                     "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
                     "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                     "requires": {
-                        "hoek": "4.2.0"
+                        "hoek": "4.2.1"
                     }
                 }
             }
@@ -753,6 +827,107 @@
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
             "dev": true
+        },
+        "decompress": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
+            "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+            "requires": {
+                "decompress-tar": "4.1.1",
+                "decompress-tarbz2": "4.1.1",
+                "decompress-targz": "4.1.1",
+                "decompress-unzip": "4.0.1",
+                "graceful-fs": "4.1.11",
+                "make-dir": "1.2.0",
+                "pify": "2.3.0",
+                "strip-dirs": "2.1.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                }
+            }
+        },
+        "decompress-response": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+            "requires": {
+                "mimic-response": "1.0.0"
+            }
+        },
+        "decompress-tar": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+            "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+            "requires": {
+                "file-type": "5.2.0",
+                "is-stream": "1.1.0",
+                "tar-stream": "1.5.5"
+            }
+        },
+        "decompress-tarbz2": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+            "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+            "requires": {
+                "decompress-tar": "4.1.1",
+                "file-type": "6.2.0",
+                "is-stream": "1.1.0",
+                "seek-bzip": "1.0.5",
+                "unbzip2-stream": "1.2.5"
+            },
+            "dependencies": {
+                "file-type": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+                    "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
+                }
+            }
+        },
+        "decompress-targz": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+            "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+            "requires": {
+                "decompress-tar": "4.1.1",
+                "file-type": "5.2.0",
+                "is-stream": "1.1.0"
+            }
+        },
+        "decompress-unzip": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+            "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+            "requires": {
+                "file-type": "3.9.0",
+                "get-stream": "2.3.1",
+                "pify": "2.3.0",
+                "yauzl": "2.9.1"
+            },
+            "dependencies": {
+                "file-type": {
+                    "version": "3.9.0",
+                    "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+                    "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+                },
+                "get-stream": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+                    "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+                    "requires": {
+                        "object-assign": "4.1.1",
+                        "pinkie-promise": "2.0.1"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                }
+            }
         },
         "deep-assign": {
             "version": "1.0.0",
@@ -827,6 +1002,24 @@
             "resolved": "https://registry.npmjs.org/dockerfile-parse/-/dockerfile-parse-0.2.0.tgz",
             "integrity": "sha1-59F8EK04xqBQ4k+7ToiVBcGSdvo="
         },
+        "download": {
+            "version": "6.2.5",
+            "resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",
+            "integrity": "sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA==",
+            "requires": {
+                "caw": "2.0.1",
+                "content-disposition": "0.5.2",
+                "decompress": "4.2.0",
+                "ext-name": "5.0.0",
+                "file-type": "5.2.0",
+                "filenamify": "2.0.0",
+                "get-stream": "3.0.0",
+                "got": "7.1.0",
+                "make-dir": "1.2.0",
+                "p-event": "1.3.0",
+                "pify": "3.0.0"
+            }
+        },
         "dtrace-provider": {
             "version": "0.8.6",
             "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.6.tgz",
@@ -877,6 +1070,11 @@
                 }
             }
         },
+        "duplexer3": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+        },
         "duplexify": {
             "version": "3.5.1",
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
@@ -902,7 +1100,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
             "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-            "dev": true,
             "requires": {
                 "once": "1.4.0"
             }
@@ -915,8 +1112,7 @@
         "escape-string-regexp": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-            "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
-            "dev": true
+            "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
         },
         "esprima": {
             "version": "4.0.0",
@@ -993,6 +1189,23 @@
                 "homedir-polyfill": "1.0.1"
             }
         },
+        "ext-list": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+            "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+            "requires": {
+                "mime-db": "1.30.0"
+            }
+        },
+        "ext-name": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
+            "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+            "requires": {
+                "ext-list": "2.2.2",
+                "sort-keys-length": "1.0.1"
+            }
+        },
         "extend": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
@@ -1041,9 +1254,9 @@
             }
         },
         "fast-deep-equal": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-            "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
         },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
@@ -1054,16 +1267,35 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-            "dev": true,
             "requires": {
                 "pend": "1.2.0"
             }
+        },
+        "file-type": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+            "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
         },
         "filename-regex": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
             "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
             "dev": true
+        },
+        "filename-reserved-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+            "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
+        },
+        "filenamify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.0.0.tgz",
+            "integrity": "sha1-vRYiYsC26Uv7zc8Zo7uzdk94VpU=",
+            "requires": {
+                "filename-reserved-regex": "2.0.0",
+                "strip-outer": "1.0.1",
+                "trim-repeated": "1.0.0"
+            }
         },
         "fill-range": {
             "version": "2.2.3",
@@ -1130,13 +1362,23 @@
             "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-            "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "requires": {
                 "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
+                "combined-stream": "1.0.6",
                 "mime-types": "2.1.17"
+            },
+            "dependencies": {
+                "combined-stream": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+                    "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+                    "requires": {
+                        "delayed-stream": "1.0.0"
+                    }
+                }
             }
         },
         "formidable": {
@@ -1158,6 +1400,14 @@
             "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
             "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
             "dev": true
+        },
+        "fs-minipass": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+            "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+            "requires": {
+                "minipass": "2.2.4"
+            }
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -1203,6 +1453,14 @@
             "dev": true,
             "requires": {
                 "is-property": "1.0.2"
+            }
+        },
+        "get-proxy": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
+            "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
+            "requires": {
+                "npm-conf": "1.1.3"
             }
         },
         "get-stream": {
@@ -1451,11 +1709,36 @@
                 "sparkles": "1.0.0"
             }
         },
+        "got": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+            "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+            "requires": {
+                "decompress-response": "3.3.0",
+                "duplexer3": "0.1.4",
+                "get-stream": "3.0.0",
+                "is-plain-obj": "1.1.0",
+                "is-retry-allowed": "1.1.0",
+                "is-stream": "1.1.0",
+                "isurl": "1.0.0",
+                "lowercase-keys": "1.0.1",
+                "p-cancelable": "0.3.0",
+                "p-timeout": "1.2.1",
+                "safe-buffer": "5.1.1",
+                "timed-out": "4.0.1",
+                "url-parse-lax": "1.0.0",
+                "url-to-options": "1.0.1"
+            }
+        },
         "graceful-fs": {
             "version": "4.1.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-            "dev": true
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+        },
+        "graceful-readlink": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
         },
         "growl": {
             "version": "1.9.2",
@@ -1947,6 +2230,19 @@
                 "streamifier": "0.1.1",
                 "tar": "2.2.1",
                 "through2": "2.0.3"
+            },
+            "dependencies": {
+                "tar": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                    "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+                    "dev": true,
+                    "requires": {
+                        "block-stream": "0.0.9",
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3"
+                    }
+                }
             }
         },
         "gulp-util": {
@@ -2116,6 +2412,19 @@
                 "sparkles": "1.0.0"
             }
         },
+        "has-symbol-support-x": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+            "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+        },
+        "has-to-string-tag-x": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+            "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+            "requires": {
+                "has-symbol-support-x": "1.4.2"
+            }
+        },
         "has-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -2183,7 +2492,7 @@
             "requires": {
                 "boom": "4.3.1",
                 "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
+                "hoek": "4.2.1",
                 "sntp": "2.1.0"
             }
         },
@@ -2194,9 +2503,9 @@
             "dev": true
         },
         "hoek": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-            "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+            "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
         },
         "homedir-polyfill": {
             "version": "1.0.1",
@@ -2233,6 +2542,11 @@
                 "sshpk": "1.13.1"
             }
         },
+        "ieee754": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
+            "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
+        },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2250,8 +2564,7 @@
         "ini": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-            "dev": true
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "interpret": {
             "version": "1.1.0",
@@ -2381,6 +2694,11 @@
                 "xtend": "4.0.1"
             }
         },
+        "is-natural-number": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+            "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
+        },
         "is-number": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -2406,6 +2724,11 @@
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
             "dev": true
+        },
+        "is-object": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+            "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
         },
         "is-odd": {
             "version": "1.0.0",
@@ -2435,6 +2758,11 @@
                     }
                 }
             }
+        },
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -2484,6 +2812,11 @@
             "requires": {
                 "is-unc-path": "1.0.0"
             }
+        },
+        "is-retry-allowed": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
         },
         "is-stream": {
             "version": "1.1.0",
@@ -2555,6 +2888,15 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+        },
+        "isurl": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+            "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+            "requires": {
+                "has-to-string-tag-x": "1.4.1",
+                "is-object": "1.0.1"
+            }
         },
         "jade": {
             "version": "0.26.3",
@@ -2654,7 +2996,7 @@
             "integrity": "sha1-9bK6GA8A7YwqNg8wwnQIM3NCx28=",
             "requires": {
                 "js-yaml": "3.10.0",
-                "request": "2.83.0",
+                "request": "2.85.0",
                 "rx": "4.1.0",
                 "underscore": "1.8.3"
             }
@@ -3069,11 +3411,24 @@
                 "lodash.escape": "3.2.0"
             }
         },
+        "lowercase-keys": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+        },
         "lru-cache": {
             "version": "2.7.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
             "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
             "dev": true
+        },
+        "make-dir": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
+            "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+            "requires": {
+                "pify": "3.0.0"
+            }
         },
         "make-iterator": {
             "version": "1.0.0",
@@ -3199,6 +3554,11 @@
                 "mime-db": "1.30.0"
             }
         },
+        "mimic-response": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
+            "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
+        },
         "minimalistic-assert": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
@@ -3216,6 +3576,30 @@
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        },
+        "minipass": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
+            "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+            "requires": {
+                "safe-buffer": "5.1.1",
+                "yallist": "3.0.2"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+                    "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+                }
+            }
+        },
+        "minizlib": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
+            "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
+            "requires": {
+                "minipass": "2.2.4"
+            }
         },
         "mixin-deep": {
             "version": "1.3.0",
@@ -3446,6 +3830,15 @@
                 "remove-trailing-separator": "1.1.0"
             }
         },
+        "npm-conf": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
+            "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+            "requires": {
+                "config-chain": "1.1.11",
+                "pify": "3.0.0"
+            }
+        },
         "npm-run-path": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -3462,8 +3855,7 @@
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-copy": {
             "version": "0.1.0",
@@ -3706,10 +4098,31 @@
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
+        "p-cancelable": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+            "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+        },
+        "p-event": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/p-event/-/p-event-1.3.0.tgz",
+            "integrity": "sha1-jmtPT2XHK8W2/ii3XtqHT5akoIU=",
+            "requires": {
+                "p-timeout": "1.2.1"
+            }
+        },
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
             "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        },
+        "p-timeout": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
+            "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
+            "requires": {
+                "p-finally": "1.0.0"
+            }
         },
         "parse-filepath": {
             "version": "1.0.2",
@@ -3811,8 +4224,7 @@
         "pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-            "dev": true
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
         },
         "performance-now": {
             "version": "2.1.0",
@@ -3824,17 +4236,20 @@
             "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-1.2.0.tgz",
             "integrity": "sha512-OGo+iSOk44HRJ8q15AyG570UYxcm5u+R99DI8Khu8P3tKGkVu5EZX4ywHglWSTMNNXQ274oeGpYrvFEhDIFGPg=="
         },
+        "pify": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
         "pinkie": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
         },
         "pinkie-promise": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
             "requires": {
                 "pinkie": "2.0.4"
             }
@@ -3873,6 +4288,11 @@
             "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
             "dev": true
         },
+        "prepend-http": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+        },
         "preserve": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -3889,6 +4309,11 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
         },
         "pseudomap": {
             "version": "1.0.2",
@@ -4037,9 +4462,9 @@
             "dev": true
         },
         "request": {
-            "version": "2.83.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+            "version": "2.85.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+            "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
             "requires": {
                 "aws-sign2": "0.7.0",
                 "aws4": "1.6.0",
@@ -4047,7 +4472,7 @@
                 "combined-stream": "1.0.5",
                 "extend": "3.0.1",
                 "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
+                "form-data": "2.3.2",
                 "har-validator": "5.0.3",
                 "hawk": "6.0.2",
                 "http-signature": "1.2.0",
@@ -4170,6 +4595,24 @@
             "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz",
             "integrity": "sha1-gaCY9Efku8P/MxKiQ1IbwGDvWRE=",
             "optional": true
+        },
+        "seek-bzip": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+            "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+            "requires": {
+                "commander": "2.8.1"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                    "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+                    "requires": {
+                        "graceful-readlink": "1.0.1"
+                    }
+                }
+            }
         },
         "select-hose": {
             "version": "2.0.0",
@@ -4396,7 +4839,23 @@
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
             "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
             "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.2.1"
+            }
+        },
+        "sort-keys": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+            "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+            "requires": {
+                "is-plain-obj": "1.1.0"
+            }
+        },
+        "sort-keys-length": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+            "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
+            "requires": {
+                "sort-keys": "1.1.2"
             }
         },
         "source-map": {
@@ -4721,10 +5180,26 @@
                 "strip-bom": "2.0.0"
             }
         },
+        "strip-dirs": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+            "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+            "requires": {
+                "is-natural-number": "4.0.1"
+            }
+        },
         "strip-eof": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+        },
+        "strip-outer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+            "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+            "requires": {
+                "escape-string-regexp": "1.0.2"
+            }
         },
         "supports-color": {
             "version": "1.2.0",
@@ -4733,21 +5208,41 @@
             "dev": true
         },
         "tar": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-            "dev": true,
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+            "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "chownr": "1.0.1",
+                "fs-minipass": "1.2.5",
+                "minipass": "2.2.4",
+                "minizlib": "1.1.0",
+                "mkdirp": "0.5.1",
+                "safe-buffer": "5.1.1",
+                "yallist": "3.0.2"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+                    "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+                }
+            }
+        },
+        "tar-stream": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+            "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+            "requires": {
+                "bl": "1.2.2",
+                "end-of-stream": "1.4.0",
+                "readable-stream": "2.3.3",
+                "xtend": "4.0.1"
             }
         },
         "through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-            "dev": true
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "through2": {
             "version": "2.0.3",
@@ -4783,6 +5278,11 @@
             "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
             "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
             "dev": true
+        },
+        "timed-out": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
         "tmp": {
             "version": "0.0.31",
@@ -4964,6 +5464,14 @@
                 "punycode": "1.4.1"
             }
         },
+        "trim-repeated": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+            "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+            "requires": {
+                "escape-string-regexp": "1.0.2"
+            }
+        },
         "tslib": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
@@ -5067,6 +5575,15 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
             "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
             "dev": true
+        },
+        "unbzip2-stream": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
+            "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
+            "requires": {
+                "buffer": "3.6.0",
+                "through": "2.3.8"
+            }
         },
         "unc-path-regex": {
             "version": "0.1.2",
@@ -5191,6 +5708,19 @@
                 "querystringify": "1.0.0",
                 "requires-port": "1.0.0"
             }
+        },
+        "url-parse-lax": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+            "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+            "requires": {
+                "prepend-http": "1.0.4"
+            }
+        },
+        "url-to-options": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+            "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
         },
         "use": {
             "version": "2.0.2",
@@ -5426,7 +5956,7 @@
                 "gulp-untar": "0.0.6",
                 "gulp-vinyl-zip": "2.1.0",
                 "mocha": "4.1.0",
-                "request": "2.83.0",
+                "request": "2.85.0",
                 "semver": "5.4.1",
                 "source-map-support": "0.5.0",
                 "url-parse": "1.2.0",
@@ -5557,8 +6087,7 @@
         "xtend": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-            "dev": true
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         },
         "yallist": {
             "version": "2.1.2",
@@ -5578,7 +6107,6 @@
             "version": "2.9.1",
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
             "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
-            "dev": true,
             "requires": {
                 "buffer-crc32": "0.2.13",
                 "fd-slicer": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -79,6 +79,10 @@
                             "type": "string",
                             "description": "File path to a kubectl binary."
                         },
+                        "vs-kubernetes.helm-path": {
+                            "type": "string",
+                            "description": "File path to a helm binary."
+                        },
                         "vs-kubernetes.draft-path": {
                             "type": "string",
                             "description": "File path to a draft binary."
@@ -91,6 +95,7 @@
                     "default": {
                         "vs-kubernetes.namespace": "",
                         "vs-kubernetes.kubectl-path": "",
+                        "vs-kubernetes.helm-path": "",
                         "vs-kubernetes.draft-path": "",
                         "vs-kubernetes.autoCleanupOnDebugTerminate": false
                     }
@@ -665,10 +670,12 @@
         "compare-versions": "^3.1.0",
         "docker-file-parser": "^1.0.3",
         "dockerfile-parse": "^0.2.0",
+        "download": "^6.2.5",
         "fuzzysearch": "^1.0.3",
         "js-yaml": "^3.8.2",
         "k8s": "^0.4.12",
         "lodash": ">3",
+        "mkdirp": "^0.5.1",
         "natives": "^1.1.3",
         "node-yaml-parser": "^0.0.9",
         "opn": "^5.2.0",
@@ -676,6 +683,7 @@
         "portfinder": "^1.0.13",
         "restify": "^6.3.4",
         "shelljs": "^0.7.7",
+        "tar": "^4.4.1",
         "tmp": "^0.0.31",
         "uuid": "^3.1.0",
         "vscode-debugadapter": "1.27.0",

--- a/src/components/installer/installer.ts
+++ b/src/components/installer/installer.ts
@@ -1,0 +1,177 @@
+'use strict';
+
+import * as download from 'download';
+import * as fs from 'fs';
+import mkdirp = require('mkdirp');
+import * as path from 'path';
+import * as tar from 'tar';
+import * as tmp from 'tmp';
+import * as vscode from 'vscode';
+import { Shell, Platform } from '../../shell';
+import { Errorable } from '../../wizard';
+import { exec } from 'child_process';
+
+export async function installKubectl(shell: Shell) : Promise<Errorable<void>> {
+    const tool = 'kubectl';
+    const binFile = (shell.isUnix()) ? 'kubectl' : 'kubectl.exe';
+    const os = platformUrlString(shell.platform());
+
+    const version = await getStableKubectlVersion();
+    if (!version.succeeded) {
+        return { succeeded: false, result: null, error: version.error };
+    }
+
+    const installFolder = getInstallFolder(shell, tool);
+    mkdirp.sync(installFolder);
+    
+    const kubectlUrl = `https://storage.googleapis.com/kubernetes-release/release/${version.result.trim()}/bin/${os}/amd64/${binFile}`;
+    const downloadFile = path.join(installFolder, binFile);
+    const downloadResult = await downloadTo(kubectlUrl, downloadFile);
+    if (!downloadResult.succeeded) {
+        return { succeeded: false, result: null, error: [`Failed to download kubectl: ${downloadResult.error[0]}`] };
+    }
+
+    if (shell.isUnix()) {
+        fs.chmodSync(downloadFile, '0777');
+    }
+
+    await addPathToConfig(`vs-kubernetes.${tool}-path`, downloadFile);
+    return { succeeded: true, result: null, error: [] };
+}
+
+async function getStableKubectlVersion() : Promise<Errorable<string>> {
+    const downloadResult = await downloadToTempFile('https://storage.googleapis.com/kubernetes-release/release/stable.txt');
+    if (!downloadResult.succeeded) {
+        return { succeeded: false, result: '', error: [`Failed to establish kubectl stable version: ${downloadResult.error[0]}`] };
+    }
+    const version = fs.readFileSync(downloadResult.result, 'utf-8');
+    fs.unlinkSync(downloadResult.result);
+    return { succeeded: true, result: version, error: [] };
+}
+
+export async function installHelm(shell: Shell) : Promise<Errorable<void>> {
+    const tool = 'helm';
+    const urlTemplate = 'https://storage.googleapis.com/kubernetes-helm/helm-v2.8.2-{os_placeholder}-amd64.tar.gz';
+    return await installToolFromTar(tool, urlTemplate, shell);
+}
+
+export async function installDraft(shell: Shell) : Promise<Errorable<void>> {
+    const tool = 'draft';
+    const urlTemplate = 'https://azuredraft.blob.core.windows.net/draft/draft-v0.13.0-{os_placeholder}-amd64.tar.gz';
+    return await installToolFromTar(tool, urlTemplate, shell, [Platform.MacOS, Platform.Linux]);
+}
+
+async function installToolFromTar(tool: string, urlTemplate: string, shell: Shell, supported?: Platform[]) : Promise<Errorable<void>> {
+    const os = platformUrlString(shell.platform(), supported);
+    if (!os) {
+        return { succeeded: false, result: null, error: ['Not supported on this OS'] };
+    }
+    const installFolder = getInstallFolder(shell, tool);
+    const executable = formatBin(tool, shell.platform());
+    const url = urlTemplate.replace('{os_placeholder}', os);
+    const configKey = `vs-kubernetes.${tool}-path`;
+    return installFromTar(url, installFolder, executable, configKey);
+}
+
+function getInstallFolder(shell: Shell, tool: string) : string {
+    return path.join(shell.home(), `.vs-kubernetes/tools/${tool}`);
+}
+
+function platformUrlString(platform: Platform, supported?: Platform[]) : string | null {
+    if (supported && supported.indexOf(platform) < 0) {
+        return null;
+    }
+    switch (platform) {
+        case Platform.Windows: return 'windows';
+        case Platform.MacOS: return 'darwin';
+        case Platform.Linux: return 'linux';
+        default: return null;
+    }
+}
+
+function formatBin(tool: string, platform: Platform) : string | null {
+    const platformString = platformUrlString(platform);
+    if (!platformString) {
+        return null;
+    }
+    const toolPath = `${platformString}-amd64/${tool}`;
+    if (platform === Platform.Windows) {
+        return toolPath + '.exe';
+    }
+    return toolPath;
+}
+
+async function installFromTar(sourceUrl: string, destinationFolder: string, executablePath: string, configKey: string) : Promise<Errorable<void>> {
+    // download it
+    const downloadResult = await downloadToTempFile(sourceUrl);
+    if (!downloadResult.succeeded) {
+        return { succeeded: false, result: null, error: ['Failed to download Helm: error was ' + downloadResult.error[0]] };
+    }
+    const tarfile = downloadResult.result;
+
+    // untar it
+    const untarResult = await untar(tarfile, destinationFolder);
+    if (!untarResult.succeeded) {
+        return { succeeded: false, result: null, error: ['Failed to unpack Helm: error was ' + downloadResult.error[0]] };
+    }
+
+    // add path to config
+    const executableFullPath = path.join(destinationFolder, executablePath);
+    await addPathToConfig(configKey, executableFullPath);
+
+    await fs.unlink(tarfile);
+
+    return { succeeded: true, result: null, error: [] };
+}
+
+async function downloadToTempFile(sourceUrl: string) : Promise<Errorable<string>> {
+    const tempFileObj = tmp.fileSync({ prefix: "vsk-autoinstall-" });
+    const downloadResult = await downloadTo(sourceUrl, tempFileObj.name);
+    return { succeeded: downloadResult.succeeded, result: tempFileObj.name, error: downloadResult.error };
+}
+
+async function downloadTo(sourceUrl: string, destinationFile: string) : Promise<Errorable<void>> {
+    try {
+        const buffer = await download(sourceUrl, path.dirname(destinationFile), { filename: path.basename(destinationFile) });
+        return { succeeded: true, result: null, error: [] };
+    } catch (e) {
+        return { succeeded: false, result: null, error: [e.message] };
+    }
+}
+
+async function untar(sourceFile: string, destinationFolder: string) : Promise<Errorable<void>> {
+    try {
+        if (!fs.existsSync(destinationFolder)) {
+            mkdirp.sync(destinationFolder);
+        }
+        await tar.x({
+            cwd: destinationFolder,
+            file: sourceFile
+        });
+        return { succeeded: true, result: null, error: [] };
+    } catch (e) {
+        return { succeeded: false, result: null, error: [ e.somethingtba ] };
+    }
+}
+
+async function addPathToConfig(configKey: string, executableFullPath: string) : Promise<void> {
+    const config = vscode.workspace.getConfiguration().inspect("vs-kubernetes");
+    await addPathToConfigAtScope(configKey, executableFullPath, vscode.ConfigurationTarget.Global, config.globalValue, true);
+    await addPathToConfigAtScope(configKey, executableFullPath, vscode.ConfigurationTarget.Workspace, config.workspaceValue, false);
+    await addPathToConfigAtScope(configKey, executableFullPath, vscode.ConfigurationTarget.WorkspaceFolder, config.workspaceFolderValue, false);
+}
+
+async function addPathToConfigAtScope(configKey: string, value: string, scope: vscode.ConfigurationTarget, valueAtScope: any, createIfNotExist: boolean) : Promise<void> {
+    if (!createIfNotExist) {
+        if (!valueAtScope || !(valueAtScope[configKey])) {
+            return;
+        }
+    }
+
+    let newValue : any = {};
+    if (valueAtScope) {
+        newValue = Object.assign({}, valueAtScope);
+    }
+    newValue[configKey] = value;
+    await vscode.workspace.getConfiguration().update("vs-kubernetes", newValue, scope);
+}

--- a/src/components/installer/installer.ts
+++ b/src/components/installer/installer.ts
@@ -57,8 +57,8 @@ export async function installHelm(shell: Shell) : Promise<Errorable<void>> {
 
 export async function installDraft(shell: Shell) : Promise<Errorable<void>> {
     const tool = 'draft';
-    const urlTemplate = 'https://azuredraft.blob.core.windows.net/draft/draft-v0.13.0-{os_placeholder}-amd64.tar.gz';
-    return await installToolFromTar(tool, urlTemplate, shell, [Platform.MacOS, Platform.Linux]);
+    const urlTemplate = 'https://azuredraft.blob.core.windows.net/draft/draft-v0.14.0-{os_placeholder}-amd64.tar.gz';
+    return await installToolFromTar(tool, urlTemplate, shell);
 }
 
 async function installToolFromTar(tool: string, urlTemplate: string, shell: Shell, supported?: Platform[]) : Promise<Errorable<void>> {

--- a/src/components/kubectl/dashboard.ts
+++ b/src/components/kubectl/dashboard.ts
@@ -10,13 +10,14 @@ import { portForwardToPod, PortMapping, buildPortMapping } from './port-forward'
 import { host } from '../../host';
 import { shell } from '../../shell';
 import { create as kubectlCreate, Kubectl } from '../../kubectl';
+import { installDependencies } from '../../extension';
 
 
 const KUBE_DASHBOARD_URL = "http://localhost:8001/ui/";
 const TERMINAL_NAME = "Kubernetes Dashboard";
 const PROXY_OUTPUT_FILE = resolve(__dirname, 'proxy.out');
 
-const kubectl = kubectlCreate(host, fs, shell);
+const kubectl = kubectlCreate(host, fs, shell, installDependencies);
 
 // The instance of the terminal running Kubectl Dashboard
 let terminal:vscode.Terminal;

--- a/src/components/kubectl/port-forward.ts
+++ b/src/components/kubectl/port-forward.ts
@@ -5,11 +5,11 @@ import { create as kubectlCreate, Kubectl } from '../../kubectl';
 import { fs } from '../../fs';
 import { shell } from '../../shell';
 import { host } from '../../host';
-import { findAllPods, tryFindKindNameFromEditor, FindPodsResult } from '../../extension';
+import { findAllPods, tryFindKindNameFromEditor, FindPodsResult, installDependencies } from '../../extension';
 import { QuickPickOptions } from 'vscode';
 import * as portFinder from 'portfinder';
 
-const kubectl = kubectlCreate(host, fs, shell);
+const kubectl = kubectlCreate(host, fs, shell, installDependencies);
 const PORT_FORWARD_TERMINAL = 'kubectl port-forward';
 const MAX_PORT_COUNT = 65535;
 

--- a/src/draft/draft.ts
+++ b/src/draft/draft.ts
@@ -5,34 +5,40 @@ import * as syspath from 'path';
 import * as binutil from '../binutil';
 
 export interface Draft {
-    checkPresent() : Promise<boolean>;
+    checkPresent(mode: CheckPresentMode) : Promise<boolean>;
     isFolderMapped(path: string) : boolean;
     packs() : Promise<string[] | undefined>;
     invoke(args: string) : Promise<ShellResult>;
     path() : Promise<string | undefined>;
 }
 
-export function create(host : Host, fs : FS, shell : Shell) : Draft {
-    return new DraftImpl(host, fs, shell, false);
+export function create(host : Host, fs : FS, shell : Shell, installDependenciesCallback: () => void) : Draft {
+    return new DraftImpl(host, fs, shell, installDependenciesCallback, false);
+}
+
+export enum CheckPresentMode {
+    Alert,
+    Silent,
 }
 
 interface Context {
     readonly host : Host;
     readonly fs : FS;
     readonly shell : Shell;
+    readonly installDependenciesCallback : () => void;
     binFound : boolean;
     binPath : string;
 }
 
 class DraftImpl implements Draft {
-    constructor(host : Host, fs : FS, shell : Shell, draftFound : boolean) {
-        this.context = { host : host, fs : fs, shell : shell, binFound : draftFound, binPath : 'draft' };
+    constructor(host : Host, fs : FS, shell : Shell, installDependenciesCallback : () => void, draftFound : boolean) {
+        this.context = { host : host, fs : fs, shell : shell, installDependenciesCallback : installDependenciesCallback, binFound : draftFound, binPath : 'draft' };
     }
 
     private readonly context : Context;
 
-    checkPresent() : Promise<boolean> {
-        return checkPresent(this.context);
+    checkPresent(mode: CheckPresentMode) : Promise<boolean> {
+        return checkPresent(this.context, mode);
     }
 
     isFolderMapped(path: string) : boolean {
@@ -52,17 +58,17 @@ class DraftImpl implements Draft {
     }
 }
 
-async function checkPresent(context : Context) : Promise<boolean> {
+async function checkPresent(context : Context, mode: CheckPresentMode) : Promise<boolean> {
     if (context.binFound) {
         return true;
     }
 
-    return await checkForDraftInternal(context);
+    return await checkForDraftInternal(context, mode);
 }
 
 async function packs(context : Context) : Promise<string[] | undefined> {
-    if (await checkPresent(context)) {
-        const dhResult = await context.shell.exec("draft home");
+    if (await checkPresent(context, CheckPresentMode.Alert)) {
+        const dhResult = await context.shell.exec(context.binPath + " home");
         if (dhResult.code === 0) {
             const draftHome = dhResult.stdout.trim();
             const draftPacksDir = syspath.join(draftHome, 'packs');
@@ -75,7 +81,7 @@ async function packs(context : Context) : Promise<string[] | undefined> {
 }
 
 async function invoke(context : Context, args : string) : Promise<ShellResult> {
-    if (await checkPresent(context)) {
+    if (await checkPresent(context, CheckPresentMode.Alert)) {
         const result = context.shell.exec(context.binPath + ' ' + args);
         return result;
     }
@@ -87,20 +93,19 @@ async function path(context : Context) : Promise<string | undefined> {
 }
 
 async function pathCore(context : Context) : Promise<string | undefined> {
-    if (await checkPresent(context)) {
+    if (await checkPresent(context, CheckPresentMode.Alert)) {
         return context.binPath;
     }
     return undefined;
 }
 
-async function checkForDraftInternal(context : Context) : Promise<boolean> {
+async function checkForDraftInternal(context : Context, mode: CheckPresentMode) : Promise<boolean> {
     const binName = 'draft';
     const bin = context.host.getConfiguration('vs-kubernetes')[`vs-kubernetes.${binName}-path`];
 
     const inferFailedMessage = 'Could not find "draft" binary.';
     const configuredFileMissingMessage = bin + ' does not exist!';
-
-    return binutil.checkForBinary(context, bin, binName, inferFailedMessage, configuredFileMissingMessage);
+    return binutil.checkForBinary(context, bin, binName, inferFailedMessage, configuredFileMissingMessage, mode === CheckPresentMode.Alert);
 }
 
 function isFolderMapped(context: Context, path: string) : boolean {

--- a/src/draft/draftRuntime.ts
+++ b/src/draft/draftRuntime.ts
@@ -7,10 +7,11 @@ import { Readable } from 'stream';
 import { host } from '../host';
 import { shell } from '../shell';
 import { fs } from '../fs';
-import { create as draftCreate } from './draft';
+import { create as draftCreate, CheckPresentMode } from './draft';
+import { installDependencies } from '../extension';
 
 export class DraftRuntime extends EventEmitter {
-	private _draft = draftCreate(host, fs, shell);
+	private _draft = draftCreate(host, fs, shell, installDependencies);
 	private _connectProccess: ChildProcess;
 
 	constructor() {
@@ -26,7 +27,7 @@ export class DraftRuntime extends EventEmitter {
 		let output = vscode.window.createOutputChannel("draft");
 		output.show();
 
-		let isPresent = await this._draft.checkPresent();
+		let isPresent = await this._draft.checkPresent(CheckPresentMode.Alert);
 		if (!isPresent) {
 			host.showInformationMessage("Draft is not installed!");
 			return;

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -3,9 +3,17 @@
 import * as vscode from 'vscode';
 import * as shelljs from 'shelljs';
 
+export enum Platform {
+    Windows,
+    MacOS,
+    Linux,
+    Unsupported,  // shouldn't happen!
+}
+
 export interface Shell {
     isWindows() : boolean;
     isUnix() : boolean;
+    platform() : Platform;
     home() : string;
     combinePath(basePath : string, relativePath : string);
     fileUri(filePath) : vscode.Uri;
@@ -17,6 +25,7 @@ export interface Shell {
 export const shell : Shell = {
     isWindows : isWindows,
     isUnix : isUnix,
+    platform : platform,
     home : home,
     combinePath : combinePath,
     fileUri : fileUri,
@@ -41,6 +50,15 @@ function isWindows() : boolean {
 
 function isUnix() : boolean {
     return !isWindows();
+}
+
+function platform() : Platform {
+    switch (process.platform) {
+        case 'win32': return Platform.Windows;
+        case 'darwin': return Platform.MacOS;
+        case 'linux': return Platform.Linux;
+        default: return Platform.Unsupported;
+    }
 }
 
 function home() : string {

--- a/test/draft.test.ts
+++ b/test/draft.test.ts
@@ -7,7 +7,7 @@ import * as fakes from './fakes';
 import { Host } from '../src/host';
 import { Shell, ShellResult } from '../src/shell';
 import { FS } from '../src/fs';
-import { create as draftCreate } from '../src/draft/draft';
+import { create as draftCreate, CheckPresentMode as DraftCheckPresentMode } from '../src/draft/draft';
 import * as kuberesources from '../src/kuberesources';
 
 interface FakeContext {
@@ -20,7 +20,8 @@ function draftCreateWithFakes(ctx : FakeContext) {
     return draftCreate(
         ctx.host || fakes.host(),
         ctx.fs || fakes.fs(),
-        ctx.shell || fakes.shell()
+        ctx.shell || fakes.shell(),
+        () => {}
     );
 }
 
@@ -41,7 +42,7 @@ suite("draft tests", () => {
                 const draft = draftCreateWithFakes({
                     host: fakes.host({errors: errors})
                 });
-                const present = await draft.checkPresent();
+                const present = await draft.checkPresent(DraftCheckPresentMode.Alert);
                 assert.equal(false, present);
                 assert.equal(errors.length, 1);
                 textassert.startsWith('Could not find "draft" binary.', errors[0]);
@@ -52,10 +53,20 @@ suite("draft tests", () => {
                 const draft = draftCreateWithFakes({
                     host: fakes.host({errors: errors, configuration: draftFakePathConfig()})
                 });
-                const present = await draft.checkPresent();
+                const present = await draft.checkPresent(DraftCheckPresentMode.Alert);
                 assert.equal(false, present);
                 assert.equal(errors.length, 1);
                 textassert.startsWith('c:\\fake\\draft\\draft.exe does not exist!', errors[0]);
+            });
+
+            test("...and in silent mode, then no errors are reported", async () => {
+                let errors : string[] = [];
+                const draft = draftCreateWithFakes({
+                    host: fakes.host({errors: errors})
+                });
+                const present = await draft.checkPresent(DraftCheckPresentMode.Silent);
+                assert.equal(false, present);
+                assert.equal(errors.length, 0);
             });
 
             test("...and configuration is present and file exists, then checkPresent does not report any messages", async () => {
@@ -66,7 +77,7 @@ suite("draft tests", () => {
                     host: fakes.host({errors: errors, warnings: warnings, infos: infos, configuration: draftFakePathConfig()}),
                     fs: fakes.fs({existentPaths: [draftFakePath]})
                 });
-                await draft.checkPresent();
+                await draft.checkPresent(DraftCheckPresentMode.Alert);
                 assert.equal(errors.length, 0);
                 assert.equal(warnings.length, 0);
                 assert.equal(infos.length, 0);
@@ -77,7 +88,7 @@ suite("draft tests", () => {
                     host: fakes.host({configuration: draftFakePathConfig()}),
                     fs: fakes.fs({existentPaths: [draftFakePath]})
                 });
-                const present = await draft.checkPresent();
+                const present = await draft.checkPresent(DraftCheckPresentMode.Alert);
                 assert.equal(true, present);
             });
 
@@ -93,7 +104,7 @@ suite("draft tests", () => {
                     host: fakes.host({errors: errors, warnings: warnings, infos: infos}),
                     shell: fakes.shell({recognisedCommands: [{command: 'where.exe draft.exe', code: 0, stdout: 'c:\\draft.exe'}]})
                 });
-                await draft.checkPresent();
+                await draft.checkPresent(DraftCheckPresentMode.Alert);
                 assert.equal(errors.length, 0);
                 assert.equal(warnings.length, 0);
                 assert.equal(infos.length, 0);
@@ -107,7 +118,7 @@ suite("draft tests", () => {
                     host: fakes.host({errors: errors, warnings: warnings, infos: infos}),
                     shell: fakes.shell({isWindows: false, isUnix: true, recognisedCommands: [{command: 'which draft', code: 0, stdout: '/usr/bin/draft'}]})
                 });
-                await draft.checkPresent();
+                await draft.checkPresent(DraftCheckPresentMode.Alert);
                 assert.equal(errors.length, 0);
                 assert.equal(warnings.length, 0);
                 assert.equal(infos.length, 0);
@@ -117,7 +128,7 @@ suite("draft tests", () => {
                 const draft = draftCreateWithFakes({
                     shell: fakes.shell({recognisedCommands: [{command: 'where.exe draft.exe', code: 0, stdout: 'c:\\draft.exe'}]})
                 });
-                const present = await draft.checkPresent();
+                const present = await draft.checkPresent(DraftCheckPresentMode.Alert);
                 assert.equal(true, present);
             });
 

--- a/test/kubectl.test.ts
+++ b/test/kubectl.test.ts
@@ -17,7 +17,8 @@ function kubectlCreateWithFakes(ctx : FakeContext) {
     return kubectlCreate(
         ctx.host || fakes.host(),
         ctx.fs || fakes.fs(),
-        ctx.shell || fakes.shell()
+        ctx.shell || fakes.shell(),
+        () => {}
     );
 }
 


### PR DESCRIPTION
This adds an option to the 'kubectl/helm/draft not found' error to install the extension's dependencies -- currently limited to `kubectl`, Helm and Draft.  (We'd like to do Docker and Azure CLI too, but that was a bit much for this PR.)

The experience is that if we detect a missing command line tool (via background e.g. populating the tree view or a command e.g. Helm Create), we pop an alert which now has the addition button "Install dependencies."  If the user clicks this button then we install kubectl, Helm and Draft into a `.vs-kubernetes/tools` directory under their home directory, and set VS Code config settings to point to these private copies.  We do **not** add the binaries to the system path, so if the user tries to run `kubectl` or `helm` at a terminal they will still get 'not found'.  Is this okay?  As a future consideration we should probably also support versioning: currently as long as we find the CLI tools we need, we don't check that they are up to date.

The experience still has some rough edges, and the code is quite untidy.  We should streamline the way we locate and run binaries, and also look at error reporting given that several things may be trying to locate `kubectl` at the same time.  However, I think it's usable, and I'd rather get people playing with it sooner rather than later.  (But would appreciate reviewers giving it a sanity check first!)

**BIG CAVEAT:** It has NOT been tested on Mac.  (Because I don't have access to a Mac.)  It Works On My Machine TM on both Windows and Linux (Ubuntu), though lacks a thorough test matrix.

@squillace @bacongobbler @technosophos or anyone else with a Mac: Could one of you fine people please test on Mac?  I don't have the facilities...