### PR TITLE
Fixed invalid 'chart not found' message if YAML file open on startup

### DIFF
--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -230,7 +230,9 @@ export function pickChartForFile(file: string, options: PickChartUIOptions, fn) 
                 });
 
                 if (paths.length == 0) {
-                    vscode.window.showErrorMessage("Chart not found for " + file);
+                    if (options.warnIfNoCharts) {
+                        vscode.window.showErrorMessage("Chart not found for " + file);
+                    }
                     return;
                 }
 


### PR DESCRIPTION
A user (stop looking shifty, @chzbrgr71, we see you) reported that the accursed and thrice-accursed 'chart not found' message was still popping up and making his kittens sad.  This also made me sad because I had fixed the damn thing _at least_ once already and I did not want to spend my twilight years suppressing the same message in ever more creative ways.  Hours of pinpoint debugging revealed that the error occurred under the wild and extreme conditions of having a YAML file open at extension startup.  This took a different code path from the previous fix, on which I failed to check the vital "stop bugging Brian with annoying messages" flag.  This PR checks the flag, and occasionally mutters darkly to itself about mysterious enemies.