### PR TITLE
Yet another run at the "display Kubernetes resource manifests from cluster" problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "preview": true,
     "publisher": "ms-kubernetes-tools",
     "engines": {
-        "vscode": "^1.19.0"
+        "vscode": "^1.23.0"
     },
     "license": "MIT",
     "categories": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -614,7 +614,6 @@ function loadKubernetes(explorerNode?: explorer.ResourceNode) {
 
 function loadKubernetesCore(value: string) {
     const outputFormat = vscode.workspace.getConfiguration('vs-kubernetes')['vs-kubernetes.outputFormat'];
-    const loadCommand = `-o ${outputFormat} get ${value}`;
     const docname = `${value.replace('/', '-')}.${outputFormat}`;
     const nonce = new Date().getTime();
     const uri = `${K8S_RESOURCE_SCHEME}://loadkubernetescore/${docname}?value=${value}&_=${nonce}`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ import { KubernetesCompletionProvider } from "./yaml-support/yaml-snippet";
 import { showWorkspaceFolderPick } from './hostutils';
 import { DraftConfigurationProvider } from './draft/draftConfigurationProvider';
 import { installHelm, installDraft, installKubectl } from './components/installer/installer';
-
+import { KubernetesResourceVirtualFileSystemProvider, K8S_RESOURCE_SCHEME } from './kuberesources.virtualfs';
 
 let explainActive = false;
 let swaggerSpecPromise = null;
@@ -92,6 +92,7 @@ export async function activate(context): Promise<extensionapi.ExtensionAPI> {
     kubectl.checkPresent('activation');
 
     const treeProvider = explorer.create(kubectl, host);
+    const resourceDocProvider = new KubernetesResourceVirtualFileSystemProvider();
     const previewProvider = new HelmTemplatePreviewDocumentProvider();
     const inspectProvider = new HelmInspectDocumentProvider();
     const completionProvider = new HelmTemplateCompletionProvider();
@@ -181,6 +182,9 @@ export async function activate(context): Promise<extensionapi.ExtensionAPI> {
 
         // Tree data providers
         vscode.window.registerTreeDataProvider('extension.vsKubernetesExplorer', treeProvider),
+
+        // Temporarily loaded resource providers
+        vscode.workspace.registerFileSystemProvider(K8S_RESOURCE_SCHEME, resourceDocProvider, { /* TODO: case sensitive? */ }),
 
         // Code lenses
         vscode.languages.registerCodeLensProvider(HELM_REQ_MODE, new HelmRequirementsCodeLensProvider()),

--- a/src/kuberesources.virtualfs.ts
+++ b/src/kuberesources.virtualfs.ts
@@ -27,7 +27,7 @@ export class KubernetesResourceVirtualFileSystemProvider implements FileSystemPr
             type: FileType.File,
             ctime: 0,
             mtime: 0,
-            size: 65536  // TODO: determine if these fields matter
+            size: 65536  // These files don't seem to matter for us
         };
     }
 
@@ -68,7 +68,7 @@ export class KubernetesResourceVirtualFileSystemProvider implements FileSystemPr
     }
 
     delete(uri: Uri, options: { recursive: boolean }): void | Thenable<void> {
-        // no-op for now
+        // no-op
     }
 
     rename(oldUri: Uri, newUri: Uri, options: { overwrite: boolean }): void | Thenable<void> {

--- a/src/kuberesources.virtualfs.ts
+++ b/src/kuberesources.virtualfs.ts
@@ -1,4 +1,4 @@
-import { Uri, FileSystemProvider, FileType, FileStat, FileChangeEvent, Event, EventEmitter, Disposable } from 'vscode';
+import { Uri, FileSystemProvider, FileType, FileStat, FileChangeEvent, Event, EventEmitter, Disposable, workspace } from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as querystring from 'querystring';
@@ -49,8 +49,9 @@ export class KubernetesResourceVirtualFileSystemProvider implements FileSystemPr
     }
 
     async loadResource(uri: Uri): Promise<string> {
+        const outputFormat = workspace.getConfiguration('vs-kubernetes')['vs-kubernetes.outputFormat'];
         const value = querystring.parse(uri.query).value;
-        const sr = await this.kubectl.invokeAsyncWithProgress(`-o json get ${value}`, `Loading ${value}...`);
+        const sr = await this.kubectl.invokeAsyncWithProgress(`-o ${outputFormat} get ${value}`, `Loading ${value}...`);
 
         if (sr.code !== 0) {
             this.host.showErrorMessage('Get command failed: ' + sr.stderr);

--- a/src/kuberesources.virtualfs.ts
+++ b/src/kuberesources.virtualfs.ts
@@ -1,0 +1,52 @@
+import * as vscode from 'vscode';
+import { Uri, FileType } from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+
+export const K8S_RESOURCE_SCHEME = "k8smsx";
+
+export class KubernetesResourceVirtualFileSystemProvider implements vscode.FileSystemProvider {
+
+    private readonly _onDidChangeFile: vscode.EventEmitter<vscode.FileChangeEvent[]> = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
+
+    onDidChangeFile: vscode.Event<vscode.FileChangeEvent[]> = this._onDidChangeFile.event;
+
+    watch(uri, options): vscode.Disposable {
+        return new vscode.Disposable(() => {});
+    }
+
+    stat(uri): vscode.FileStat {
+        return {
+            type: vscode.FileType.File,
+            ctime: 0,
+            mtime: 0,
+            size: 65536  // TODO: determine if these fields matter
+        };
+    }
+
+    readDirectory(uri: Uri): [string, FileType][] | Thenable<[string, FileType][]> {
+        return [];
+    }
+
+    createDirectory(uri: Uri): void | Thenable<void> {
+        // no-op
+    }
+
+    readFile(uri: Uri): Uint8Array | Thenable<Uint8Array> {
+        return new Buffer(`TODO: work out what goes here`, 'utf8');
+    }
+
+    writeFile(uri: Uri, content: Uint8Array, options: { create: boolean, overwrite: boolean }): void | Thenable<void> {
+        // TODO: create directories if necessary (also need to figure out Save As strategy)
+        const fspath = path.join(vscode.workspace.rootPath, uri.fsPath);
+        fs.writeFileSync(fspath, content);
+    }
+
+    delete(uri: Uri, options: { recursive: boolean }): void | Thenable<void> {
+        // no-op for now
+    }
+
+    rename(oldUri: Uri, newUri: Uri, options: { overwrite: boolean }): void | Thenable<void> {
+        // no-op
+    }
+}


### PR DESCRIPTION
When someone does a Load command, or clicks on a resource in the tree to load its JSON/YAML, we want three things:

* The user should be able to close the JSON/YAML and not be bugged with a save prompt (or be left with a temp file in their project)
* The user should be able to save the JSON/YAML
* The user should be able to edit the JSON/YAML and be prompted to save

Loading filesystem documents violated the first bullet, as we had to poke the JSON/YAML into a document which made it dirty and ask to be saved.  Using a TextDocumentContentProvider violated the other two as you couldn't save or edit the document.

This attempt abuses VS Code 1.23 file system providers to try to solve the problem.  The Load command now loads from a URI scheme backed by a FileSystemProvider instead of a TextDocumentContentProvider.  The initial 'read' from this URI gets the resource manifest - it is not dirty as VS Code thinks it has been loaded from an external persistent source.  So it can be closed without being prompted to save.  VS Code allows such documents to be edited and written back.  We abuse the write facility to write the document to the project directory (which is flawed, as VS Code does not identify the k8smsx://foo.json document with the new foo.json file on disk, but may be good enough for the common case).

New documents load as temp windows, so you need to edit/save them or Ctrl+K > Enter them to keep them open after you open the next one.  This however is consistent with the single-click load behaviour of the file tree.  The revisiting experience for a non-temp-window document is perhaps imperfect - if you open say `deploy/foo`, make it stay-open with Ctrl+K > Enter, then re-click `deploy/foo` you will get a second window with the latest `foo` JSON/YAML.  I think this is okay but we may need to refine it.

Testing suggestions, testing experiences, feedback, etc. actively sought!