### PR TITLE
Display context name instead of cluster name in tree view

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
             "kubernetesView": [
                 {
                     "id": "extension.vsKubernetesExplorer",
-                    "name": "Kubernetes"
+                    "name": "Clusters"
                 }
             ]
         },

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -68,8 +68,8 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<KubernetesObj
     }
 
     private async getClusters(): Promise<KubernetesObject[]> {
-        const clusters = await kubectlUtils.getClusters(this.kubectl);
-        return clusters.map((cluster) => new KubernetesCluster(cluster.name, cluster));
+        const contexts = await kubectlUtils.getContexts(this.kubectl);
+        return contexts.map((context) => new KubernetesContext(context.contextName, context));
     }
 }
 
@@ -90,8 +90,8 @@ class DummyObject implements KubernetesObject {
     }
 }
 
-class KubernetesCluster implements KubernetesObject {
-    constructor(readonly id: string, readonly metadata?: any) {
+class KubernetesContext implements KubernetesObject {
+    constructor(readonly id: string, readonly metadata?: kubectlUtils.KubectlContext) {
     }
 
     getChildren(kubectl: Kubectl, host: Host): vscode.ProviderResult<KubernetesObject[]> {
@@ -113,6 +113,7 @@ class KubernetesCluster implements KubernetesObject {
             treeItem.collapsibleState = vscode.TreeItemCollapsibleState.None;
             treeItem.contextValue += ".inactive";
         }
+        treeItem.tooltip = `${this.metadata.contextName}\nCluster: ${this.metadata.clusterName}`;
         return treeItem;
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1700,6 +1700,9 @@ async function createClusterKubernetes() {
 }
 
 async function useContextKubernetes(explorerNode: explorer.KubernetesObject) {
+    if (!explorerNode || !explorerNode.metadata) {
+        return;
+    }
     const contextObj = explorerNode.metadata as kubectlUtils.KubectlContext;
     const targetContext = contextObj.contextName;
     const shellResult = await kubectl.invokeAsync(`config use-context ${targetContext}`);
@@ -1711,17 +1714,19 @@ async function useContextKubernetes(explorerNode: explorer.KubernetesObject) {
 }
 
 async function clusterInfoKubernetes(explorerNode: explorer.KubernetesObject) {
-    const contextObj = explorerNode.metadata as kubectlUtils.KubectlContext;
-    const targetContext = contextObj.contextName;
     kubectl.invokeInSharedTerminal("cluster-info");
 }
 
 async function deleteContextKubernetes(explorerNode: explorer.KubernetesObject) {
-    const answer = await vscode.window.showWarningMessage(`Do you want to delete the cluster '${explorerNode.id}' from the kubeconfig?`, ...deleteMessageItems);
+    if (!explorerNode || !explorerNode.metadata) {
+        return;
+    }
+    const contextObj = explorerNode.metadata as kubectlUtils.KubectlContext;
+    const answer = await vscode.window.showWarningMessage(`Do you want to delete the cluster '${contextObj.contextName}' from the kubeconfig?`, ...deleteMessageItems);
     if (answer.isCloseAffordance) {
         return;
     }
-    if (await kubectlUtils.deleteCluster(kubectl, explorerNode.metadata)) {
+    if (await kubectlUtils.deleteCluster(kubectl, contextObj)) {
         refreshExplorer();
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1700,7 +1700,8 @@ async function createClusterKubernetes() {
 }
 
 async function useContextKubernetes(explorerNode: explorer.KubernetesObject) {
-    const targetContext = explorerNode.metadata.context;
+    const contextObj = explorerNode.metadata as kubectlUtils.KubectlContext;
+    const targetContext = contextObj.contextName;
     const shellResult = await kubectl.invokeAsync(`config use-context ${targetContext}`);
     if (shellResult.code === 0) {
         refreshExplorer();
@@ -1710,7 +1711,8 @@ async function useContextKubernetes(explorerNode: explorer.KubernetesObject) {
 }
 
 async function clusterInfoKubernetes(explorerNode: explorer.KubernetesObject) {
-    const targetContext = explorerNode.metadata.context;
+    const contextObj = explorerNode.metadata as kubectlUtils.KubectlContext;
+    const targetContext = contextObj.contextName;
     kubectl.invokeInSharedTerminal("cluster-info");
 }
 

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -5,10 +5,10 @@ import { sleep } from "./sleep";
 import { ObjectMeta, KubernetesCollection, DataResource, Namespace, Pod, KubernetesResource } from './kuberesources.objectmodel';
 import { failed } from "./errorable";
 
-export interface Cluster {
-    readonly name: string;
-    readonly context: string;
-    readonly user: string;
+export interface KubectlContext {
+    readonly clusterName: string;
+    readonly contextName: string;
+    readonly userName: string;
     readonly active: boolean;
 }
 
@@ -58,7 +58,7 @@ export async function getCurrentClusterConfig(kubectl: Kubectl): Promise<Cluster
     };
 }
 
-export async function getClusters(kubectl: Kubectl): Promise<Cluster[]> {
+export async function getContexts(kubectl: Kubectl): Promise<KubectlContext[]> {
     const kubectlConfig = await getKubeconfig(kubectl);
     if (!kubectlConfig) {
         return [];
@@ -67,37 +67,37 @@ export async function getClusters(kubectl: Kubectl): Promise<Cluster[]> {
     const contexts = kubectlConfig.contexts;
     return contexts.map((c) => {
         return {
-            name: c.context.cluster,
-            context: c.name,
-            user: c.context.user,
+            clusterName: c.context.cluster,
+            contextName: c.name,
+            userName: c.context.user,
             active: c.name === currentContext
         };
     });
 }
 
-export async function deleteCluster(kubectl: Kubectl, cluster: Cluster): Promise<boolean> {
-    const deleteClusterResult = await kubectl.invokeAsyncWithProgress(`config delete-cluster ${cluster.name}`, "Deleting cluster...");
+export async function deleteCluster(kubectl: Kubectl, cluster: KubectlContext): Promise<boolean> {
+    const deleteClusterResult = await kubectl.invokeAsyncWithProgress(`config delete-cluster ${cluster.clusterName}`, "Deleting cluster...");
     if (deleteClusterResult.code !== 0) {
-        kubeChannel.showOutput(`Failed to delete the specified cluster ${cluster.name} from the kubeconfig: ${deleteClusterResult.stderr}`, `Delete-${cluster.name}`);
-        vscode.window.showErrorMessage(`Delete ${cluster.name} failed. See Output window for more details.`);
+        kubeChannel.showOutput(`Failed to delete the specified cluster ${cluster.clusterName} from the kubeconfig: ${deleteClusterResult.stderr}`, `Delete ${cluster.contextName}`);
+        vscode.window.showErrorMessage(`Delete ${cluster.contextName} failed. See Output window for more details.`);
         return false;
     }
 
-    const deleteUserResult = await kubectl.invokeAsyncWithProgress(`config unset users.${cluster.user}`, "Deleting user...");
+    const deleteUserResult = await kubectl.invokeAsyncWithProgress(`config unset users.${cluster.userName}`, "Deleting user...");
     if (deleteUserResult.code !== 0) {
-        kubeChannel.showOutput(`Failed to delete user info for cluster ${cluster.name} from the kubeconfig: ${deleteUserResult.stderr}`);
-        vscode.window.showErrorMessage(`Delete ${cluster.name} Failed. See Output window for more details.`);
+        kubeChannel.showOutput(`Failed to delete user info for context ${cluster.contextName} from the kubeconfig: ${deleteUserResult.stderr}`);
+        vscode.window.showErrorMessage(`Delete ${cluster.contextName} Failed. See Output window for more details.`);
         return false;
     }
 
-    const deleteContextResult = await kubectl.invokeAsyncWithProgress(`config delete-context ${cluster.context}`, "Deleting context...");
+    const deleteContextResult = await kubectl.invokeAsyncWithProgress(`config delete-context ${cluster.contextName}`, "Deleting context...");
     if (deleteContextResult.code !== 0) {
-        kubeChannel.showOutput(`Failed to delete the specified cluster's context ${cluster.context} from the kubeconfig: ${deleteContextResult.stderr}`);
-        vscode.window.showErrorMessage(`Delete ${cluster.name} Failed. See Output window for more details.`);
+        kubeChannel.showOutput(`Failed to delete the specified cluster's context ${cluster.contextName} from the kubeconfig: ${deleteContextResult.stderr}`);
+        vscode.window.showErrorMessage(`Delete ${cluster.contextName} Failed. See Output window for more details.`);
         return false;
     }
 
-    vscode.window.showInformationMessage(`Deleted cluster '${cluster.name}' and associated data from the kubeconfig.`);
+    vscode.window.showInformationMessage(`Deleted context '${cluster.contextName}' and associated data from the kubeconfig.`);
     return true;
 }
 


### PR DESCRIPTION
ACS and AKS tend to provide fairly user-hostile cluster/context names.  Contexts can be renamed using `kubectl config rename-context`, but clusters can't.  So it is preferable to display context names in the tree view so that users can replace them with beautified ones.

I also took the opportunity to rename the tree to **Clusters**, because the Kubernetes label is already prepended by virtue of being on the new Activity Bar tab.

Fixes #178.