### PR TITLE
Force 'natives' module version to fix gulp tslint crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1516,7 +1516,7 @@
                     "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
                     "dev": true,
                     "requires": {
-                        "natives": "1.1.1"
+                        "natives": "1.1.3"
                     }
                 },
                 "isarray": {
@@ -3408,10 +3408,9 @@
             }
         },
         "natives": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
-            "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
-            "dev": true
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.3.tgz",
+            "integrity": "sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g=="
         },
         "ncp": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -669,6 +669,7 @@
         "js-yaml": "^3.8.2",
         "k8s": "^0.4.12",
         "lodash": ">3",
+        "natives": "^1.1.3",
         "node-yaml-parser": "^0.0.9",
         "opn": "^5.2.0",
         "pluralize": "^4.0.0",


### PR DESCRIPTION
Exploring an option to prevent `gulp tslint` crashing in the CI environment.