### PR TITLE
Fix for Pod status in Node Explorer View #272

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -193,7 +193,7 @@ class KubernetesResourceFolder extends KubernetesFolder {
     }
 
     async getChildren(kubectl: Kubectl, host: Host): Promise<KubernetesObject[]> {
-        const childrenLines = await kubectl.asLines("get " + this.kind.abbreviation);
+        const childrenLines = await kubectl.asLines(`get ${this.kind.abbreviation}`);
         if (failed(childrenLines)) {
             host.showErrorMessage(childrenLines.error[0]);
             return [new DummyObject("Error")];

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -204,6 +204,8 @@ class KubernetesResourceFolder extends KubernetesFolder {
                 return new KubernetesResource(this.kind, line.name, { status: line.status });
             });
         }
+        childrenLines.result.shift();
+        // ignore headers for other resources
         return childrenLines.result.map((line) => {
             const bits = line.split(' ');
             return new KubernetesResource(this.kind, bits[0]);

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -219,7 +219,6 @@ async function asLines(context: Context, command: string): Promise<Errorable<str
     const shellResult = await invokeAsync(context, command);
     if (shellResult.code === 0) {
         let lines = shellResult.stdout.split('\n');
-        // lines.shift();
         lines = lines.filter((l) => l.length > 0);
         return { succeeded: true, result: lines };
 

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -219,7 +219,7 @@ async function asLines(context: Context, command: string): Promise<Errorable<str
     const shellResult = await invokeAsync(context, command);
     if (shellResult.code === 0) {
         let lines = shellResult.stdout.split('\n');
-        lines.shift();
+        // lines.shift();
         lines = lines.filter((l) => l.length > 0);
         return { succeeded: true, result: lines };
 

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -330,3 +330,22 @@ export async function getResourceAsJson<T extends KubernetesResource | Kubernete
     }
     return shellResult.result;
 }
+
+/**
+ * Parse column based output which is seperated by whitespace(s) from kubectl or similar sources
+ * for example, kubectl get po
+ * @param lineOutput raw output with headers from kubectl or similar sources
+ * @return array of objects with key as column header and value
+ */
+export function parseLineOutput(lineOutput: string[]): { [key: string]: string }[] {
+    const headers = lineOutput.shift();
+    const parsedHeaders = headers.toLowerCase().replace(/\s+/g, '|').split('|');
+    return lineOutput.map((line) => {
+        const lineInfoObject = {};
+        const bits = line.replace(/\s+/g, '|').split('|');
+        bits.forEach((columnValue, index) => {
+            lineInfoObject[parsedHeaders[index]] = columnValue;
+        });
+        return lineInfoObject;
+    });
+}


### PR DESCRIPTION
@itowlson this fixes the issue with the pod status in node explorer view. Wanted to open an PR for feedback to see if we should move to `JSON` based parsing of status as compared to column based parsing. Also wanted to get some clarification on use of [`getPods`](https://github.com/Azure/vscode-kubernetes-tools/blob/master/src/explorer.ts#L258) vs [`kubectl.asLines`](https://github.com/Azure/vscode-kubernetes-tools/blob/master/src/explorer.ts#L181) to get pod information as to which is the preferred method. Happy to refactor `getPods` to reflect pod status. 