### PR TITLE
Fixed error when selecting service without selector in tree

### DIFF
--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -136,6 +136,10 @@ export async function getPodSelector(resource: string, kubectl: Kubectl): Promis
 }
 
 export async function getPods(kubectl: Kubectl, selector: any): Promise<Pod[]> {
+    if (!selector) {
+        return [];
+    }
+
     const currentNS = await currentNamespace(kubectl);
 
     const labels = [];


### PR DESCRIPTION
Kubernetes services are not required to have selectors, for example if the service is implemented by an external endpoint.  Clicking a service without a selector in the tree view previously caused an error "Cannot read property 'matchLabels' of undefined".  This fixes that error.

Fixes #190.