### PR TITLE
Clarify in cluster wizards that the extension is not confined to Azure

### DIFF
--- a/src/components/clusterprovider/clusterproviderserver.ts
+++ b/src/components/clusterprovider/clusterproviderserver.ts
@@ -84,6 +84,24 @@ function handleGetProviderListHtml(action: clusterproviderregistry.ClusterProvid
     }
     `);
 
+    const otherClustersInfo = action === 'configure' ? `
+    <p>
+    If your type of cluster isn't listed here, don't worry. Just add it to your
+    kubeconfig file normally (see your cloud or cluster documentation), and it will show
+    up in Visual Studio Code automatically. If you're using multiple kubeconfig files,
+    you may need to change the <b>vs-kubernetes &gt; vs-kubernetes.kubeconfig</b> setting
+    to refer to the right file.
+    </p>
+    ` : `
+    <p>
+    If your type of cluster isn't listed here, don't worry. Just create it normally
+    (see your cloud or cluster documentation) and add it to your kubeconfig file, and it will show
+    up in Visual Studio Code automatically. If you're using multiple kubeconfig files,
+    you may need to change the <b>vs-kubernetes &gt; vs-kubernetes.kubeconfig</b> setting
+    to refer to the right file.
+    </p>
+    `;
+
     const html = `<html><body><h1 id='h'>Choose cluster type</h1>
             <style id='styleholder'>
             </style>
@@ -100,6 +118,9 @@ function handleGetProviderListHtml(action: clusterproviderregistry.ClusterProvid
             <p>
             <a id='nextlink' href='${initialUri}' onclick='promptWait()'>Next &gt;</a>
             </p>
+
+            ${otherClustersInfo}
+
             </div></body></html>`;
 
     return html;


### PR DESCRIPTION
We don't want people to look at the Add Existing Cluster or Create Cluster wizards and think that, because those currently only have Azure adapters, the whole extension is Azure only.  So added some text explaining that we work with anything and it just needs to be in your kubeconfig.