### PR TITLE
Making Errorable<T> more type safe

### DIFF
--- a/src/components/git/git.ts
+++ b/src/components/git/git.ts
@@ -21,9 +21,9 @@ export class Git {
     public async checkout(commitId: string): Promise<Errorable<void>> {
         const sr = await this.git(`checkout ${commitId}`);
         if (sr.code === 0) {
-            return { succeeded: true, result: null, error: [] };
+            return { succeeded: true, result: null };
         }
-        return { succeeded: false, result: null, error: [ sr.stderr ] };
+        return { succeeded: false, error: [ sr.stderr ] };
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,7 @@ import * as telemetry from './telemetry-helper';
 import * as extensionapi from './extension.api';
 import {dashboardKubernetes} from './components/kubectl/dashboard';
 import {portForwardKubernetes} from './components/kubectl/port-forward';
-import { Errorable } from './wizard';
+import { Errorable, failed } from './wizard';
 import { Git } from './components/git/git';
 import { DebugSession } from './debug/debugSession';
 import { getDebugProviderOfType, getSupportedDebuggerTypes } from './debug/providerRegistry';
@@ -1219,7 +1219,7 @@ async function syncKubernetes(): Promise<void> {
     if (choice === 'OK') {
         const checkoutResult = await git.checkout(commitId);
 
-        if (!checkoutResult.succeeded) {
+        if (failed(checkoutResult)) {
             vscode.window.showErrorMessage(`Error checking out commit ${commitId}: ${checkoutResult.error[0]}`);
         }
     }
@@ -1592,7 +1592,7 @@ async function installDependency(name: string, alreadyGot: boolean, installFunc:
     } else {
         kubeChannel.showOutput(`Installing ${name}...`);
         const result = await installFunc(shell);
-        if (!result.succeeded) {
+        if (failed(result)) {
             kubeChannel.showOutput(`Unable to install ${name}: ${result.error[0]}`);
         }
     }


### PR DESCRIPTION
The `Errorable<T>` interface (which represents the result of an operation that might fail with an error) is currently not type-safe - the `result` and `error` properties are both always present, whether the result was success or failure.  This makes it hard to add strict null checks as it is not always possible to give meaningful values for `result`.  It is safer to define `Errorable<T>` as a union of success and failure cases: this makes TypeScript check for safe usage, and avoids the need to pass null or undefined results in the error case.  This removes an obstacle to strict null checking in a future PR.