### PR TITLE
Support container-level operations on multi-container pods

### DIFF
--- a/src/components/installer/installer.ts
+++ b/src/components/installer/installer.ts
@@ -154,7 +154,7 @@ async function untar(sourceFile: string, destinationFolder: string): Promise<Err
             file: sourceFile
         });
         return { succeeded: true, result: null };
-    } catch /*(e)*/ {
+    } catch (e) {
         return { succeeded: false, error: [ "tar extract failed" ] /* TODO: extract error from exception */ };
     }
 }

--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -158,11 +158,13 @@ export class DebugSession implements IDebugSession {
         }
 
         // Select the target container to attach.
+        // TODO: consolidate with container selection in extension.ts.
         if (containers.length > 1) {
             const containerPickItems: vscode.QuickPickItem[] = containers.map((container) => {
                 return {
-                    label: `${container.name} (${container.image})`,
-                    description: "container",
+                    label: container.name,
+                    description: '',
+                    detail: container.image,
                     name: container.name
                 };
             });


### PR DESCRIPTION
The Terminal, Exec and Logs commands previously always operated only on the first container of a multi-container pod.  This PR prompts for the container if the pod contains multiple containers.  Note that Debug (Attach) and Sync already handled multiple containers (the former on a different code path) - I've rationalised the UI but have not consolidated the Debug (Attach) selection code.

Fixes #203, although the original post there asked for containers to be displayed in the tree view; we can add that too if people feel strongly about it.