### PR TITLE
update node-yaml-parser version to 0.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3396,9 +3396,9 @@
             "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
         },
         "node-yaml-parser": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/node-yaml-parser/-/node-yaml-parser-0.0.7.tgz",
-            "integrity": "sha512-I2joNrjOCNSdPdwO70gR1oHWMMeBDHWMEqGsOMgWHPauT1Eps+EFA6d9b2We1L2RLKHrmaFr+NRlbj5Q4j2HOw=="
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/node-yaml-parser/-/node-yaml-parser-0.0.9.tgz",
+            "integrity": "sha512-bFFmAdUs9sdD+TwF/A91b4ozU2KJSDuK7HiBV0QDhdG7Cunu/4PakBLn3wWWAJurAJd7GqAeEwYhu32bTHOvQg=="
         },
         "node.extend": {
             "version": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -576,7 +576,7 @@
         "js-yaml": "^3.8.2",
         "k8s": "^0.4.12",
         "lodash": ">3",
-        "node-yaml-parser": "^0.0.7",
+        "node-yaml-parser": "^0.0.9",
         "opn": "^5.2.0",
         "pluralize": "^4.0.0",
         "portfinder": "^1.0.13",


### PR DESCRIPTION
fix issue https://github.com/Azure/vscode-kubernetes-tools/issues/147: some yaml errors during the time user input are not fixed by node-yaml-parser, 0.0.9 fix some of them.