### PR TITLE
Fixing pod listing for services in explorer view

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -333,12 +333,16 @@ class KubernetesSelectorResource extends KubernetesResource {
         if (!this.selector) {
             return [];
         }
-        const selectors = [];
-        for (const sel in this.selector.matchLabels) {
-            selectors.push(`${sel}=${this.selector.matchLabels[sel]}`);
+        let selectorString = "";
+        if (this.selector.matchLabels) {
+            const selectors = [];
+            selectors.push("-l");
+            for (const sel in this.selector.matchLabels) {
+                selectors.push(`${sel}=${this.selector.matchLabels[sel]}`);
+            }
+            selectorString = selectors.join(",");
         }
-        const selectorString = selectors.join(",");
-        const pods = await kubectl.fromLines(`get po -l ${selectorString}`);
+        const pods = await kubectl.fromLines(`get po ${selectorString}`);
         if (failed(pods)) {
             host.showErrorMessage(pods.error[0]);
             return [new DummyObject("Error")];

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -339,7 +339,7 @@ class KubernetesSelectorResource extends KubernetesResource {
             for (const sel in this.selector.matchLabels) {
                 selectors.push(`${sel}=${this.selector.matchLabels[sel]}`);
             }
-            selectorString = "-l" + selectors.join(",");
+            selectorString = `-l ${selectors.join(",")}`;
         }
         const pods = await kubectl.fromLines(`get po ${selectorString}`);
         if (failed(pods)) {

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -336,11 +336,10 @@ class KubernetesSelectorResource extends KubernetesResource {
         let selectorString = "";
         if (this.selector.matchLabels) {
             const selectors = [];
-            selectors.push("-l");
             for (const sel in this.selector.matchLabels) {
                 selectors.push(`${sel}=${this.selector.matchLabels[sel]}`);
             }
-            selectorString = selectors.join(",");
+            selectorString = "-l" + selectors.join(",");
         }
         const pods = await kubectl.fromLines(`get po ${selectorString}`);
         if (failed(pods)) {


### PR DESCRIPTION
While refactoring for #277 missed the where the `matchLabels` are empty (as current namespace is selected) for  `Services` -> `<Service-Name>` and hence pods under an service were not showing up and the extension threw an error. This PR fixes that. Sorry about breaking this functionality. 