### PR TITLE
Helm templates can live in subdirectories under /templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -632,7 +632,9 @@
                     "Chart.yaml",
                     "requirements.yaml",
                     "**/templates/*.yaml",
-                    "**/templates/*.tpl"
+                    "**/templates/*.tpl",
+                    "**/templates/**/*.yaml",
+                    "**/templates/**/*.tpl"
                 ],
                 "configuration": "./language-configuration.json"
             },


### PR DESCRIPTION
When a Helm template YAML file is not directly in `.../templates`, but instead in a subdirectory (e.g. `.../templates/my-template`, it is currently identified as the YAML filetype rather than the helm-template file type.  This PR treats `.yaml` and `.tpl` files _anywhere_ under the `templates` directory as file type helm-template.

Fixes #225.