### PR TITLE
Update growl to 1.10.x, whose security vulns remain unknown so far

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -687,9 +687,9 @@
             }
         },
         "commander": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-            "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+            "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
             "dev": true
         },
         "compare-versions": {
@@ -999,9 +999,9 @@
             "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc="
         },
         "diff": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-            "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+            "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
             "dev": true
         },
         "docker-file-parser": {
@@ -1753,9 +1753,9 @@
             "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
         },
         "growl": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-            "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+            "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
             "dev": true
         },
         "gulp": {
@@ -2912,30 +2912,6 @@
                 "is-object": "1.0.1"
             }
         },
-        "jade": {
-            "version": "0.26.3",
-            "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-            "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-            "dev": true,
-            "requires": {
-                "commander": "0.6.1",
-                "mkdirp": "0.3.0"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-                    "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
-                    "dev": true
-                },
-                "mkdirp": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-                    "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-                    "dev": true
-                }
-            }
-        },
         "js-tokens": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -3645,42 +3621,43 @@
             }
         },
         "mocha": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-            "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+            "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
             "dev": true,
             "requires": {
-                "commander": "2.3.0",
-                "debug": "2.2.0",
-                "diff": "1.4.0",
-                "escape-string-regexp": "1.0.2",
-                "glob": "3.2.11",
-                "growl": "1.9.2",
-                "jade": "0.26.3",
+                "browser-stdout": "1.3.0",
+                "commander": "2.11.0",
+                "debug": "3.1.0",
+                "diff": "3.3.1",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.2",
+                "growl": "1.10.3",
+                "he": "1.1.1",
                 "mkdirp": "0.5.1",
-                "supports-color": "1.2.0",
-                "to-iso-string": "0.0.2"
+                "supports-color": "4.4.0"
             },
             "dependencies": {
-                "glob": {
-                    "version": "3.2.11",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                    "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "minimatch": "0.3.0"
+                        "ms": "2.0.0"
                     }
                 },
-                "minimatch": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                    "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
-                    }
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
@@ -5223,10 +5200,13 @@
             }
         },
         "supports-color": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-            "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
-            "dev": true
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+            "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+            "dev": true,
+            "requires": {
+                "has-flag": "2.0.0"
+            }
         },
         "tar": {
             "version": "4.4.1",
@@ -5332,12 +5312,6 @@
                     }
                 }
             }
-        },
-        "to-iso-string": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
-            "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
-            "dev": true
         },
         "to-object-path": {
             "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -800,7 +800,7 @@
         "@types/node": "^6.0.40",
         "gulp": "^3.9.1",
         "gulp-tslint": "^8.1.2",
-        "mocha": "^2.3.3",
+        "mocha": "^4.1.0",
         "tslint": "^5.9.1",
         "typescript": "^2.2.32",
         "vscode": "^1.0.17"


### PR DESCRIPTION
We have a 'known vulnerable dependency' flag from GitHub for growl 1.9.x.  I don't think the vulnerability is an issue for us, but we want to make it go away.

The naughty version is brought in by an old version of mocha, so I upgraded that as well (to a version consistent with the vscode package).