### PR TITLE
Remove space in log command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -964,7 +964,7 @@ function getLogs(pod) {
 
 function getLogsCore(podName : string, podNamespace? : string) {
     // TODO: Support multiple containers here!
-    let cmd = ' logs ' + podName;
+    let cmd = 'logs ' + podName;
     if (podNamespace && podNamespace.length > 0) {
         cmd += ' --namespace=' + podNamespace;
     }


### PR DESCRIPTION
There is an additional space before `logs`. Currently it will show as:
```
$ kubectl__logs_<pod>
```