### PR TITLE
Add new regions to create AKS cluster wizard

### DIFF
--- a/src/components/clusterprovider/azure/azure.ts
+++ b/src/components/clusterprovider/azure/azure.ts
@@ -193,7 +193,7 @@ export async function listAksLocations(context: Context) : Promise<Errorable<Ser
 
     // There's no CLI for this, so we have to hardwire it for now
     const productionRegions = [];
-    const previewRegions = ["centralus", "eastus", "westeurope"];
+    const previewRegions = ["centralus", "eastus", "westeurope", "canadacentral", "canadaeast"];
     const result = locationDisplayNamesEx(productionRegions, previewRegions, locations);
     return { succeeded: true, result: result, error: [] };
 }


### PR DESCRIPTION
AKS has added a couple of Canada regions to the preview.  We need to offer these in the Create Cluster region drop-down.