### PR TITLE
Fixing missing selector conditions

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -333,14 +333,7 @@ class KubernetesSelectorResource extends KubernetesResource {
         if (!this.selector) {
             return [];
         }
-        let selectorString = "";
-        if (this.selector.matchLabels) {
-            const selectors = [];
-            for (const sel in this.selector.matchLabels) {
-                selectors.push(`${sel}=${this.selector.matchLabels[sel]}`);
-            }
-            selectorString = `-l ${selectors.join(",")}`;
-        }
+        const selectorString = kubectlUtils.getResourceSelectorString(this.selector);
         const pods = await kubectl.fromLines(`get po ${selectorString}`);
         if (failed(pods)) {
             host.showErrorMessage(pods.error[0]);


### PR DESCRIPTION
With the refactor for #272 I [missed couple](https://github.com/Azure/vscode-kubernetes-tools/pull/281#discussion_r200733572) of conditions selector in the `Explorer View`. 

As a consequence it broke the listing of Services and Deployments in explorer view causing `kubectl` to return all pods instead of the pods belonging only to the selected service. 

This PR converts code in `getPods` to a re-usable function `getResourceSelectorString` in `kubectlUtils` and fixes the explorer view in services returning only the pods belonging to the service. 
Sorry about missing one of the selection cases earlier. 😞 