### PR TITLE
When creating cluster, generate SSH keys if missing

### DIFF
--- a/src/components/clusterprovider/azure/azureclusterprovider.ts
+++ b/src/components/clusterprovider/azure/azureclusterprovider.ts
@@ -151,7 +151,7 @@ function formPage(fd: FormData): string {
 // Pages for the various wizard steps
 
 async function promptForSubscription(previousData: any, context: azure.Context, action: clusterproviderregistry.ClusterProviderAction, nextStep: string): Promise<string> {
-    const subscriptionList = await azure.getSubscriptionList(context, previousData.id);
+    const subscriptionList = await azure.getSubscriptionList(context);
     if (!subscriptionList.result.succeeded) {
         return renderCliError('PromptForSubscription', subscriptionList);
     }


### PR DESCRIPTION
This is a tale of shame and ignorance.

The existing Azure Create Cluster code assumes the user has already generated SSH keys.  If not, the Azure CLI fails with an error telling you to pass `--generate-ssh-keys`.  I've been improving the checks around this but they still seem to be unreliable, but I didn't want to pass `--generate-ssh-keys` because I didn't want to clobber any existing SSH keys or to create new ones that the user didn't know about.

It turns out, as the `az aks create` documentation _clearly states, Ivan, very clearly_, that the generate option does NOT clobber existing keys, does not even generate new keys if existing ones already, er, exist, and even emits a helpful message WHICH THE EXTENSION WOULD ALREADY DISPLAY warning the user if new keys were created and where to find them.

So I have deleted all that pre-checking crap and added the generate option unconditionally.  If only shame and ignorance could be deleted so easily!  If only!

Anyway, fixes #229.