### PR TITLE
Fix limitations on Apply command

### DIFF
--- a/src/components/kubectl/port-forward.ts
+++ b/src/components/kubectl/port-forward.ts
@@ -183,18 +183,18 @@ async function findPortForwardablePods (): Promise<PortForwardFindPodsResult> {
     let kindFromEditor = tryFindKindNameFromEditor();
 
     // Find the pod type from the open editor.
-    if (kindFromEditor !== null) {
+    if (succeeded(kindFromEditor)) {
 
         // Not a pod type, so not port-forwardable, fallback to looking
         // up all pods.
-        if (kindFromEditor.kind !== 'pods' && kindFromEditor.kind !== 'pod') {
+        if (kindFromEditor.result.kind !== 'pods' && kindFromEditor.result.kind !== 'pod') {
             return await findAllPods();
         }
 
         return {
             succeeded: true,
-            pod: kindFromEditor.resourceName,
-            namespace: kindFromEditor.namespace,
+            pod: kindFromEditor.result.resourceName,
+            namespace: kindFromEditor.result.namespace,
             fromOpenDocument: true
         };
     }


### PR DESCRIPTION
This PR fixes a couple of issues with the Apply command:

* You can't Apply a multi-resource YAML.  This is because Apply wants to show you a diff against the existing cluster configuration first, and we don't yet handle diffing multiple objects.  The fix for this is to cheat: we now put up a warning saying "hey we can't show you what's going to change but would you like to go ahead and apply it anyway?"

* You can't Apply changes made to a resource loaded via Load.  There is a workaround, to save the YAML, close it, open it from the file system and make the changes and apply them; but this PR enables the much simpler workflow of "Load > edit text > Apply".

This PR involved some slightly fiddly and hard to test changes to some pretty old code, so it might be best to consider it WIP for now - would very much appreciate eyes on it though, and suggestions for improving and unifying code paths.  It feels like it's still more fiddly than it ought to be.  If anyone fancies pulling it and trying to break it, that would be great too.

Fixes #218 (hopefully) and #234.