### PR TITLE
Fix remaining tree commands that didn't work on namespaced pods

### DIFF
--- a/src/components/kubectl/port-forward.ts
+++ b/src/components/kubectl/port-forward.ts
@@ -8,6 +8,7 @@ import { QuickPickOptions } from 'vscode';
 import * as portFinder from 'portfinder';
 import { succeeded } from '../../errorable';
 import * as kubectlUtils from '../../kubectlUtils';
+import { KubernetesExplorer, ResourceNode } from '../../explorer';
 
 const PORT_FORWARD_TERMINAL = 'kubectl port-forward';
 const MAX_PORT_COUNT = 65535;
@@ -43,9 +44,10 @@ function isFindResultFromDocument(obj: PortForwardFindPodsResult): obj is PodFro
 export async function portForwardKubernetes (kubectl: Kubectl, explorerNode?: any): Promise<void> {
     if (explorerNode) {
         // The port forward option only appears on pod level workloads in the tree view.
-        const podName = explorerNode.id;
+        const resourceNode = explorerNode as ResourceNode;
+        const podName = resourceNode.id;
         const portMapping = await promptForPort();
-        const namespace = await kubectlUtils.currentNamespace(kubectl);
+        const namespace = resourceNode.namespace || await kubectlUtils.currentNamespace(kubectl);
         portForwardToPod(kubectl, podName, portMapping, namespace);
         return;
     } else {

--- a/src/debug/debugProvider.ts
+++ b/src/debug/debugProvider.ts
@@ -52,5 +52,5 @@ export interface IDebugProvider {
      * @param container the container id.
      * @return the resolved port info.
      */
-    resolvePortsFromContainer(kubectl: Kubectl, pod: string, container: string): Promise<PortInfo>;
+    resolvePortsFromContainer(kubectl: Kubectl, pod: string, podNamespace: string | undefined, container: string): Promise<PortInfo>;
 }

--- a/src/debug/debugUtils.ts
+++ b/src/debug/debugUtils.ts
@@ -51,9 +51,10 @@ export async function promptForAppPort(ports: string[], defaultPort: string, env
  * @param container the container name.
  * @return the commands associated with the processes.
  */
-export async function getCommandsOfProcesses(kubectl: Kubectl, pod: string, container: string): Promise<string[]> {
+export async function getCommandsOfProcesses(kubectl: Kubectl, pod: string, podNamespace: string | undefined, container: string): Promise<string[]> {
     const commandLines: string[] = [];
-    const execCmd = `exec ${pod} ${container ? "-c ${selectedContainer}" : ""} -- ps -ef`;
+    const nsarg = podNamespace ? `--namespace ${podNamespace}` : '';
+    const execCmd = `exec ${pod} ${nsarg} ${container ? "-c ${selectedContainer}" : ""} -- ps -ef`;
     const execResult = await kubectl.invokeAsync(execCmd);
     if (execResult.code === 0) {
         /**

--- a/src/debug/javaDebugProvider.ts
+++ b/src/debug/javaDebugProvider.ts
@@ -88,9 +88,9 @@ export class JavaDebugProvider implements IDebugProvider {
         };
     }
 
-    public async resolvePortsFromContainer(kubectl: Kubectl, pod: string, container: string): Promise<PortInfo> {
+    public async resolvePortsFromContainer(kubectl: Kubectl, pod: string, podNamespace: string | undefined, container: string): Promise<PortInfo> {
         let rawDebugPortInfo: string;
-        const commandLines = await debugUtils.getCommandsOfProcesses(kubectl, pod, container);
+        const commandLines = await debugUtils.getCommandsOfProcesses(kubectl, pod, podNamespace, container);
         for (const commandLine of commandLines) {
             // java -Djava.security.egd=file:/dev/./urandom -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1044,quiet=y -jar target/app.jar
             const matches = commandLine.match(fullJavaDebugOptsRegExp);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1154,7 +1154,8 @@ function getPorts() {
 
 function describeKubernetes(explorerNode?: explorer.ResourceNode) {
     if (explorerNode) {
-        kubectl.invokeInSharedTerminal(`describe ${explorerNode.resourceId}`);
+        const nsarg = explorerNode.namespace ? `--namespace ${explorerNode.namespace}` : '';
+        kubectl.invokeInSharedTerminal(`describe ${explorerNode.resourceId} ${nsarg}`);
     } else {
         findKindNameOrPrompt(kuberesources.commonKinds, 'describe', { nameOptional: true }, (value) => {
             kubectl.invokeInSharedTerminal(`describe ${value}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1336,7 +1336,8 @@ const deleteKubernetes = async (explorerNode?: explorer.ResourceNode) => {
         if (answer.isCloseAffordance) {
             return;
         }
-        const shellResult = await kubectl.invokeAsyncWithProgress(`delete ${explorerNode.resourceId}`, `Deleting ${explorerNode.resourceId}...`);
+        const nsarg = explorerNode.namespace ? `--namespace ${explorerNode.namespace}` : '';
+        const shellResult = await kubectl.invokeAsyncWithProgress(`delete ${explorerNode.resourceId} ${nsarg}`, `Deleting ${explorerNode.resourceId}...`);
         await reportDeleteResult(explorerNode.resourceId, shellResult);
     } else {
         promptKindName(kuberesources.commonKinds, 'delete', { nameOptional: true }, async (kindName) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1546,10 +1546,10 @@ const debugKubernetes = async () => {
     }
 };
 
-const debugAttachKubernetes = async (explorerNode: explorer.KubernetesObject) => {
+const debugAttachKubernetes = async (explorerNode: explorer.ResourceNode) => {
     const workspaceFolder = await showWorkspaceFolderPick();
     if (workspaceFolder) {
-        new DebugSession(kubectl).attach(workspaceFolder, explorerNode ? explorerNode.id : null);
+        new DebugSession(kubectl).attach(workspaceFolder, explorerNode ? explorerNode.id : null, explorerNode ? explorerNode.namespace : undefined);
     }
 };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -674,8 +674,10 @@ function exposeKubernetes() {
 
 function getKubernetes(explorerNode?: any) {
     if (explorerNode) {
-        const id = explorerNode.resourceId || explorerNode.id;
-        kubectl.invokeInSharedTerminal(`get ${id} -o wide`);
+        const resourceNode = explorerNode as explorer.ResourceNode;
+        const id = resourceNode.resourceId || resourceNode.id;
+        const nsarg = resourceNode.namespace ? `--namespace ${resourceNode.namespace}` : '';
+        kubectl.invokeInSharedTerminal(`get ${id} ${nsarg} -o wide`);
     } else {
         findKindNameOrPrompt(kuberesources.commonKinds, 'get', { nameOptional: true }, (value) => {
             kubectl.invokeInSharedTerminal(` get ${value} -o wide`);

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -322,8 +322,9 @@ function isTransientPodState(status: string): boolean {
  * @param resourceId the resource id.
  * @return the result as a json object, or undefined if errors happen.
  */
-export async function getResourceAsJson<T extends KubernetesResource | KubernetesCollection<KubernetesResource>>(kubectl: Kubectl, resourceId: string): Promise<T | undefined> {
-    const shellResult = await kubectl.asJson<T>(`get ${resourceId} -o json`);
+export async function getResourceAsJson<T extends KubernetesResource | KubernetesCollection<KubernetesResource>>(kubectl: Kubectl, resourceId: string, resourceNamespace?: string): Promise<T | undefined> {
+    const nsarg = resourceNamespace ? `--namespace ${resourceNamespace}` : '';
+    const shellResult = await kubectl.asJson<T>(`get ${resourceId} ${nsarg} -o json`);
     if (failed(shellResult)) {
         vscode.window.showErrorMessage(shellResult.error[0]);
         return undefined;


### PR DESCRIPTION
When we added the feature to expand the pods under a node, we deferred dealing with pods that were outside the active namespace.  An earlier PR made it so they loaded correctly but other commands still didn't work.  This PR fixes the following commands:

* Get
* Delete
* Debug Attach
* Port Forward
* Describe

The remaining commands (Terminal, Show Logs, Follow Logs) are addressed in #279.