### PR TITLE
Support alternate kubeconfigs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ And then add:
 
 Where `<your-image-prefix-here>` is something like `docker.io/brendanburns`.
 
+### Selecting a kubeconfig file
+
+By default, the extension uses the active kubeconfig file -- that is, the file
+to which the KUBECONFIG environment variable points, or the default kubeconfig
+if no KUBECONFIG environment variable exists.  If you want to swap kubeconfig
+files, you can specify the file path in the `vs-kubernetes.kubeconfig` setting in
+your user or workspace settings.
+
 ### Running from source
 
 If you are building and running the extension from source, see [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites for the development environment.
@@ -131,6 +139,7 @@ If you are building and running the extension from source, see [CONTRIBUTING.md]
        * `vs-kubernetes.kubectl-path` - File path to the kubectl binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
        * `vs-kubernetes.helm-path` - File path to the helm binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
        * `vs-kubernetes.draft-path` - File path to the draft binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension (note current versions of Draft are not supported on Windows).
+       * `vs-kubernetes.kubeconfig` - File path to the kubeconfig file you want to use. This overrides both the default kubeconfig and the KUBECONFIG environment variable.
        * `vs-kubernetes.autoCleanupOnDebugTerminate` - The flag to control whether to auto cleanup the created deployment and associated pod by the command "Kubernetes: Debug (Launch)". The cleanup action occurs when it failed to start debug session or debug session terminated. If not specified, the extension will prompt for whether to clean up or not. You might choose not to clean up if you wanted to view pod logs, etc.
    * `vsdocker.imageUser` - Image prefix for docker images e.g. 'docker.io/brendanburns'
 

--- a/package.json
+++ b/package.json
@@ -87,6 +87,10 @@
                             "type": "string",
                             "description": "File path to a draft binary."
                         },
+                        "vs-kubernetes.kubeconfig": {
+                            "type": "string",
+                            "description": "File path to the kubeconfig file."
+                        },
                         "vs-kubernetes.autoCleanupOnDebugTerminate": {
                             "type": "boolean",
                             "description": "Once the debug session is terminated, automatically clean up the created Deployment and associated Pod by the command \"Kubernetes: Debug (Launch)\"."
@@ -97,6 +101,7 @@
                         "vs-kubernetes.kubectl-path": "",
                         "vs-kubernetes.helm-path": "",
                         "vs-kubernetes.draft-path": "",
+                        "vs-kubernetes.kubeconfig": "",
                         "vs-kubernetes.autoCleanupOnDebugTerminate": false
                     }
                 },

--- a/src/components/clusterprovider/azure/azure.ts
+++ b/src/components/clusterprovider/azure/azure.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import * as vscode from 'vscode';
 import { Shell } from '../../../shell';
 import { FS } from '../../../fs';
 import { Errorable, ActionResult, fromShellJson, fromShellExitCodeAndStandardError, fromShellExitCodeOnly } from '../../../wizard';
