### PR TITLE
Provide additional diagnostics when unable to display Helm release list

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -85,11 +85,15 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<KubernetesObj
  * For example, display an "Error" dummy node when failing to get children of expandable parent.
  */
 class DummyObject implements KubernetesObject {
-    constructor(readonly id: string) {
+    constructor(readonly id: string, readonly diagnostic?: string) {
     }
 
     getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem> {
-        return new vscode.TreeItem(this.id, vscode.TreeItemCollapsibleState.None);
+        const treeItem = new vscode.TreeItem(this.id, vscode.TreeItemCollapsibleState.None);
+        if (this.diagnostic) {
+            treeItem.tooltip = this.diagnostic;
+        }
+        return treeItem;
     }
 
     getChildren(kubectl: Kubectl, host: Host): vscode.ProviderResult<KubernetesObject[]> {
@@ -423,7 +427,7 @@ class HelmReleasesFolder extends KubernetesResourceFolder {
         const releases = await helmexec.helmListAll(currentNS);
 
         if (failed(releases)) {
-            return [new DummyObject(releases.error[0])];
+            return [new DummyObject("Helm list error", releases.error[0])];
         }
 
         return releases.result.map((r) => new HelmReleaseResource(r));

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -306,7 +306,7 @@ export async function helmListAll(namespace?: string): Promise<Errorable<string[
         const sr = await helmExecAsync(`list --max 0 ${nsarg} ${offsetarg}`);
 
         if (sr.code !== 0) {
-            return { succeeded: false, error: [ 'Helm list error' ] };
+            return { succeeded: false, error: [ sr.stderr ] };
         }
 
         const lines = sr.stdout.split('\n')


### PR DESCRIPTION
If there was an error listing Helm releases, the tree view previous just said "Helm list error".  This PR adds a tooltip with the error message from the Helm CLI.