### PR TITLE
Fix silent failures when there is no workspace

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -696,11 +696,17 @@ async function findPodsCore(findPodCmdOptions: string) : Promise<FindPodsResult>
 }
 
 async function findPodsForApp() : Promise<FindPodsResult> {
+    if (!vscode.workspace.rootPath) {
+        return { succeeded: true, pods: [] };
+    }
     let appName = path.basename(vscode.workspace.rootPath);
     return await findPodsByLabel(`run=${appName}`);
 }
 
 async function findDebugPodsForApp() : Promise<FindPodsResult> {
+    if (!vscode.workspace.rootPath) {
+        return { succeeded: true, pods: [] };
+    }
     let appName = path.basename(vscode.workspace.rootPath);
     return await findPodsByLabel(`run=${appName}-debug`);
 }

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -148,6 +148,10 @@ export function helmDryRun() {
 //
 // callback is fn(path)
 export function pickChart(fn) {
+    if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
+        vscode.window.showErrorMessage("This command requires an open folder.");
+        return;
+    }
     vscode.workspace.findFiles("**/Chart.yaml", "", 1024).then((matches) => {
         switch(matches.length) {
             case 0:


### PR DESCRIPTION
Several commands which need a workspace (open folder) fail silently when the user doesn't have a folder open.  This PR provides fallback or error reporting behaviour for this scenarios.

Fixes #194.