@@ -333,10 +334,12 @@ async function downloadKubectlCli(context: Context, clusterType: string): Promis
 }
 
 async function getCredentials(context: Context, clusterType: string, clusterName: string, clusterGroup: string, maxAttempts: number): Promise<any> {
+    const kubeconfig: string = vscode.workspace.getConfiguration('vs-kubernetes')['vs-kubernetes.kubeconfig'];
+    const kubeconfigFileOption = kubeconfig ? `-f "${kubeconfig}"` : '';
     let attempts = 0;
     while (true) {
         attempts++;
-        const cmd = `az ${getClusterCommandAndSubcommand(clusterType)} get-credentials -n ${clusterName} -g ${clusterGroup}`;
+        const cmd = `az ${getClusterCommandAndSubcommand(clusterType)} get-credentials -n ${clusterName} -g ${clusterGroup} ${kubeconfigFileOption}`;
         const sr = await context.shell.exec(cmd);
 
         if (sr.code === 0 && !sr.stderr) {

--- a/src/components/kubectl/dashboard.ts
+++ b/src/components/kubectl/dashboard.ts
@@ -128,13 +128,9 @@ export async function dashboardKubernetes (): Promise<void> {
         {encoding: 'utf8'}
     ).on('data', onStreamData);
 
-    terminal = vscode.window.createTerminal(TERMINAL_NAME);
-    vscode.window.onDidCloseTerminal(onClosedTerminal);
-
     // stdout is also written to a file via `tee`. We read this file as a stream
     // to listen for when the server is ready.
-    terminal.sendText(`kubectl proxy | tee ${PROXY_OUTPUT_FILE}`);
-    terminal.show(true);
+    await kubectl.invokeInNewTerminal('proxy', TERMINAL_NAME, onClosedTerminal, `tee ${PROXY_OUTPUT_FILE}`);
 }
 
 /**

--- a/src/components/kubectl/port-forward.ts
+++ b/src/components/kubectl/port-forward.ts
@@ -215,7 +215,7 @@ export async function portForwardToPod (podName: string, portMapping: PortMappin
 
     let usedNamespace = namespace === undefined ? 'default' : namespace;
 
-    kubectl.invokeInTerminal(`port-forward ${podName} ${usedPort}:${targetPort} -n ${usedNamespace}`, PORT_FORWARD_TERMINAL);
+    kubectl.invokeInNewTerminal(`port-forward ${podName} ${usedPort}:${targetPort} -n ${usedNamespace}`, PORT_FORWARD_TERMINAL);
     host.showInformationMessage(`Forwarding from 127.0.0.1:${usedPort} -> ${podName}:${targetPort}`);
 
     return usedPort;

--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -334,7 +334,7 @@ export class DebugSession implements IDebugSession {
         portMapping.push(proxyDebugPort + ":" + debugPort);
 
         return {
-            proxyProcess: spawnChildProcess(kubectl.path(), ["port-forward", podName, ...portMapping]),
+            proxyProcess: await kubectl.spawnAsChild(["port-forward", podName, ...portMapping]),
             proxyDebugPort,
             proxyAppPort
         };

--- a/src/draft/draft.ts
+++ b/src/draft/draft.ts
@@ -9,7 +9,7 @@ export interface Draft {
     isFolderMapped(path: string): boolean;
     packs(): Promise<string[] | undefined>;
     invoke(args: string): Promise<ShellResult>;
-    path(): Promise<string | undefined>;
+    up(): Promise<void>;
 }
 
 export function create(host: Host, fs: FS, shell: Shell, installDependenciesCallback: () => void): Draft {
@@ -53,8 +53,8 @@ class DraftImpl implements Draft {
         return invoke(this.context, args);
     }
 
-    path(): Promise<string | undefined> {
-        return path(this.context);
+    up(): Promise<void> {
+        return up(this.context);
     }
 }
 
@@ -84,6 +84,18 @@ async function invoke(context: Context, args: string): Promise<ShellResult> {
     if (await checkPresent(context, CheckPresentMode.Alert)) {
         const result = context.shell.exec(context.binPath + ' ' + args);
         return result;
+    }
+}
+
+async function up(context: Context): Promise<void> {
+    if (await checkPresent(context, CheckPresentMode.Alert)) {
+        if (context.shell.isUnix()) {
+            const term = context.host.createTerminal('draft up', `bash`, [ '-c', `draft up ; bash` ]);
+            term.show(true);
+        } else {
+            const term = context.host.createTerminal('draft up', 'powershell.exe', [ '-NoExit', `draft`, `up` ]);
+            term.show(true);
+        }
     }
 }
 

--- a/src/draft/draftRuntime.ts
+++ b/src/draft/draftRuntime.ts
@@ -60,7 +60,7 @@ function createProcess(cmd: string, args: string[], output: OutputChannel): Chil
 	console.log(`started ${cmd} ${args.toString()}`);
 	host.showInformationMessage(`starting ${cmd} ${args.toString()}`);
 
-	let proc = spawn(cmd, args, { cwd: vscode.workspace.rootPath });
+	let proc = spawn(cmd, args, shell.execOpts());
 	console.log(process.env.PATH);
 	// output data on the tab
 	subscribeToDataEvent(proc.stdout, output);

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -35,7 +35,13 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<KubernetesObj
     private _onDidChangeTreeData: vscode.EventEmitter<KubernetesObject | undefined> = new vscode.EventEmitter<KubernetesObject | undefined>();
     readonly onDidChangeTreeData: vscode.Event<KubernetesObject | undefined> = this._onDidChangeTreeData.event;
 
-    constructor(private readonly kubectl: Kubectl, private readonly host: Host) { }
+    constructor(private readonly kubectl: Kubectl, private readonly host: Host) {
+        host.onDidChangeConfiguration((change) => {
+            if (change.affectsConfiguration('vs-kubernetes')) {
+                this.refresh();
+            }
+        });
+    }
 
     getTreeItem(element: KubernetesObject): vscode.TreeItem | Thenable<vscode.TreeItem> {
         return element.getTreeItem();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -684,10 +684,10 @@ function exposeKubernetes() {
 function getKubernetes(explorerNode?: any) {
     if (explorerNode) {
         const id = explorerNode.resourceId || explorerNode.id;
-        kubectl.invokeInTerminal(`get ${id} -o wide`);
+        kubectl.invokeInSharedTerminal(`get ${id} -o wide`);
     } else {
         findKindNameOrPrompt(kuberesources.commonKinds, 'get', { nameOptional: true }, (value) => {
-            kubectl.invokeInTerminal(` get ${value} -o wide`);
+            kubectl.invokeInSharedTerminal(` get ${value} -o wide`);
         });
     }
 }
@@ -1069,7 +1069,7 @@ function getLogsCore(podName: string, podNamespace?: string) {
     if (podNamespace && podNamespace.length > 0) {
         cmd += ' --namespace=' + podNamespace;
     }
-    kubectl.invokeInTerminal(cmd);
+    kubectl.invokeInSharedTerminal(cmd);
 }
 
 function kubectlOutputTo(name: string) {
@@ -1101,10 +1101,10 @@ function getPorts() {
 
 function describeKubernetes(explorerNode?: explorer.ResourceNode) {
     if (explorerNode) {
-        kubectl.invokeInTerminal(`describe ${explorerNode.resourceId}`);
+        kubectl.invokeInSharedTerminal(`describe ${explorerNode.resourceId}`);
     } else {
         findKindNameOrPrompt(kuberesources.commonKinds, 'describe', { nameOptional: true }, (value) => {
-            kubectl.invokeInTerminal(`describe ${value}`);
+            kubectl.invokeInSharedTerminal(`describe ${value}`);
         });
     }
 }
@@ -1174,13 +1174,12 @@ async function execKubernetesCore(isTerminal): Promise<void> {
     }
 
     const execCmd = ' exec ' + pod.metadata.name + ' ' + cmd;
-    kubectl.invokeInTerminal(execCmd);
+    kubectl.invokeInSharedTerminal(execCmd);
 }
 
 function execTerminalOnPod(podName: string, terminalCmd: string) {
     const terminalExecCmd: string[] = ['exec', '-it', podName, '--', terminalCmd];
-    const term = vscode.window.createTerminal(`${terminalCmd} on ${podName}`, kubectl.path(), terminalExecCmd);
-    term.show();
+    kubectl.runAsTerminal(terminalExecCmd, `${terminalCmd} on ${podName}`);
 }
 
 async function isBashOnPod(podName: string): Promise<boolean> {
@@ -1545,7 +1544,7 @@ async function useContextKubernetes(explorerNode: explorer.KubernetesObject) {
 
 async function clusterInfoKubernetes(explorerNode: explorer.KubernetesObject) {
     const targetContext = explorerNode.metadata.context;
-    kubectl.invokeInTerminal("cluster-info");
+    kubectl.invokeInSharedTerminal("cluster-info");
 }
 
 async function deleteContextKubernetes(explorerNode: explorer.KubernetesObject) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1677,19 +1677,8 @@ async function execDraftUp() {
         vscode.window.showInformationMessage('This folder is not configured for draft. Run draft create to configure it.');
         return;
     }
-    if (!(await draft.checkPresent(DraftCheckPresentMode.Alert))) {
-        return;
-    }
 
-    // if it's already running... how can we tell?
-    const draftPath = await draft.path();
-    if (shell.isUnix()) {
-        const term = vscode.window.createTerminal('draft up', `bash`, [ '-c', `${draftPath} up ; bash` ]);
-        term.show(true);
-    } else {
-        const term = vscode.window.createTerminal('draft up', 'powershell.exe', [ '-NoExit', `${draftPath}`, `up` ]);
-        term.show(true);
-    }
+    await draft.up();
 }
 
 function editorIsActive(): boolean {

--- a/src/host.ts
+++ b/src/host.ts
@@ -103,6 +103,12 @@ function shellEnvironment(baseEnvironment: any): any {
             env[pathVariable] = (currentPath ? `${currentPath}${pathEntrySeparator}` : '') + toolDirectory;
         }
     }
+
+    const kubeconfig: string = vscode.workspace.getConfiguration('vs-kubernetes')['vs-kubernetes.kubeconfig'];
+    if (kubeconfig) {
+        env['KUBECONFIG'] = kubeconfig;
+    }
+
     return env;
 }
 

--- a/src/host.ts
+++ b/src/host.ts
@@ -12,6 +12,7 @@ export interface Host {
     getConfiguration(key: string): any;
     createTerminal(name?: string, shellPath?: string, shellArgs?: string[]): vscode.Terminal;
     onDidCloseTerminal(listener: (e: vscode.Terminal) => any): vscode.Disposable;
+    onDidChangeConfiguration(listener: (ch: vscode.ConfigurationChangeEvent) => any): vscode.Disposable;
 }
 
 export const host: Host = {
@@ -23,6 +24,7 @@ export const host: Host = {
     getConfiguration : getConfiguration,
     createTerminal : createTerminal,
     onDidCloseTerminal : onDidCloseTerminal,
+    onDidChangeConfiguration : onDidChangeConfiguration,
     showInputBox : showInputBox
 };
 
@@ -90,6 +92,10 @@ function createTerminal(name?: string, shellPath?: string, shellArgs?: string[])
 
 function onDidCloseTerminal(listener: (e: vscode.Terminal) => any): vscode.Disposable {
     return vscode.window.onDidCloseTerminal(listener);
+}
+
+function onDidChangeConfiguration(listener: (e: vscode.ConfigurationChangeEvent) => any): vscode.Disposable {
+    return vscode.workspace.onDidChangeConfiguration(listener);
 }
 
 function shellEnvironment(baseEnvironment: any): any {

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -84,10 +84,8 @@ class KubectlImpl implements Kubectl {
                 }
             });
             this.context.host.onDidChangeConfiguration((change) => {
-                if (change.affectsConfiguration('vs-kubernetes')) {
-                    if (this.sharedTerminal) {
-                        this.sharedTerminal.dispose();
-                    }
+                if (change.affectsConfiguration('vs-kubernetes') && this.sharedTerminal) {
+                    this.sharedTerminal.dispose();
                 }
             });
         }

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -163,11 +163,7 @@ async function spawnAsChild(context: Context, command: string[]): Promise<ChildP
 
 async function invokeInTerminal(context: Context, command: string, pipeTo: string | undefined, terminal: Terminal): Promise<void> {
     if (await checkPresent(context, 'command')) {
-        let bin = baseKubectlPath(context).trim();
-        if (bin.indexOf(" ") > -1 && !/^['"]/.test(bin)) {
-            bin = `"${bin}"`;
-        }
-        const kubectlCommand = `${bin} ${command}`;
+        const kubectlCommand = `kubectl ${command}`;
         const fullCommand = pipeTo ? `${kubectlCommand} | ${pipeTo}` : kubectlCommand;
         terminal.sendText(fullCommand);
         terminal.show();

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -83,6 +83,13 @@ class KubectlImpl implements Kubectl {
                     disposable.dispose();
                 }
             });
+            this.context.host.onDidChangeConfiguration((change) => {
+                if (change.affectsConfiguration('vs-kubernetes')) {
+                    if (this.sharedTerminal) {
+                        this.sharedTerminal.dispose();
+                    }
+                }
+            });
         }
         return this.sharedTerminal;
     }

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -157,7 +157,7 @@ async function invokeAsyncWithProgress(context: Context, command: string, progre
 
 async function spawnAsChild(context: Context, command: string[]): Promise<ChildProcess> {
     if (await checkPresent(context, 'command')) {
-        return spawnChildProcess(path(context), command);
+        return spawnChildProcess(path(context), command, context.shell.execOpts());
     }
 }
 

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -132,7 +132,7 @@ export function shellEnvironment(baseEnvironment: any): any {
 }
 
 function pathVariableName(env: any): string {
-    if (isWindows) {
+    if (isWindows()) {
         for (const v of Object.keys(env)) {
             if (v.toLowerCase() === "path") {
                 return v;

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -2,6 +2,7 @@
 
 import * as vscode from 'vscode';
 import * as shelljs from 'shelljs';
+import * as path from 'path';
 
 export enum Platform {
     Windows,
@@ -31,7 +32,7 @@ export const shell: Shell = {
     fileUri : fileUri,
     execOpts : execOpts,
     exec : exec,
-    execCore : execCore
+    execCore : execCore,
 };
 
 const WINDOWS: string = 'win32';
@@ -87,10 +88,7 @@ function execOpts(): any {
     if (isWindows()) {
         env = Object.assign({ }, env, { HOME: home() });
     }
-    const kubeconfig: string = vscode.workspace.getConfiguration('vs-kubernetes')['vs-kubernetes.kubeconfig'];
-    if (kubeconfig) {
-        env['KUBECONFIG'] = kubeconfig;
-    }
+    env = shellEnvironment(env);
     const opts = {
         cwd: vscode.workspace.rootPath,
         env: env,
@@ -112,6 +110,42 @@ function execCore(cmd: string, opts: any): Promise<ShellResult> {
         shelljs.exec(cmd, opts, (code, stdout, stderr) => resolve({code : code, stdout : stdout, stderr : stderr}));
     });
 }
+
+export function shellEnvironment(baseEnvironment: any): any {
+    let env = Object.assign({}, baseEnvironment);
+    let pathVariable = pathVariableName(env);
+    for (const tool of ['kubectl', 'helm', 'draft']) {
+        const toolPath = vscode.workspace.getConfiguration('vs-kubernetes')[`vs-kubernetes.${tool}-path`];
+        if (toolPath) {
+            const toolDirectory = path.dirname(toolPath);
+            const currentPath = env[pathVariable];
+            env[pathVariable] = (currentPath ? `${currentPath}${pathEntrySeparator()}` : '') + toolDirectory;
+        }
+    }
+
+    const kubeconfig: string = vscode.workspace.getConfiguration('vs-kubernetes')['vs-kubernetes.kubeconfig'];
+    if (kubeconfig) {
+        env['KUBECONFIG'] = kubeconfig;
+    }
+
+    return env;
+}
+
+function pathVariableName(env: any): string {
+    if (isWindows) {
+        for (const v of Object.keys(env)) {
+            if (v.toLowerCase() === "path") {
+                return v;
+            }
+        }
+    }
+    return "PATH";
+}
+
+function pathEntrySeparator() {
+    return isWindows() ? ';' : ':';
+}
+
 
 export function isShellResult<T>(obj: T | ShellResult): obj is ShellResult {
     const sr = <ShellResult>obj;

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -87,6 +87,10 @@ function execOpts(): any {
     if (isWindows()) {
         env = Object.assign({ }, env, { HOME: home() });
     }
+    const kubeconfig: string = vscode.workspace.getConfiguration('vs-kubernetes')['vs-kubernetes.kubeconfig'];
+    if (kubeconfig) {
+        env['KUBECONFIG'] = kubeconfig;
+    }
     const opts = {
         cwd: vscode.workspace.rootPath,
         env: env,


### PR DESCRIPTION
We've had a few people who have multiple kubeconfig files and want to be able to swap between them.  This PR adds a setting (which can be at user or workspace level) to control which kubeconfig file is used.

Considerations for reviewers:

* Is a setting discoverable enough, or should users be able to swap using a hotkey?  Or should we even display multiple kubeconfigs in the tree view and allow users to switch between them?
* Are there any paths I have missed that spawn kubectl or anything else that uses kubeconfig?  I _think_ I have them all, but we have sprouted quite a few places that go round the back of the abstractions.  Please check areas that you know to be sure I haven't messed them up (e.g. @radu-matei's Draft debug stuff).
* In order to minimise the risk above, I've tried to encapsulate the way we invoke tools, and centralise associated logic, e.g. by setting up PATH in child processes rather than by invoking binaries by full path.  (This should have been a separate PR; sorry.)  Again, please check if any of the changes in areas you know look suspicious, or test them if possible, in scenarios both where the tool is on the PATH and where the tool is _not_ on PATH and its location is set through config.