### PR TITLE
[WIP] Draft debug adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,21 @@
             "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
             "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw=="
         },
+        "@types/glob": {
+            "version": "5.0.35",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
+            "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
+            "requires": {
+                "@types/events": "1.1.0",
+                "@types/minimatch": "3.0.3",
+                "@types/node": "6.0.96"
+            }
+        },
+        "@types/minimatch": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+        },
         "@types/mocha": {
             "version": "2.2.46",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.46.tgz",
@@ -37,6 +52,15 @@
                 "@types/bunyan": "1.8.4",
                 "@types/node": "6.0.96",
                 "@types/spdy": "3.4.4"
+            }
+        },
+        "@types/shelljs": {
+            "version": "0.7.8",
+            "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.7.8.tgz",
+            "integrity": "sha512-M2giRw93PxKS7YjU6GZjtdV9HASdB7TWqizBXe4Ju7AqbKlWvTr0gNO92XH56D/gMxqD/jNHLNfC5hA34yGqrQ==",
+            "requires": {
+                "@types/glob": "5.0.35",
+                "@types/node": "6.0.96"
             }
         },
         "@types/spdy": {
@@ -225,6 +249,11 @@
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
             "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
             "dev": true
+        },
+        "await-notify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/await-notify/-/await-notify-1.0.1.tgz",
+            "integrity": "sha1-C0gTOyLlJBgeEVV2ZRhfKi885Hw="
         },
         "aws-sign2": {
             "version": "0.7.0",
@@ -5472,6 +5501,19 @@
                     }
                 }
             }
+        },
+        "vscode-debugadapter": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.27.0.tgz",
+            "integrity": "sha512-JwE3fWmKnpjYnFqhff0umqIJi4c26gh/CXZ5LNb4gLIuPd5sEAEoEbGeCcAaajuTrVxFw6FlYEep9y+IQCf+ww==",
+            "requires": {
+                "vscode-debugprotocol": "1.27.0"
+            }
+        },
+        "vscode-debugprotocol": {
+            "version": "1.27.0",
+            "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.27.0.tgz",
+            "integrity": "sha512-cg3lKqVwxNpO2pLBxSwkBvE7w06+bHfbA/s14u8izSWyhJtPgRu1lQwi5tEyTRuwfEugfoPwerYL4vtY6teQDw=="
         },
         "vscode-extension-telemetry": {
             "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
         "onCommand:extension.draftUp",
         "onView:extension.vsKubernetesExplorer",
         "onLanguage:helm",
-        "onLanguage:yaml"
+        "onLanguage:yaml",
+        "onDebug"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -554,6 +555,96 @@
                 "language": "helm",
                 "path": "./snippets/helm.json"
             }
