### PR TITLE
If HOME is defined on Windows, then use that rather than USERPROFILE

### DIFF
--- a/src/components/download/download.ts
+++ b/src/components/download/download.ts
@@ -1,0 +1,39 @@
+const home = process.env['HOME'];
+
+import * as download_core from 'download';  // NEVER do a naked import of this as it corrupts $HOME on Windows - use wrapper functions from this module (or export the download function from this module if you really need the flexibility of the core implementation)
+import * as path from 'path';
+import * as stream from 'stream';
+import * as tmp from 'tmp';
+
+import { succeeded, Errorable } from '../../errorable';
+
+// Fix download module corrupting HOME environment variable on Windows
+// See https://github.com/Azure/vscode-kubernetes-tools/pull/302#issuecomment-404678781
+// and https://github.com/kevva/npm-conf/issues/13
+if (home) {
+    process.env['HOME'] = home;
+}
+
+type DownloadFunc =
+    (url: string, destination?: string, options?: any)
+         => Promise<Buffer> & stream.Duplex; // Stream has additional events - see https://www.npmjs.com/package/download
+
+const download: DownloadFunc = download_core;
+
+export async function toTempFile(sourceUrl: string): Promise<Errorable<string>> {
+    const tempFileObj = tmp.fileSync({ prefix: "vsk-autoinstall-" });
+    const downloadResult = await to(sourceUrl, tempFileObj.name);
+    if (succeeded(downloadResult)) {
+        return { succeeded: true, result: tempFileObj.name };
+    }
+    return { succeeded: false, error: downloadResult.error };
+}
+
+export async function to(sourceUrl: string, destinationFile: string): Promise<Errorable<void>> {
+    try {
+        await download(sourceUrl, path.dirname(destinationFile), { filename: path.basename(destinationFile) });
+        return { succeeded: true, result: null };
+    } catch (e) {
+        return { succeeded: false, error: [e.message] };
+    }
+}

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -63,8 +63,7 @@ function platform(): Platform {
 }
 
 function home(): string {
-    const homeVar = isWindows() ? 'USERPROFILE' : 'HOME';
-    return process.env[homeVar];
+    return process.env['HOME'] || process.env['USERPROFILE'];
 }
 
 function combinePath(basePath: string, relativePath: string) {


### PR DESCRIPTION
The Azure CLI and kubectl both use the HOME environment variable, falling back on USERPROFILE only if HOME is not defined.  We had a bug where, when we spawned them, if we were on Windows, we always set HOME to the value of USERPROFILE.  So if a user had a custom HOME, spawning would break.

Fixes #301.