### PR TITLE
Add explorer api to allow third-party extension to mount tree nodes into explorer

### DIFF
--- a/src/explorer.api.ts
+++ b/src/explorer.api.ts
@@ -1,0 +1,26 @@
+import { KubernetesObject } from "./explorer";
+
+export interface ExplorerDataProvider {
+    getChildren(parent: KubernetesObject): Promise<KubernetesObject[]>;
+}
+
+export interface KubernetesExplorerDataProviderRegistry {
+    register(dataProvider: ExplorerDataProvider): void;
+    list(): Array<ExplorerDataProvider>;
+}
+
+class KubernetesExplorerDataProviderRegistryImpl implements KubernetesExplorerDataProviderRegistry {
+    private readonly providers = new Array<ExplorerDataProvider>();
+
+    register(dataProvider: ExplorerDataProvider): void {
+        this.providers.push(dataProvider);
+    }
+
+    list(): Array<ExplorerDataProvider> {
+        return [].concat(this.providers);
+    }
+}
+
+export function createKubernetesExplorerRegistry(): KubernetesExplorerDataProviderRegistry {
+    return new KubernetesExplorerDataProviderRegistryImpl();
+}

--- a/src/explorer.api.ts
+++ b/src/explorer.api.ts
@@ -1,4 +1,11 @@
-import { KubernetesObject } from "./explorer";
+import * as vscode from "vscode";
+
+export interface KubernetesObject {
+    readonly id: string;
+    readonly metadata?: any;
+    getChildren(kubectl: any, host: any): vscode.ProviderResult<KubernetesObject[]>;
+    getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem>;
+}
 
 export interface ExplorerDataProvider {
     getChildren(parent: KubernetesObject): Promise<KubernetesObject[]>;

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-import { KubernetesExplorerDataProviderRegistry } from './explorer.api';
+import { KubernetesExplorerDataProviderRegistry, KubernetesObject } from './explorer.api';
 import * as shell from './shell';
 import { Kubectl } from './kubectl';
 import * as kubectlUtils from './kubectlUtils';
@@ -18,13 +18,6 @@ export function createKubernetesResourceFolder(kind: kuberesources.ResourceKind)
 
 export function createKubernetesResource(kind: kuberesources.ResourceKind, id: string, metadata?: any): KubernetesObject {
     return new KubernetesResource(kind, id, metadata);
-}
-
-export interface KubernetesObject {
-    readonly id: string;
-    readonly metadata?: any;
-    getChildren(kubectl: Kubectl, host: Host): vscode.ProviderResult<KubernetesObject[]>;
-    getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem>;
 }
 
 export interface ResourceNode {

--- a/src/extension.api.ts
+++ b/src/extension.api.ts
@@ -1,6 +1,8 @@
 import * as clusterproviderregistry from './components/clusterprovider/clusterproviderregistry';
+import { KubernetesExplorerDataProviderRegistry } from './explorer.api';
 
 export interface ExtensionAPI {
     readonly apiVersion: string;
     readonly clusterProviderRegistry: clusterproviderregistry.ClusterProviderRegistry;
+    readonly explorerDataProviderRegistry: KubernetesExplorerDataProviderRegistry;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ import { kubeChannel } from './kubeChannel';
 import * as kubeconfig from './kubeconfig';
 import { create as kubectlCreate, Kubectl } from './kubectl';
 import * as kubectlUtils from './kubectlUtils';
-import { createKubernetesExplorerRegistry, KubernetesExplorerDataProviderRegistry} from './explorer.api';
+import { createKubernetesExplorerRegistry, KubernetesExplorerDataProviderRegistry, KubernetesObject} from './explorer.api';
 import * as explorer from './explorer';
 import { create as draftCreate, Draft, CheckPresentMode as DraftCheckPresentMode } from './draft/draft';
 import * as logger from './logger';
@@ -1318,7 +1318,7 @@ const debugKubernetes = async () => {
     }
 };
 
-const debugAttachKubernetes = async (explorerNode: explorer.KubernetesObject) => {
+const debugAttachKubernetes = async (explorerNode: KubernetesObject) => {
     const workspaceFolder = await showWorkspaceFolderPick();
     if (workspaceFolder) {
         new DebugSession(kubectl).attach(workspaceFolder, explorerNode ? explorerNode.id : null);
@@ -1482,7 +1482,7 @@ async function createClusterKubernetes() {
     vscode.commands.executeCommand('vscode.previewHtml', createCluster.operationUri(newId), 2, "Create Kubernetes Cluster");
 }
 
-async function useContextKubernetes(explorerNode: explorer.KubernetesObject) {
+async function useContextKubernetes(explorerNode: KubernetesObject) {
     const targetContext = explorerNode.metadata.context;
     const shellResult = await kubectl.invokeAsync(`config use-context ${targetContext}`);
     if (shellResult.code === 0) {
@@ -1492,12 +1492,12 @@ async function useContextKubernetes(explorerNode: explorer.KubernetesObject) {
     }
 }
 
-async function clusterInfoKubernetes(explorerNode: explorer.KubernetesObject) {
+async function clusterInfoKubernetes(explorerNode: KubernetesObject) {
     const targetContext = explorerNode.metadata.context;
     kubectl.invokeInTerminal("cluster-info");
 }
 
-async function deleteContextKubernetes(explorerNode: explorer.KubernetesObject) {
+async function deleteContextKubernetes(explorerNode: KubernetesObject) {
     const answer = await vscode.window.showWarningMessage(`Do you want to delete the cluster '${explorerNode.id}' from the kubeconfig?`, ...deleteMessageItems);
     if (answer.isCloseAffordance) {
         return;
@@ -1507,13 +1507,13 @@ async function deleteContextKubernetes(explorerNode: explorer.KubernetesObject) 
     }
 }
 
-async function useNamespaceKubernetes(explorerNode: explorer.KubernetesObject) {
+async function useNamespaceKubernetes(explorerNode: KubernetesObject) {
     if (await kubectlUtils.switchNamespace(kubectl, explorerNode.id)) {
         refreshExplorer();
     }
 }
 
-function copyKubernetes(explorerNode: explorer.KubernetesObject) {
+function copyKubernetes(explorerNode: KubernetesObject) {
     clipboard.writeSync(explorerNode.id);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,7 @@ import { kubeChannel } from './kubeChannel';
 import * as kubeconfig from './kubeconfig';
 import { create as kubectlCreate, Kubectl } from './kubectl';
 import * as kubectlUtils from './kubectlUtils';
+import { createKubernetesExplorerRegistry, KubernetesExplorerDataProviderRegistry} from './explorer.api';
 import * as explorer from './explorer';
 import { create as draftCreate, Draft } from './draft';
 import * as logger from './logger';
@@ -62,6 +63,7 @@ const configureFromClusterUI = configureFromCluster.uiProvider();
 const createClusterUI = createCluster.uiProvider();
 const clusterProviderRegistry = clusterproviderregistry.get();
 const git = new Git(shell);
+const explorerDataProviderRegistry = createKubernetesExplorerRegistry();
 
 const deleteMessageItems: vscode.MessageItem[] = [
     {
@@ -85,7 +87,7 @@ export const HELM_TPL_MODE: vscode.DocumentFilter = { language: "helm", scheme: 
 export async function activate(context) : Promise<extensionapi.ExtensionAPI> {
     kubectl.checkPresent('activation');
 
-    const treeProvider = explorer.create(kubectl, host);
+    const treeProvider = explorer.create(kubectl, host, explorerDataProviderRegistry);
     const previewProvider = new HelmTemplatePreviewDocumentProvider();
     const inspectProvider = new HelmInspectDocumentProvider();
     const completionProvider = new HelmTemplateCompletionProvider();
@@ -214,7 +216,8 @@ export async function activate(context) : Promise<extensionapi.ExtensionAPI> {
 
     return {
         apiVersion: '0.1',
-        clusterProviderRegistry: clusterProviderRegistry
+        clusterProviderRegistry: clusterProviderRegistry,
+        explorerDataProviderRegistry: explorerDataProviderRegistry
     };
 }
 

--- a/test/explorer.test.ts
+++ b/test/explorer.test.ts
@@ -8,6 +8,7 @@ import * as fakes from './fakes';
 
 import { Host } from '../src/host';
 import { Shell, ShellResult } from '../src/shell';
+import { createKubernetesExplorerRegistry } from '../src/explorer.api';
 import * as kubeExplorer from '../src/explorer';
 import * as kuberesources from '../src/kuberesources';
 
@@ -19,7 +20,8 @@ interface FakeContext {
 function explorerCreateWithFakes(ctx : FakeContext) {
     return kubeExplorer.create(
         ctx.kubectl || fakes.kubectl(),
-        ctx.host || fakes.host()
+        ctx.host || fakes.host(),
+        createKubernetesExplorerRegistry()
     );
 }
 


### PR DESCRIPTION
This PR will make Kubernetes Explorer Tree View to be extendable by other extensions.
In my current design, the third-party extension can add new children nodes at all levels of Kubernetes Explorer Tree View. I'm not sure whether this is too flexible. If anyone have concern about this, please let me know.


And See the sample code about how to extend the explorer on other extension side.
https://github.com/testforstephen/vscode-service-catalog/blob/master/src/extension.ts

https://github.com/testforstephen/vscode-service-catalog/blob/master/src/explorer.ts

@squillace @bnookala @andxu @akaroml 