+        ],
+        "debuggers": [
+            {
+                "type": "draft",
+                "label": "Draft Debug",
+                "program": "./out/src/draft/debugAdapter.js",
+                "runtime": "node",
+                "configurationAttributes": {
+                    "launch": {
+                        "required": [
+                            "type",
+                            "name",
+                            "original-debug"
+                        ],
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "description": "The type of launch configuration",
+                                "default": "draft"
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "The name of the debug configuration",
+                                "default": "Draft debug"
+                            },
+                            "original-debug": {
+                                "type": "object",
+                                "description": "Actual debug configuration VS Code will launch after app is deployed.",
+                                "default": {
+                                    "type": "node",
+                                    "request": "attach",
+                                    "name": "Attach to remote",
+                                    "address": "localhost",
+                                    "port": 9229,
+                                    "remoteRoot": "/usr/src/app/"
+                                }
+                            }
+                        }
+                    }
+                },
+                "initialConfigurations": [
+                    {
+                        "type": "draft",
+                        "request": "launch",
+                        "name": "Draft Debug",
+                        "original-debug": {}
+                    }
+                ],
+                "configurationSnippets": [
+                    {
+                        "label": "Draft Debug: NodeJS",
+                        "description": "Configuration for debugging NodeJS apps on Kubernetes using Draft",
+                        "body": {
+                            "type": "draft",
+                            "request": "launch",
+                            "name": "Draft Debug",
+                            "original-debug": {
+                                "type": "node",
+                                "request": "attach",
+                                "name": "Attach to remote",
+                                "address": "localhost",
+                                "port": 9229,
+                                "remoteRoot": "/usr/src/app/"
+                            }
+                        }
+                    },
+                    {
+                        "label": "Draft Debug: Golang",
+                        "description": "Configuration for debugging Golang apps on Kubernetes, using Draft",
+                        "body": {
+                            "type": "draft",
+                            "request": "launch",
+                            "name": "Draft Debug",
+                            "original-debug": {
+                                "name": "Kubernetes remote debugging",
+                                "type": "go",
+                                "request": "launch",
+                                "mode": "remote",
+                                "remotePath": "/go/src/app",
+                                "port": 2345,
+                                "host": "127.0.0.1",
+                                "program": "${workspaceRoot}",
+                                "env": {},
+                                "args": []
+                            }
+                        }
+                    }
+                ],
+                "extensions": []
+            }
         ]
     },
     "scripts": {
@@ -568,6 +659,8 @@
     ],
     "dependencies": {
         "@types/restify": "^5.0.7",
+        "@types/shelljs": "^0.7.8",
+        "await-notify": "^1.0.1",
         "clipboardy": "^1.2.3",
         "compare-versions": "^3.1.0",
         "docker-file-parser": "^1.0.3",
@@ -584,6 +677,8 @@
         "shelljs": "^0.7.7",
         "tmp": "^0.0.31",
         "uuid": "^3.1.0",
+        "vscode-debugadapter": "1.27.0",
+        "vscode-debugprotocol": "1.27.0",
         "vscode-extension-telemetry": "^0.0.6",
         "vscode-uri": "^1.0.1",
         "yamljs": "0.2.10"

--- a/src/draft/debugAdapter.ts
+++ b/src/draft/debugAdapter.ts
@@ -1,0 +1,3 @@
+import { DraftDebugSession } from "./debugDebug";
+
+DraftDebugSession.run(DraftDebugSession);

--- a/src/draft/debugDebug.ts
+++ b/src/draft/debugDebug.ts
@@ -39,16 +39,23 @@ export class DraftDebugSession extends LoggingDebugSession {
 
         //start a `draft up` and `draft connect` session and attach debugger
         this._runtime.draftUpDebug(this.config);
-        
+
         this.sendResponse(response);
     }
 
     protected evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): void {
-        // TODO - check for request type
-        //
-        // when a request is received (such as a file was saved), restart the Draft cycle
-        this._runtime.killConnect();
-        this._runtime.draftUpDebug(this.config);
+        if (args['restart'] == true) {
+            // TODO - check for request type
+            //
+            // when a request is received (such as a file was saved), restart the Draft cycle
+            this._runtime.killConnect();
+            this._runtime.draftUpDebug(this.config);
+        }
+
+        if (args['stop'] == true) {
+            this._runtime.killConnect();
+            this.stop();
+        }
 
         this.sendResponse(response);
     }

--- a/src/draft/debugDebug.ts
+++ b/src/draft/debugDebug.ts
@@ -1,0 +1,55 @@
+import * as vscode from 'vscode';
+import { LoggingDebugSession, InitializedEvent, TerminatedEvent } from 'vscode-debugadapter';
+import { EventEmitter } from 'events';
+import { ChildProcess, exec } from 'child_process';
+import { OutputChannel } from 'vscode';
+import { Readable } from 'stream';
+import { DraftRuntime } from './draftRuntime';
+import { DebugProtocol } from 'vscode-debugprotocol/lib/debugProtocol';
+const { Subject } = require('await-notify');
+
+
+export class DraftDebugSession extends LoggingDebugSession {
+    private _runtime: DraftRuntime;
+    private _configurationDone = new Subject();
+
+    public config: vscode.DebugConfiguration;
+
+    constructor() {
+        super("draft-debug.txt");
+        this._runtime = new DraftRuntime();
+
+        this._runtime.on('end', () => {
+            this.sendEvent(new TerminatedEvent());
+        });
+    }
+
+    protected initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
+        this.sendResponse(response);
+        this.sendEvent(new InitializedEvent());
+    }
+
+    protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.LaunchRequestArguments): void {
+        this._configurationDone.notify();
+    }
+
+    protected async launchRequest(response: DebugProtocol.LaunchResponse, args: DebugProtocol.LaunchRequestArguments) {
+        // wait until configuration has finished (and configurationDoneRequest has been called)
+        await this._configurationDone.wait(1000);
+
+        //start a `draft up` and `draft connect` session and attach debugger
+        this._runtime.draftUpDebug(this.config);
+        
+        this.sendResponse(response);
+    }
+
+    protected evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): void {
+        // TODO - check for request type
+        //
+        // when a request is received (such as a file was saved), restart the Draft cycle
+        this._runtime.killConnect();
+        this._runtime.draftUpDebug(this.config);
+
+        this.sendResponse(response);
+    }
+}

