### PR TITLE
Kubernetes resource object types

### DIFF
--- a/src/components/clusterprovider/azure/azure.ts
+++ b/src/components/clusterprovider/azure/azure.ts
@@ -3,7 +3,8 @@
 import * as vscode from 'vscode';
 import { Shell } from '../../../shell';
 import { FS } from '../../../fs';
-import { Errorable, ActionResult, fromShellJson, fromShellExitCodeAndStandardError, fromShellExitCodeOnly, succeeded, failed, Diagnostic } from '../../../wizard';
+import { ActionResult, fromShellJson, fromShellExitCodeAndStandardError, fromShellExitCodeOnly, Diagnostic } from '../../../wizard';
+import { Errorable, succeeded, failed } from '../../../errorable';
 import * as compareVersions from 'compare-versions';
 import { sleep } from '../../../sleep';
 

--- a/src/components/clusterprovider/azure/azureclusterprovider.ts
+++ b/src/components/clusterprovider/azure/azureclusterprovider.ts
@@ -3,7 +3,8 @@ import * as restify from 'restify';
 import * as portfinder from 'portfinder';
 import * as clusterproviderregistry from '../clusterproviderregistry';
 import * as azure from './azure';
-import { Errorable, script, styles, formStyles, waitScript, ActionResult, succeeded, failed, Failed, Succeeded, Diagnostic } from '../../../wizard';
+import { script, styles, formStyles, waitScript, ActionResult, Diagnostic } from '../../../wizard';
+import { Errorable, succeeded, failed, Failed, Succeeded } from '../../../errorable';
 
 // HTTP request dispatch
 

--- a/src/components/git/git.ts
+++ b/src/components/git/git.ts
@@ -1,5 +1,5 @@
 import { Shell, ShellResult } from '../../shell';
