### PR TITLE
Type safety improvements - first tranche

### DIFF
--- a/src/components/clusterprovider/azure/azure.ts
+++ b/src/components/clusterprovider/azure/azure.ts
@@ -79,7 +79,7 @@ async function verifyPrerequisitesAsync(context: Context): Promise<string[]> {
     return errors;
 }
 
-async function azureCliVersion(context: Context): Promise<string> {
+async function azureCliVersion(context: Context): Promise<string | null> {
     const sr = await context.shell.exec('az --version');
     if (sr.code !== 0 || sr.stderr) {
         return null;
@@ -232,7 +232,7 @@ async function resourceGroupExists(context: Context, resourceGroupName: string):
 
 async function ensureResourceGroupAsync(context: Context, resourceGroupName: string, location: string): Promise<Errorable<Diagnostic>> {
     if (await resourceGroupExists(context, resourceGroupName)) {
-        return { succeeded: true, result: null };
+        return { succeeded: true, result: { value: '' } };
     }
 
     const sr = await context.shell.exec(`az group create -n "${resourceGroupName}" -l "${location}"`);

--- a/src/components/clusterprovider/azure/azureclusterprovider.ts
+++ b/src/components/clusterprovider/azure/azureclusterprovider.ts
@@ -10,8 +10,8 @@ import { refreshExplorer } from '../common/explorer';
 // HTTP request dispatch
 
 // TODO: de-globalise
-let wizardServer: restify.Server;
-let wizardPort: number;
+let wizardServer: restify.Server | undefined;
+let wizardPort: number | undefined;
 
 type HtmlRequestHandler = (
     step: string | undefined,

--- a/src/components/clusterprovider/clusterproviderserver.ts
+++ b/src/components/clusterprovider/clusterproviderserver.ts
@@ -52,7 +52,7 @@ function handleClusterTypeSelection(request: restify.Request, response: restify.
 
     reporter.sendTelemetryEvent("cloudselection", { action: action, clusterType: clusterType });
 
-    const clusterProvider = clusterproviderregistry.get().list().find((cp) => cp.id === clusterType);  // TODO: move into clusterproviderregistry
+    const clusterProvider = clusterproviderregistry.get().list().find((cp) => cp.id === clusterType)!;  // ! is safe because clusterType originally came from this list so should never be not found
     const url = `http://localhost:${clusterProvider.port}/${action}?clusterType=${clusterProvider.id}`;
     response.redirect(307, url, next);
 }

--- a/src/components/clusterprovider/minikube/minikube.ts
+++ b/src/components/clusterprovider/minikube/minikube.ts
@@ -3,7 +3,7 @@
 import * as vscode from 'vscode';
 import { shell, ShellResult } from '../../../shell';
 
-export async function startMinikube() {
+export async function startMinikube(): Promise<void> {
     shell.exec('minikube start').then((result: ShellResult) => {
         if (result.code === 0) {
             vscode.window.showInformationMessage('Cluster started.');
@@ -15,7 +15,7 @@ export async function startMinikube() {
     });
 }
 
-export async function stopMinikube() {
+export async function stopMinikube(): Promise<void> {
     shell.exec('minikube stop').then((result: ShellResult) => {
         if (result.code === 0) {
             vscode.window.showInformationMessage('Cluster stopped.');

--- a/src/components/clusterprovider/minikube/minikubeclusterprovider.ts
+++ b/src/components/clusterprovider/minikube/minikubeclusterprovider.ts
@@ -18,7 +18,7 @@ type HtmlRequestHandler = (
     context: Context,
 ) => Promise<string>;
 
-let minikubeWizardServer: restify.Server;
+let minikubeWizardServer: restify.Server | undefined;
 
 export async function init(registry: clusterproviderregistry.ClusterProviderRegistry, context: Context): Promise<void> {
     if (!minikubeWizardServer) {

--- a/src/components/git/git.ts
+++ b/src/components/git/git.ts
@@ -18,7 +18,7 @@ export class Git {
         return null;
     }
 
-    public async checkout(commitId: string): Promise<Errorable<void>> {
+    public async checkout(commitId: string): Promise<Errorable<null>> {
         const sr = await this.git(`checkout ${commitId}`);
         if (sr.code === 0) {
             return { succeeded: true, result: null };

--- a/src/configMap.ts
+++ b/src/configMap.ts
@@ -51,7 +51,7 @@ export async function deleteKubernetesConfigFile(kubectl: Kubectl, obj: Kubernet
         return;
     }
     const result = await vscode.window.showWarningMessage(`Are you sure you want to delete ${obj.id}? This can not be undone`, ...deleteMessageItems);
-    if (result.title !== deleteMessageItems[0].title) {
+    if (!result || result.title !== deleteMessageItems[0].title) {
         return;
     }
     const currentNS = await currentNamespace(kubectl);
@@ -92,7 +92,7 @@ export async function addKubernetesConfigFile(kubectl: Kubectl, obj: KubernetesD
             const fileName = basename(filePath);
             if (dataHolder.data[fileName]) {
                 const response = await vscode.window.showWarningMessage(`Are you sure you want to overwrite '${fileName}'? This can not be undone`, ...overwriteMessageItems);
-                if (response.title !== overwriteMessageItems[0].title) {
+                if (!response || response.title !== overwriteMessageItems[0].title) {
                     return;
                 }
             }

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,4 +1,4 @@
-export function sanitiseTag(name: string) {
+export function sanitiseTag(name: string): string {
     // Name components may contain lowercase letters, digits and separators.
     // A separator is defined as a period, one or two underscores, or one or
     // more dashes. A name component may not start or end with a separator.

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -97,7 +97,7 @@ class DummyObject implements KubernetesObject {
 }
 
 class KubernetesContext implements KubernetesObject {
-    constructor(readonly id: string, readonly metadata?: kubectlUtils.KubectlContext) {
+    constructor(readonly id: string, readonly metadata: kubectlUtils.KubectlContext) {
     }
 
     getChildren(kubectl: Kubectl, host: Host): vscode.ProviderResult<KubernetesObject[]> {

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -255,7 +255,7 @@ class KubernetesNodeResource extends KubernetesResource {
     }
 
     async getChildren(kubectl: Kubectl, host: Host): Promise<KubernetesObject[]> {
-        const pods = await kubectlUtils.getPods(kubectl, null, 'all');
+        const pods = await kubectlUtils.getPods(kubectl, null, kubectlUtils.ALL_NAMESPACES);
         const filteredPods = pods.filter((p) => `node/${p.nodeName}` === this.resourceId);
         return filteredPods.map((p) => new KubernetesResource(kuberesources.allKinds.pod, p.name, p));
     }

--- a/src/hostutils.ts
+++ b/src/hostutils.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-export async function showWorkspaceFolderPick(): Promise<vscode.WorkspaceFolder> {
+export async function showWorkspaceFolderPick(): Promise<vscode.WorkspaceFolder | undefined> {
     if (!vscode.workspace.workspaceFolders) {
         vscode.window.showErrorMessage('This command requires an open folder.');
         return undefined;


### PR DESCRIPTION
I want to turn on strict null checking (and other safety improvements such as strict function checking), but this is going to have to be a work in progress, as it's a pervasive change to the codebase that will take some time and we can't afford to block master while making such widespread changes.  So my Plan B is to turn on strict null checks _locally_, make a small tranche of changes, and get that through as a PR _without_ turning on strict null checks in the shared codebase.  This will allow us to gradually knock off modules, so that when we finally turn on strict null checks for real, there should be only a few regressions to deal with.

A fellow can dream, right?

So here is the first tranche.  I want to get this in reasonably quickly, so that it doesn't get out of date the way my previous efforts have.  There will be more tranches, many more... and then, comrades, one glorious day, the glorious revolution...

(Please see the commit history if you want this broken down into more digestible chunks.)