--- a/src/draft/draft.ts
+++ b/src/draft/draft.ts
@@ -1,8 +1,8 @@
-import { Host } from './host';
-import { Shell, ShellResult } from './shell';
-import { FS } from './fs';
+import { Host } from '../host';
+import { Shell, ShellResult } from '../shell';
+import { FS } from '../fs';
 import * as syspath from 'path';
-import * as binutil from './binutil';
+import * as binutil from '../binutil';
 
 export interface Draft {
     checkPresent() : Promise<boolean>;

--- a/src/draft/draftConfigurationProvider.ts
+++ b/src/draft/draftConfigurationProvider.ts
@@ -1,0 +1,30 @@
+import { WorkspaceFolder, DebugConfiguration, CancellationToken, ProviderResult, DebugConfigurationProvider } from "vscode";
+import * as Net from 'net';
+import { DraftDebugSession } from "./debugDebug";
+
+export class DraftConfigurationProvider implements DebugConfigurationProvider {
+    private _server?: Net.Server;
+
+    constructor() {
+    }
+
+    resolveDebugConfiguration(folder: WorkspaceFolder | undefined, config: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration> {
+        if (!this._server) {
+            this._server = Net.createServer((socket) => {
+                const session = new DraftDebugSession();
+                session.config = config;
+                session.setRunAsServer(true);
+                session.start(<NodeJS.ReadableStream>socket, socket);
+            }).listen(0);
+        }
+        config.debugServer = this._server.address().port;
+
+        return config;
+    }
+
+    dispose() {
+        if (this._server) {
+            this._server.close();
+        }
+    }
+}

--- a/src/draft/draftRuntime.ts
+++ b/src/draft/draftRuntime.ts
@@ -1,0 +1,131 @@
+import * as vscode from 'vscode';
+import { LoggingDebugSession, InitializedEvent, TerminatedEvent } from 'vscode-debugadapter';
+import { EventEmitter } from 'events';
+import { ChildProcess, exec, execFile, spawn } from 'child_process';
+import { OutputChannel } from 'vscode';
+import { Readable } from 'stream';
+import { host } from '../host';
+import { shell } from '../shell';
+import { fs } from '../fs';
+import { create as draftCreate } from './draft';
+
+export class DraftRuntime extends EventEmitter {
+	private _draft = draftCreate(host, fs, shell);
+	private _connectProccess: ChildProcess;
+
+	constructor() {
+		super();
+	}
+
+	public killConnect() {
+		this._connectProccess.kill('SIGTERM');
+	}
+
+	public async draftUpDebug(config: vscode.DebugConfiguration) {
+
+		let output = vscode.window.createOutputChannel("draft");
+		output.show();
+
+		let isPresent = await this._draft.checkPresent();
+		if (!isPresent) {
+			host.showInformationMessage("Draft is not installed!");
+			return;
+		}
+
+		if (!this._draft.isFolderMapped(vscode.workspace.rootPath)) {
+			host.showErrorMessage("This folder does not contain a Draft app. Run draft create first!");
+			return;
+		}
+
+		// //wait for `draft up` to finish
+		await waitForProcessToExit(createProcess('draft', ['up'], output));
+
+		// wait for `draft connect` to be ready
+		this._connectProccess = createProcess('draft', ['connect'], output);
+		await waitConnectionReady(this._connectProccess, config);
+
+		host.showInformationMessage(`attaching debugger`);
+
+		vscode.debug.startDebugging(undefined, config['original-debug']);
+		vscode.debug.onDidTerminateDebugSession((e) => {
+			this.killConnect();
+			output.dispose();
+		});
+	}
+}
+
+function createProcess(cmd: string, args: string[], output: OutputChannel): ChildProcess {
+	// notify that cmd started
+	console.log(`started ${cmd} ${args.toString()}`);
+	host.showInformationMessage(`starting ${cmd} ${args.toString()}`);
+
+	let proc = spawn(cmd, args, { cwd: vscode.workspace.rootPath });
+	console.log(process.env.PATH);
+	// output data on the tab
+	subscribeToDataEvent(proc.stdout, output);
+	subscribeToDataEvent(proc.stderr, output);
+
+	proc.on('exit', (code) => {
+		host.showInformationMessage(`finished ${cmd} ${args.toString()}`);
+		console.log(`finished ${cmd} ${args.toString()} with exit code ${code}`);
+	});
+	return proc;
+}
+
+async function waitForProcessToExit(proc: ChildProcess): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		proc.addListener('message', (message) => { console.log(message); });
+		proc.addListener('close', (code, signal) => { console.log(`Code: ${code}, Signal: ${signal}`); });
+		proc.addListener('disconnect', () => console.log('disconnected'));
+		proc.addListener('error', (err) => { console.log(`Error: ${err}`); });
+		proc.addListener('exit', resolve);
+	});
+}
+
+// TODO - wait for specific stdout output based on debugger type
+async function waitConnectionReady(proc: ChildProcess, config: vscode.DebugConfiguration): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		let isConnectionReady: boolean = false;
+
+		proc.stdout.on('data', async (data: string) => {
+			if ((!isConnectionReady) && canAttachDebugger(data, config)) {
+				isConnectionReady = true;
+				resolve();
+			}
+		});
+
+		proc.on('close', async (code) => {
+			if (!isConnectionReady) {
+				reject('Cannot connect.');
+			}
+		});
+	});
+}
+
+// TODO - add other debugger type outputs here
+function canAttachDebugger(data: string, config: vscode.DebugConfiguration): boolean {
+	switch (config['original-debug'].type) {
+		case 'node': {
+			if (config['original-debug'].localRoot == '' || config['original-debug'].localRoot == null) {
+				config['original-debug'].localRoot = vscode.workspace.rootPath;
+			}
+			if (data.indexOf('Debugger listening') >= 0)
+				return true;
+		}
+
+		case 'go': {
+			if (config["original-debug"].program == '' || config["original-debug"].program == null) {
+				config['original-debug'].program = vscode.workspace.rootPath;
+			}
+			if (data.indexOf('API server listening') >= 0)
+				return true;
+		}
+	}
+}
+
+function subscribeToDataEvent(readable: Readable, outputChannel: OutputChannel): void {
+	readable.on('data', (chunk) => {
+		const chunkAsString = typeof chunk === 'string' ? chunk : chunk.toString();
+		outputChannel.append(chunkAsString);
+	});
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -211,10 +211,26 @@ export async function activate(context) : Promise<extensionapi.ExtensionAPI> {
             // TODO - maybe check to see if `draft.toml` is present in the workspace
             // TODO - check to make sure we enable this only when Draft is installed
             if (session != undefined) {
-                draftDebugSession.customRequest('evaluate', {draftUp: ''});
+                draftDebugSession.customRequest('evaluate', { restart: true });
             }
         }
-	});
+    });
+    
+    vscode.debug.onDidTerminateDebugSession((e) => {
+
+        // if there is an active Draft debugging session, restart the cycle
+        if (draftDebugSession != undefined) {
+            const session = vscode.debug.activeDebugSession;
+
+            // TODO - how do we make sure this doesn't affect all other debugging sessions?
+            // TODO - maybe check to see if `draft.toml` is present in the workspace
+            // TODO - check to make sure we enable this only when Draft is installed
+            if (session != undefined) {
+                draftDebugSession.customRequest('evaluate', { stop: true });
+            }
+        }
+    });
+
     // On editor change, refresh the Helm YAML preview
     vscode.window.onDidChangeActiveTextEditor((e: vscode.TextEditor) => {
         if (!editorIsActive()) {

--- a/test/draft.test.ts
+++ b/test/draft.test.ts
@@ -7,7 +7,7 @@ import * as fakes from './fakes';
 import { Host } from '../src/host';
 import { Shell, ShellResult } from '../src/shell';
 import { FS } from '../src/fs';
-import { create as draftCreate } from '../src/draft';
+import { create as draftCreate } from '../src/draft/draft';
 import * as kuberesources from '../src/kuberesources';
 
 interface FakeContext {


### PR DESCRIPTION
This PR is a work in progress to add native VS Code experience to run and debug apps deployed with Draft.

It is still rough around the edges and there's lots of things to add and review:

- [x] check if Draft is installed before starting debug sessions (solved by #136)
- [x] prompt to install Draft if  `draft.toml` or specific launch file is detected ( solved by #136)
- [x] `draftRuntime.ts` needs a complete rewrite
- [x] a way to ensure the debugger is only attached after the connection is actually active (and not just the port is used)
- [x] add the actual debug configuration as part of `launch.json`
- [x] make sure the Draft cycle is not started when not using Draft
- [x] find way to stop debugging session if Draft is not present or folder doesn't contain a Draft app
- [x] fix tests
- [x] add specific way of checking connection is ready based on the debugger type (fixed for NodeJS)
- [ ] decide on adding an `attach` target that only attaches to existing deployments
- [ ] add timeout in waiting to attach the debugger

This is a first attempt at integrating with the extension - please provide all types of feedback on debug sessions and how the debugger integrates with the extension.