-import { Errorable } from '../../wizard';
+import { Errorable } from '../../errorable';
 
 export class Git {
     constructor(private readonly shell: Shell) {}

--- a/src/components/installer/installer.ts
+++ b/src/components/installer/installer.ts
@@ -8,7 +8,7 @@ import * as tar from 'tar';
 import * as tmp from 'tmp';
 import * as vscode from 'vscode';
 import { Shell, Platform } from '../../shell';
-import { Errorable, failed, succeeded } from '../../wizard';
+import { Errorable, failed, succeeded } from '../../errorable';
 import { exec } from 'child_process';
 
 export async function installKubectl(shell: Shell): Promise<Errorable<void>> {

--- a/src/components/kubectl/dashboard.ts
+++ b/src/components/kubectl/dashboard.ts
@@ -12,7 +12,7 @@ import { shell } from '../../shell';
 import { create as kubectlCreate, Kubectl } from '../../kubectl';
 import { installDependencies } from '../../extension';
 import { Node, KubernetesCollection, Pod } from '../../kuberesources.objectmodel';
-import { failed } from '../../wizard';
+import { failed } from '../../errorable';
 
 
 const KUBE_DASHBOARD_URL = "http://localhost:8001/ui/";

--- a/src/components/kubectl/dashboard.ts
+++ b/src/components/kubectl/dashboard.ts
@@ -11,6 +11,7 @@ import { host } from '../../host';
 import { shell } from '../../shell';
 import { create as kubectlCreate, Kubectl } from '../../kubectl';
 import { installDependencies } from '../../extension';
+import { Node, KubernetesCollection, Pod } from '../../kuberesources.objectmodel';
 
 
 const KUBE_DASHBOARD_URL = "http://localhost:8001/ui/";
@@ -31,7 +32,7 @@ let terminal: vscode.Terminal;
  */
 async function isAKSCluster (): Promise<boolean> {
     const nodes =  await kubectl.invokeAsync('get nodes -o json');
-    const nodesJson = JSON.parse(nodes.stdout);
+    const nodesJson: KubernetesCollection<Node> = JSON.parse(nodes.stdout);
     const nodeItems = nodesJson.items;
     const nodeCount = nodeItems.length;
 
@@ -46,7 +47,7 @@ async function isAKSCluster (): Promise<boolean> {
     return true;
 }
 
-function _isNodeAKS(node): boolean {
+function _isNodeAKS(node: Node): boolean {
     const name: string = node.metadata.name;
     const roleLabel: string = node.metadata.labels["kubernetes.io/role"];
 
@@ -67,7 +68,7 @@ async function findDashboardPod (): Promise<string> {
     const dashboardResults = await kubectl.invokeAsync(
         "get pod -n kube-system -l k8s-app=kubernetes-dashboard -o json"
     );
-    const resultsJson = JSON.parse(dashboardResults.stdout);
+    const resultsJson: KubernetesCollection<Pod> = JSON.parse(dashboardResults.stdout);
     return resultsJson.items[0].metadata.name;
 }
 

--- a/src/components/kubectl/port-forward.ts
+++ b/src/components/kubectl/port-forward.ts
@@ -9,7 +9,7 @@ import { findAllPods, tryFindKindNameFromEditor, FindPodsResult, installDependen
 import { QuickPickOptions } from 'vscode';
 import * as portFinder from 'portfinder';
 import { Pod } from '../../kuberesources.objectmodel';
-import { succeeded } from '../../wizard';
+import { succeeded } from '../../errorable';
 
 const kubectl = kubectlCreate(host, fs, shell, installDependencies);
 const PORT_FORWARD_TERMINAL = 'kubectl port-forward';

--- a/src/configMap.ts
+++ b/src/configMap.ts
@@ -8,7 +8,7 @@ import { currentNamespace, DataHolder } from './kubectlUtils';
 import { deleteMessageItems, overwriteMessageItems } from './extension';
 import { KubernetesFileObject, KubernetesDataHolderResource, KubernetesExplorer } from './explorer';
 import { allKinds } from './kuberesources';
-import { failed } from './wizard';
+import { failed } from './errorable';
 
 export const uriScheme: string = 'k8sviewfiledata';
 

--- a/src/errorable.ts
+++ b/src/errorable.ts
@@ -1,0 +1,19 @@
+export interface Succeeded<T> {
+    readonly succeeded: true;
+    readonly result: T;
+}
+
+export interface Failed {
+    readonly succeeded: false;
+    readonly error: string[];
+}
+
+export type Errorable<T> = Succeeded<T> | Failed;
+
+export function succeeded<T>(e: Errorable<T>): e is Succeeded<T> {
+    return e.succeeded;
+}
+
+export function failed<T>(e: Errorable<T>): e is Failed {
+    return !e.succeeded;
+}

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -6,6 +6,7 @@ import { Kubectl } from './kubectl';
 import * as kubectlUtils from './kubectlUtils';
 import { Host } from './host';
 import * as kuberesources from './kuberesources';
+import { failed } from './wizard';
 
 export function create(kubectl: Kubectl, host: Host): KubernetesExplorer {
     return new KubernetesExplorer(kubectl, host);
@@ -155,11 +156,11 @@ class KubernetesResourceFolder extends KubernetesFolder {
 
     async getChildren(kubectl: Kubectl, host: Host): Promise<KubernetesObject[]> {
         const childrenLines = await kubectl.asLines("get " + this.kind.abbreviation);
-        if (shell.isShellResult(childrenLines)) {
-            host.showErrorMessage(childrenLines.stderr);
+        if (failed(childrenLines)) {
+            host.showErrorMessage(childrenLines.error[0]);
             return [new DummyObject("Error")];
         }
-        return childrenLines.map((line) => {
+        return childrenLines.result.map((line) => {
             const bits = line.split(' ');
             return new KubernetesResource(this.kind, bits[0]);
         });

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -6,7 +6,7 @@ import { Kubectl } from './kubectl';
 import * as kubectlUtils from './kubectlUtils';
 import { Host } from './host';
 import * as kuberesources from './kuberesources';
-import { failed } from './wizard';
+import { failed } from './errorable';
 
 export function create(kubectl: Kubectl, host: Host): KubernetesExplorer {
     return new KubernetesExplorer(kubectl, host);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,7 @@ import * as telemetry from './telemetry-helper';
 import * as extensionapi from './extension.api';
 import {dashboardKubernetes} from './components/kubectl/dashboard';
 import {portForwardKubernetes} from './components/kubectl/port-forward';
-import { Errorable, failed } from './wizard';
+import { Errorable, failed } from './errorable';
 import { Git } from './components/git/git';
 import { DebugSession } from './debug/debugSession';
 import { getDebugProviderOfType, getSupportedDebuggerTypes } from './debug/providerRegistry';

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -4,7 +4,6 @@ import { Host } from './host';
 import { FS } from './fs';
 import { Shell, ShellHandler, ShellResult } from './shell';
 import * as binutil from './binutil';
-import { shell } from '../test/fakes';
 import { Errorable } from './wizard';
 
 export interface Kubectl {

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -4,7 +4,7 @@ import { Host } from './host';
 import { FS } from './fs';
 import { Shell, ShellHandler, ShellResult } from './shell';
 import * as binutil from './binutil';
-import { Errorable } from './wizard';
+import { Errorable } from './errorable';
 
 export interface Kubectl {
     checkPresent(errorMessageMode: CheckPresentMessageMode): Promise<boolean>;

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -4,6 +4,8 @@ import { Host } from './host';
 import { FS } from './fs';
 import { Shell, ShellHandler, ShellResult } from './shell';
 import * as binutil from './binutil';
+import { shell } from '../test/fakes';
+import { Errorable } from './wizard';
 
 export interface Kubectl {
     checkPresent(errorMessageMode: CheckPresentMessageMode): Promise<boolean>;
@@ -20,7 +22,8 @@ export interface Kubectl {
     invokeInNewTerminal(command: string, terminalName: string, onClose?: (e: Terminal) => any, pipeTo?: string): Promise<Disposable>;
     invokeInSharedTerminal(command: string): Promise<void>;
     runAsTerminal(command: string[], terminalName: string): Promise<void>;
-    asLines(command: string): Promise<string[] | ShellResult>;
+    asLines(command: string): Promise<Errorable<string[]>>;
+    asJson<T>(command: string): Promise<Errorable<T>>;
 }
 
 interface Context {
@@ -71,8 +74,11 @@ class KubectlImpl implements Kubectl {
     runAsTerminal(command: string[], terminalName: string): Promise<void> {
         return runAsTerminal(this.context, command, terminalName);
     }
-    asLines(command: string): Promise<string[] | ShellResult> {
+    asLines(command: string): Promise<Errorable<string[]>> {
         return asLines(this.context, command);
+    }
+    asJson<T>(command: string): Promise<Errorable<T>> {
+        return asJson(this.context, command);
     }
     private getSharedTerminal(): Terminal {
         if (!this.sharedTerminal) {
@@ -210,16 +216,25 @@ function baseKubectlPath(context: Context): string {
     return bin;
 }
 
-async function asLines(context: Context, command: string): Promise<string[] | ShellResult> {
+async function asLines(context: Context, command: string): Promise<Errorable<string[]>> {
     const shellResult = await invokeAsync(context, command);
     if (shellResult.code === 0) {
         let lines = shellResult.stdout.split('\n');
         lines.shift();
         lines = lines.filter((l) => l.length > 0);
-        return lines;
+        return { succeeded: true, result: lines };
 
     }
-    return shellResult;
+    return { succeeded: false, error: [ shellResult.stderr ] };
+}
+
+async function asJson<T>(context: Context, command: string): Promise<Errorable<T>> {
+    const shellResult = await invokeAsync(context, command);
+    if (shellResult.code === 0) {
+        return { succeeded: true, result: JSON.parse(shellResult.stdout.trim()) as T };
+
+    }
+    return { succeeded: false, error: [ shellResult.stderr ] };
 }
 
 function path(context: Context): string {

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -307,11 +307,11 @@ function isTransientPodState(status: string): boolean {
  * @param resourceId the resource id.
  * @return the result as a json object, or undefined if errors happen.
  */
-export async function getResourceAsJson(kubectl: Kubectl, resourceId: string): Promise<any> {
+export async function getResourceAsJson<T extends KubernetesResource | KubernetesCollection<KubernetesResource>>(kubectl: Kubectl, resourceId: string): Promise<T | undefined> {
     const shellResult = await kubectl.invokeAsync(`get ${resourceId} -o json`);
     if (shellResult.code !== 0) {
         vscode.window.showErrorMessage(shellResult.stderr);
-        return;
+        return undefined;
     }
-    return JSON.parse(shellResult.stdout.trim());
+    return JSON.parse(shellResult.stdout.trim()) as T;
 }

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -3,7 +3,7 @@ import { Kubectl } from "./kubectl";
 import { kubeChannel } from "./kubeChannel";
 import { sleep } from "./sleep";
 import { ObjectMeta, KubernetesCollection, DataResource, Namespace, Pod, KubernetesResource } from './kuberesources.objectmodel';
-import { failed } from "./wizard";
+import { failed } from "./errorable";
 
 export interface Cluster {
     readonly name: string;

--- a/src/kuberesources.objectmodel.ts
+++ b/src/kuberesources.objectmodel.ts
@@ -1,0 +1,53 @@
+export interface KubernetesResource {
+    readonly kind: string;
+    readonly metadata: ObjectMeta;
+}
+
+export interface KubernetesCollection<T extends KubernetesResource> {
+    readonly items: T[];
+}
+
+export interface ObjectMeta {
+    readonly name: string;
+    readonly namespace: string;
+    readonly labels?: KeyValuePairs;
+}
+
+export interface KeyValuePairs {
+    readonly [key: string]: string;
+}
+
+export interface DataResource extends KubernetesResource {
+    readonly data: KeyValuePairs;
+}
+
+export interface Namespace extends KubernetesResource {
+}
+
+export interface Container {
+    readonly name: string;
+    readonly image: string;
+}
+
+export interface Pod extends KubernetesResource {
+    readonly spec: PodSpec;
+}
+
+export interface Node extends KubernetesResource {
+}
+
+export interface PodSpec {
+    readonly containers: Container[];
+}
+
+function isObjectMeta(obj: any): obj is ObjectMeta {
+    return obj && obj.name && obj.namespace;
+}
+
+export function isKubernetesResource(obj: any): obj is KubernetesResource {
+    return obj && obj.kind && isObjectMeta(obj.metadata);
+}
+
+export function isPod(obj: any): obj is Pod {
+    return isKubernetesResource(obj) && obj.kind === 'Pod';
+}

--- a/src/kuberesources.objectmodel.ts
+++ b/src/kuberesources.objectmodel.ts
@@ -38,6 +38,7 @@ export interface Node extends KubernetesResource {
 
 export interface PodSpec {
     readonly containers: Container[];
+    readonly nodeName: string;
 }
 
 function isObjectMeta(obj: any): obj is ObjectMeta {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -148,9 +148,3 @@ function pathVariableName(env: any): string {
 function pathEntrySeparator() {
     return isWindows() ? ';' : ':';
 }
-
-
-export function isShellResult<T>(obj: T | ShellResult): obj is ShellResult {
-    const sr = <ShellResult>obj;
-    return sr.code !== undefined || sr.stdout !== undefined || sr.stderr !== undefined;
-}

--- a/src/wizard.ts
+++ b/src/wizard.ts
@@ -1,24 +1,5 @@
 import { ShellResult } from "./shell";
-
-export interface Succeeded<T> {
-    readonly succeeded: true;
-    readonly result: T;
-}
-
-export interface Failed {
-    readonly succeeded: false;
-    readonly error: string[];
-}
-
-export type Errorable<T> = Succeeded<T> | Failed;
-
-export function succeeded<T>(e: Errorable<T>): e is Succeeded<T> {
-    return e.succeeded;
-}
-
-export function failed<T>(e: Errorable<T>): e is Failed {
-    return !e.succeeded;
-}
+import { Errorable } from './errorable';
 
 export interface ActionResult<T> {
     readonly actionDescription: string;


### PR DESCRIPTION
This PR defines some interfaces for Kubernetes resources and collections, so that when we work with them (e.g. after loading them from JSON) we can work with them in a safer way.  It's motivated by having to hold 'what is this `any` representing... is it a Foo or some internal type containing interesting data from a Foo... what fields does it actually have... etc.' in my head.  The main additions are the resource interfaces themselves (which contain only the fields we're interested in, but that's okay, they don't need to be comprehensive) and the `kubectl.asJson` method which encapsulates the JSON parsing and type assertion (and should be used in preference to `invokeAsync` when we are requesting JSON for materialisation as an object).

These changes don't prevent maintainers from using `any` where appropriate - I just find that capturing resource shapes helps me to avoid errors and reason more efficiently.

Making these changes also revealed some cases where resource loading code wasn't dealing with the possibility of failure, e.g. `kubectl` errors; these have been fixed.