### PR TITLE
Show Helm releases in cluster tree view

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "onCommand:extension.helmInsertReq",
         "onCommand:extension.helmDepUp",
         "onCommand:extension.helmInspectValues",
+        "onCommand:extension.helmGet",
         "onCommand:extension.draftVersion",
         "onCommand:extension.draftCreate",
         "onCommand:extension.draftUp",
@@ -434,6 +435,10 @@
                     "when": "view == extension.vsKubernetesExplorer"
                 },
                 {
+                    "command": "extension.helmGet",
+                    "when": "view == extension.vsKubernetesExplorer"
+                },
+                {
                     "command": "extension.helmInspectValues",
                     "when": "filesExplorerFocus"
                 }
@@ -679,6 +684,12 @@
                 "command": "extension.helmCreate",
                 "title": "Create Chart",
                 "description": "Create a new Helm Chart",
+                "category": "Helm"
+            },
+            {
+                "command": "extension.helmGet",
+                "title": "Get Release",
+                "description": "Get a Helm release from the cluster",
                 "category": "Helm"
             }
         ],

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -403,7 +403,7 @@ class HelmReleaseResource implements KubernetesObject {
     }
 
     getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem> {
-        let treeItem = new vscode.TreeItem(this.name, vscode.TreeItemCollapsibleState.None);
+        const treeItem = new vscode.TreeItem(this.name, vscode.TreeItemCollapsibleState.None);
         treeItem.command = {
             command: "extension.helmGet",
             title: "Get",

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -391,7 +391,7 @@ export class KubernetesFileObject implements KubernetesObject {
     }
 }
 
-class HelmReleaseNode implements KubernetesObject {
+class HelmReleaseResource implements KubernetesObject {
     readonly id: string;
 
     constructor(readonly name: string) {
@@ -401,8 +401,16 @@ class HelmReleaseNode implements KubernetesObject {
     getChildren(kubectl: Kubectl, host: Host): vscode.ProviderResult<KubernetesObject[]> {
         return [];
     }
+
     getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem> {
-        return new vscode.TreeItem(this.name, vscode.TreeItemCollapsibleState.None);
+        let treeItem = new vscode.TreeItem(this.name, vscode.TreeItemCollapsibleState.None);
+        treeItem.command = {
+            command: "extension.helmGet",
+            title: "Get",
+            arguments: [this]
+        };
+        treeItem.contextValue = "vsKubernetes.helmRelease";
+        return treeItem;
     }
 }
 
@@ -423,8 +431,8 @@ class HelmReleasesFolder extends KubernetesResourceFolder {
 
         const lines = sr.stdout.split('\n').map((s) => s.trim());
         const releaseLines = lines.slice(1).filter((l) => l.length > 0);
-        const names = releaseLines.map((l) => l.split(' ')).map((a) => a[0]);
-        const nodes = names.map((n) => new HelmReleaseNode(n));
+        const names = releaseLines.map((l) => l.split('\t')).map((a) => a[0].trim());
+        const nodes = names.map((n) => new HelmReleaseResource(n));
         return nodes;
     }
 }

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -424,14 +424,15 @@ class HelmReleasesFolder extends KubernetesResourceFolder {
         if (!helmexec.ensureHelm(helmexec.EnsureMode.Silent)) {
             return [new DummyObject("Helm client is not installed")];
         }
-        const sr = await helmexec.helmExecAsync("list"); // TODO: --all?
+        const sr = await helmexec.helmExecAsync("list --short --max 0");
         if (sr.code !== 0) {
             return [new DummyObject("Helm list error")];
         }
 
-        const lines = sr.stdout.split('\n').map((s) => s.trim());
-        const releaseLines = lines.slice(1).filter((l) => l.length > 0);
-        const names = releaseLines.map((l) => l.split('\t')).map((a) => a[0].trim());
+        const names = sr.stdout
+                        .split('\n')
+                        .map((s) => s.trim())
+                        .filter((l) => l.length > 0);
         const nodes = names.map((n) => new HelmReleaseResource(n));
         return nodes;
     }

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -424,7 +424,11 @@ class HelmReleasesFolder extends KubernetesResourceFolder {
         if (!helmexec.ensureHelm(helmexec.EnsureMode.Silent)) {
             return [new DummyObject("Helm client is not installed")];
         }
-        const sr = await helmexec.helmExecAsync("list --short --max 0");
+
+        const currentNS = await kubectlUtils.currentNamespace(kubectl);
+        const nsarg = currentNS ? `--namespace ${currentNS}` : "";
+
+        const sr = await helmexec.helmExecAsync(`list --short --max 0 ${nsarg}`);
         if (sr.code !== 0) {
             return [new DummyObject("Helm list error")];
         }

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -426,18 +426,13 @@ class HelmReleasesFolder extends KubernetesResourceFolder {
         }
 
         const currentNS = await kubectlUtils.currentNamespace(kubectl);
-        const nsarg = currentNS ? `--namespace ${currentNS}` : "";
 
-        const sr = await helmexec.helmExecAsync(`list --short --max 0 ${nsarg}`);
-        if (sr.code !== 0) {
-            return [new DummyObject("Helm list error")];
+        const releases = await helmexec.helmListAll(currentNS);
+
+        if (failed(releases)) {
+            return [new DummyObject(releases.error[0])];
         }
 
-        const names = sr.stdout
-                        .split('\n')
-                        .map((s) => s.trim())
-                        .filter((l) => l.length > 0);
-        const nodes = names.map((n) => new HelmReleaseResource(n));
-        return nodes;
+        return releases.result.map((r) => new HelmReleaseResource(r));
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,7 +60,7 @@ import { KubernetesCompletionProvider } from "./yaml-support/yaml-snippet";
 import { showWorkspaceFolderPick } from './hostutils';
 import { DraftConfigurationProvider } from './draft/draftConfigurationProvider';
 import { installHelm, installDraft, installKubectl } from './components/installer/installer';
-import { KubernetesResourceVirtualFileSystemProvider, K8S_RESOURCE_SCHEME } from './kuberesources.virtualfs';
+import { KubernetesResourceVirtualFileSystemProvider, K8S_RESOURCE_SCHEME, KUBECTL_RESOURCE_AUTHORITY } from './kuberesources.virtualfs';
 import { Container, isPod, isKubernetesResource, KubernetesCollection, Pod, KubernetesResource } from './kuberesources.objectmodel';
 
 let explainActive = false;
@@ -644,7 +644,7 @@ function loadKubernetesCore(namespace: string | null, value: string) {
     const docname = `${value.replace('/', '-')}.${outputFormat}`;
     const nonce = new Date().getTime();
     const nsquery = namespace ? `ns=${namespace}&` : '';
-    const uri = `${K8S_RESOURCE_SCHEME}://loadkubernetescore/${docname}?${nsquery}value=${value}&_=${nonce}`;
+    const uri = `${K8S_RESOURCE_SCHEME}://${KUBECTL_RESOURCE_AUTHORITY}/${docname}?${nsquery}value=${value}&_=${nonce}`;
     vscode.workspace.openTextDocument(vscode.Uri.parse(uri)).then((doc) => {
         if (doc) {
             vscode.window.showTextDocument(doc);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -169,6 +169,7 @@ export async function activate(context): Promise<extensionapi.ExtensionAPI> {
         registerCommand('extension.helmDepUp', helmexec.helmDepUp),
         registerCommand('extension.helmInsertReq', helmexec.insertRequirement),
         registerCommand('extension.helmCreate', helmexec.helmCreate),
+        registerCommand('extension.helmGet', helmexec.helmGet),
 
         // Commands - Draft
         registerCommand('extension.draftVersion', execDraftVersion),

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -6,6 +6,7 @@ import * as YAML from 'yamljs';
 import * as _ from 'lodash';
 import * as fs from "fs";
 import * as extension from './extension';
+import * as explorer from './explorer';
 import * as helm from './helm';
 import { showWorkspaceFolderPick } from './hostutils';
 import { shell as sh, ShellResult } from './shell';
@@ -140,6 +141,20 @@ export function helmDryRun() {
                 logger.log("⎈⎈⎈ INSTALL FAILED");
             }
         });
+    });
+}
+
+export function helmGet(resourceNode: explorer.ResourceNode) {
+    if (!resourceNode) {
+        return;
+    }
+    const releaseName = resourceNode.id.split(':')[1];
+    helmExec(`get ${releaseName}`, (code, stdout, stderr) => {
+        if (code !== 0) {
+            vscode.window.showErrorMessage(`Helm get failed: ${stderr}`);
+            return;
+        }
+        console.log(stdout);
     });
 }
 

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -286,7 +286,7 @@ export async function helmExecAsync(args: string): Promise<ShellResult> {
     }
     const configuredBin: string | undefined = vscode.workspace.getConfiguration('vs-kubernetes')['vs-kubernetes.helm-path'];
     const bin = configuredBin ? `"${configuredBin}"` : "helm";
-    const cmd = bin + " " + args;
+    const cmd = `${bin} ${args}`;
     return await sh.exec(cmd);
 }
 
@@ -297,7 +297,7 @@ export async function helmListAll(namespace?: string): Promise<Errorable<string[
         return { succeeded: false, error: [ 'Helm not installed' ] };
     }
 
-    let releases: string[] = [];
+    const releases: string[] = [];
     let offset: string | null = null;
 
     do {
@@ -309,7 +309,7 @@ export async function helmListAll(namespace?: string): Promise<Errorable<string[
             return { succeeded: false, error: [ 'Helm list error' ] };
         }
 
-        let lines = sr.stdout.split('\n')
+        const lines = sr.stdout.split('\n')
                                .map((s) => s.trim())
                                .filter((l) => l.length > 0);
         if (lines.length > 0) {

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -294,7 +294,7 @@ const HELM_PAGING_PREFIX = "next:";
 
 export async function helmListAll(namespace?: string): Promise<Errorable<string[]>> {
     if (!ensureHelm(EnsureMode.Alert)) {
-        return { succeeded: false, error: [ 'Helm not installed' ] };
+        return { succeeded: false, error: [ "Helm client is not installed" ] };
     }
 
     const releases: string[] = [];

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -10,7 +10,7 @@ import * as explorer from './explorer';
 import * as helm from './helm';
 import { showWorkspaceFolderPick } from './hostutils';
 import { shell as sh, ShellResult } from './shell';
-import { K8S_RESOURCE_SCHEME } from './kuberesources.virtualfs';
+import { K8S_RESOURCE_SCHEME, HELM_RESOURCE_AUTHORITY } from './kuberesources.virtualfs';
 
 export interface PickChartUIOptions {
     readonly warnIfNoCharts: boolean;
@@ -152,7 +152,7 @@ export function helmGet(resourceNode: explorer.ResourceNode) {
     const releaseName = resourceNode.id.split(':')[1];
     const docname = `helmrelease-${releaseName}.txt`;
     const nonce = new Date().getTime();
-    const uri = `${K8S_RESOURCE_SCHEME}://helmget/${docname}?value=${releaseName}&_=${nonce}`;
+    const uri = `${K8S_RESOURCE_SCHEME}://${HELM_RESOURCE_AUTHORITY}/${docname}?value=${releaseName}&_=${nonce}`;
     vscode.workspace.openTextDocument(vscode.Uri.parse(uri)).then((doc) => {
         if (doc) {
             vscode.window.showTextDocument(doc);

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -8,6 +8,7 @@ import * as fs from "fs";
 import * as extension from './extension';
 import * as helm from './helm';
 import { showWorkspaceFolderPick } from './hostutils';
+import { shell as sh, ShellResult } from './shell';
 
 export interface PickChartUIOptions {
     readonly warnIfNoCharts: boolean;
@@ -258,6 +259,17 @@ export function helmExec(args: string, fn) {
     const bin = configuredBin ? `"${configuredBin}"` : "helm";
     const cmd = `${bin} ${args}`;
     shell.exec(cmd, fn);
+}
+
+export async function helmExecAsync(args: string): Promise<ShellResult> {
+    // TODO: deduplicate with helmExec
+    if (!ensureHelm(EnsureMode.Alert)) {
+        return { code: -1, stdout: "", stderr: "" };
+    }
+    const configuredBin: string | undefined = vscode.workspace.getConfiguration('vs-kubernetes')['vs-kubernetes.helm-path'];
+    const bin = configuredBin ? `"${configuredBin}"` : "helm";
+    const cmd = bin + " " + args;
+    return await sh.exec(cmd);
 }
 
 export function ensureHelm(mode: EnsureMode) {

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -10,6 +10,7 @@ import * as explorer from './explorer';
 import * as helm from './helm';
 import { showWorkspaceFolderPick } from './hostutils';
 import { shell as sh, ShellResult } from './shell';
+import { K8S_RESOURCE_SCHEME } from './kuberesources.virtualfs';
 
 export interface PickChartUIOptions {
     readonly warnIfNoCharts: boolean;
@@ -149,12 +150,13 @@ export function helmGet(resourceNode: explorer.ResourceNode) {
         return;
     }
     const releaseName = resourceNode.id.split(':')[1];
-    helmExec(`get ${releaseName}`, (code, stdout, stderr) => {
-        if (code !== 0) {
-            vscode.window.showErrorMessage(`Helm get failed: ${stderr}`);
-            return;
+    const docname = `helmrelease-${releaseName}.txt`;
+    const nonce = new Date().getTime();
+    const uri = `${K8S_RESOURCE_SCHEME}://helmget/${docname}?value=${releaseName}&_=${nonce}`;
+    vscode.workspace.openTextDocument(vscode.Uri.parse(uri)).then((doc) => {
+        if (doc) {
+            vscode.window.showTextDocument(doc);
         }
-        console.log(stdout);
     });
 }
 

--- a/src/kuberesources.virtualfs.ts
+++ b/src/kuberesources.virtualfs.ts
@@ -58,9 +58,9 @@ export class KubernetesResourceVirtualFileSystemProvider implements FileSystemPr
         const outputFormat = workspace.getConfiguration('vs-kubernetes')['vs-kubernetes.outputFormat'];
         const value = query.value;
         const ns = query.ns;
-        const loadMode = uri.authority;
+        const resourceAuthority = uri.authority;
 
-        const sr = await this.execLoadResource(loadMode, ns, value, outputFormat);
+        const sr = await this.execLoadResource(resourceAuthority, ns, value, outputFormat);
 
         if (sr.code !== 0) {
             this.host.showErrorMessage('Get command failed: ' + sr.stderr);
@@ -70,15 +70,15 @@ export class KubernetesResourceVirtualFileSystemProvider implements FileSystemPr
         return sr.stdout;
     }
 
-    async execLoadResource(loadMode: string, ns: string | undefined, value: string, outputFormat: string): Promise<ShellResult> {
-        switch (loadMode) {
+    async execLoadResource(resourceAuthority: string, ns: string | undefined, value: string, outputFormat: string): Promise<ShellResult> {
+        switch (resourceAuthority) {
             case KUBECTL_RESOURCE_AUTHORITY:
                 const nsarg = ns ? `--namespace ${ns}` : '';
                 return await this.kubectl.invokeAsyncWithProgress(`-o ${outputFormat} ${nsarg} get ${value}`, `Loading ${value}...`);
             case HELM_RESOURCE_AUTHORITY:
                 return await helmExecAsync(`get ${value}`);
             default:
-                return { code: -99, stdout: '', stderr: `Internal error: please raise an issue with the error code InvalidObjectLoadURI and report authority ${loadMode}.` };
+                return { code: -99, stdout: '', stderr: `Internal error: please raise an issue with the error code InvalidObjectLoadURI and report authority ${resourceAuthority}.` };
         }
     }
 


### PR DESCRIPTION
This adds a new top-level 'Helm Releases' node to clusters in the tree view.  At the moment there's not much you can do with this - viewing the node displays the `helm get` output as a text file, and that's it.

This is currently work in progress - it needs to be tested with large numbers of releases, and I would like feedback on whether to present the returned file as YAML (which it isn't, not really, but it colourises okay if you pretend it is) or as plain text.  Other feedback / suggestions welcome (but may be deferred to subsequent enhancements).

Fixes #245.