### PR TITLE
Fix copy of a resource being appended when resource re-selected

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -620,12 +620,9 @@ function loadKubernetesCore(value: string) {
             doc.uri.fsPath === path.join(vscode.workspace.rootPath || "", `${filename}.${extension}`)
         );
 
-        if (existingDocument) {
-            const existingDocContent = existingDocument.getText();
-            if (equalIgnoringWhitespace(existingDocContent, stdout)) {
-                vscode.window.showTextDocument(existingDocument);
-                return;
-            }
+        if (existingDocument && equalIgnoringWhitespace(existingDocument.getText(), stdout)) {
+            vscode.window.showTextDocument(existingDocument);
+            return;
         }
 
         const filepath = findUniqueName(filename, extension);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -614,7 +614,21 @@ function loadKubernetesCore(value: string) {
         }
 
         const filename = value.replace('/', '-');
-        const filepath = findUniqueName(filename, "json");
+        const extension = "json";
+
+        const existingDocument = vscode.workspace.textDocuments.find((doc) =>
+            doc.uri.fsPath === path.join(vscode.workspace.rootPath || "", `${filename}.${extension}`)
+        );
+
+        if (existingDocument) {
+            const existingDocContent = existingDocument.getText();
+            if (equalIgnoringWhitespace(existingDocContent, stdout)) {
+                vscode.window.showTextDocument(existingDocument);
+                return;
+            }
+        }
+
+        const filepath = findUniqueName(filename, extension);
 
         vscode.workspace.openTextDocument(vscode.Uri.parse('untitled:' + filepath)).then((doc) => {
             const start = new vscode.Position(0, 0),
@@ -646,6 +660,10 @@ function findUniqueName(basename: string, extension: string): string {
             return proposedName;
         }
     }
+}
+
+function equalIgnoringWhitespace(s1: string, s2: string): boolean {
+    return s1.replace(/[\r\n\t ]/g, '') === s2.replace(/[\r\n\t ]/g, '');
 }
 
 function exposeKubernetes() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -614,7 +614,7 @@ function loadKubernetesCore(value: string) {
         }
 
         const filename = value.replace('/', '-');
-        const filepath = path.join(vscode.workspace.rootPath || "", filename + '.json');
+        const filepath = findUniqueName(filename, "json");
 
         vscode.workspace.openTextDocument(vscode.Uri.parse('untitled:' + filepath)).then((doc) => {
             const start = new vscode.Position(0, 0),
@@ -628,6 +628,24 @@ function loadKubernetesCore(value: string) {
             vscode.window.showTextDocument(doc);
         });
     });
+}
+
+function findUniqueName(basename: string, extension: string): string {
+    const exists: (f: string) => boolean = (f) =>
+        fs.existsSync(f) ||
+            vscode.workspace.textDocuments.some((doc) => doc.uri.fsPath === f);
+
+    const basedir = vscode.workspace.rootPath || "";
+    const simpleName = path.join(basedir, `${basename}.${extension}`);
+    if (!exists(simpleName)) {
+        return simpleName;
+    }
+    for (let i = 1; ; i++) {
+        const proposedName = path.join(basedir, `${basename}.${i}.${extension}`);
+        if (!exists(proposedName)) {
+            return proposedName;
+        }
+    }
 }
 
 function exposeKubernetes() {


### PR DESCRIPTION
Consider the following scenario:

1. The user selects a resource in the tree view (or uses the `Load` command).
2. The extension creates an untitled document containing the resource JSON.
3. The user leaves the document open.
4. Later, the user again selects the same resource (or uses the `Load` command to load it again).

At the moment, this has a bug where the second time, the resource JSON is appended to the existing document.  This PR loads each copy of the resource into a new document.  Documents are named e.g. `deployment-foo.json`, `deployment-foo.1.json`, `deployment-foo.2.json`, etc.

A nice enhancement to this would be to compare the current JSON against the content of the existing document, and simply re-show that document if the resource had not changed.  This would avoid creating a lot of temp documents that the user has to close if they are simply browsing around in the tree.  (Alternatively, if the existing document was a temp document, I guess we could overwrite its contents with the new resource state...?)