### PR TITLE
Pod status Indicator re-implementation

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -201,6 +201,12 @@ class KubernetesResourceFolder extends KubernetesFolder {
     }
 
     async getChildren(kubectl: Kubectl, host: Host): Promise<KubernetesObject[]> {
+        if (this.kind === kuberesources.allKinds.pod) {
+            const pods = await kubectlUtils.getPods(kubectl, null, null);
+            return pods.map((pod) => {
+                return new KubernetesResource(this.kind, pod.name, pod);
+            });
+        }
         const childrenLines = await kubectl.asLines(`get ${this.kind.abbreviation}`);
         if (failed(childrenLines)) {
             host.showErrorMessage(childrenLines.error[0]);
@@ -240,6 +246,9 @@ class KubernetesResource implements KubernetesObject, ResourceNode {
             this.kind === kuberesources.allKinds.secret ||
             this.kind === kuberesources.allKinds.configMap) {
             treeItem.contextValue = `vsKubernetes.resource.${this.kind.abbreviation}`;
+            if (this.kind === kuberesources.allKinds.pod && this.metadata.status !== null) {
+                treeItem.iconPath = getIconForPodStatus(this.metadata.status.toLowerCase());
+            }
         }
         if (this.namespace) {
             treeItem.tooltip = `Namespace: ${this.namespace}`;  // TODO: show only if in non-current namespace?

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -189,16 +189,18 @@ export async function getPods(kubectl: Kubectl, selector: any, namespace: string
         labelStr = "--selector=" + labels.join(",");
     }
 
-    const pods = await kubectl.asJson<KubernetesCollection<Pod>>(`get pods -o json ${nsFlag} ${labelStr}`);
+    const pods = await kubectl.fromLines(`get pods -o wide ${nsFlag} ${labelStr}`);
     if (failed(pods)) {
         vscode.window.showErrorMessage(pods.error[0]);
         return [];
     }
-    return pods.result.items.map((item) => {
+
+    return pods.result.map((item) => {
         return {
-            name: item.metadata.name,
-            namespace: item.metadata.namespace,
-            nodeName: item.spec.nodeName
+            name: item.name,
+            namespace: item.namespace,
+            nodeName: item.node,
+            status: item.status
         };
     });
 }


### PR DESCRIPTION
Implements pod status indicators in explorer view.
Changes:
* `getPods` uses `fromLines` as compared to the JSON pod output perviously. 
* `get pods -o wide` to include node information so as to not break `PodInfo` 
* `getChildren` in `KubernetesResourceFolder` checks if the resource being explored is pod and uses `getPods`
