### PR TITLE
Fix diff and apply error when metadata.namespace not present

### DIFF
--- a/src/components/kubectl/port-forward.ts
+++ b/src/components/kubectl/port-forward.ts
@@ -25,7 +25,7 @@ interface PodFromDocument {
     readonly succeeded: true;
     readonly pod: string;
     readonly fromOpenDocument: true;
-    readonly namespace: string;
+    readonly namespace?: string;
 }
 
 type PortForwardFindPodsResult = PodFromDocument | FindPodsResult;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -838,7 +838,7 @@ export function tryFindKindNameFromEditor(): ResourceKindName {
 }
 
 interface ResourceKindName {
-    readonly namespace: string;
+    readonly namespace?: string;
     readonly kind: string;
     readonly resourceName: string;
 }
@@ -1013,7 +1013,7 @@ enum PodSelectionScope {
     All,
 }
 
-async function selectPod(scope: PodSelectionScope, fallback: PodSelectionFallback): Promise<any | null> {
+async function selectPod(scope: PodSelectionScope, fallback: PodSelectionFallback): Promise<Pod | null> {
     const findPodsResult = scope === PodSelectionScope.App ? await findPodsForApp() : await findAllPods();
 
     if (!findPodsResult.succeeded) {
@@ -1035,7 +1035,7 @@ async function selectPod(scope: PodSelectionScope, fallback: PodSelectionFallbac
     }
 
     const pickItems = podList.map((element) => { return {
-        label: `${element.metadata.namespace}/${element.metadata.name}`,
+        label: `${element.metadata.namespace || "default"}/${element.metadata.name}`,
         description: '',
         pod: element
     };});
@@ -1131,6 +1131,14 @@ interface PodSummary {
     };
 }
 
+function summary(pod: Pod): PodSummary {
+    return {
+        name: pod.metadata.name,
+        namespace: pod.metadata.namespace,
+        spec: pod.spec
+    };
+}
+
 async function selectContainerForPod(pod: PodSummary): Promise<Container | null> {
     if (!pod) {
         return null;
@@ -1199,7 +1207,7 @@ async function execKubernetesCore(isTerminal): Promise<void> {
         return;
     }
 
-    const container = await selectContainerForPod(pod.metadata);
+    const container = await selectContainerForPod(summary(pod));
 
     if (!container) {
         return;
@@ -1245,7 +1253,7 @@ async function syncKubernetes(): Promise<void> {
         return;
     }
 
-    const container = await selectContainerForPod(pod);
+    const container = await selectContainerForPod(summary(pod));
     if (!container) {
         return;
     }

--- a/src/kuberesources.objectmodel.ts
+++ b/src/kuberesources.objectmodel.ts
@@ -9,7 +9,7 @@ export interface KubernetesCollection<T extends KubernetesResource> {
 
 export interface ObjectMeta {
     readonly name: string;
-    readonly namespace: string;
+    readonly namespace?: string;
     readonly labels?: KeyValuePairs;
 }
 
@@ -42,7 +42,7 @@ export interface PodSpec {
 }
 
 function isObjectMeta(obj: any): obj is ObjectMeta {
-    return obj && obj.name && obj.namespace;
+    return obj && obj.name;
 }
 
 export function isKubernetesResource(obj: any): obj is KubernetesResource {


### PR DESCRIPTION
The Kubernetes API docs allow you to have a spec without a `metadata.namespace` element, and say this is equivalent to the `default` namespace (https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#objectmeta-v1-meta).  We had done some improvements around supporting namespaces which incorrectly assumed that the namespace would always be present; this need not be the case.

Fixes #248.