### PR TITLE
Improve startup speed

### DIFF
--- a/src/components/clusterprovider/azure/azureclusterprovider.ts
+++ b/src/components/clusterprovider/azure/azureclusterprovider.ts
@@ -1,4 +1,4 @@
-import * as restify from 'restify';
+import restify = require('restify');
 import * as portfinder from 'portfinder';
 import * as clusterproviderregistry from '../clusterproviderregistry';
 import * as azure from './azure';
@@ -21,7 +21,8 @@ type HtmlRequestHandler = (
 
 export async function init(registry: clusterproviderregistry.ClusterProviderRegistry, context: azure.Context): Promise<void> {
     if (!wizardServer) {
-        wizardServer = restify.createServer({
+        const restifyImpl: typeof restify = require('restify');
+        wizardServer = restifyImpl.createServer({
             formatters: {
                 'text/html': (req, resp, body) => body
             }
@@ -31,7 +32,7 @@ export async function init(registry: clusterproviderregistry.ClusterProviderRegi
 
         const htmlServer = new HtmlServer(context);
 
-        wizardServer.use(restify.plugins.queryParser(), restify.plugins.bodyParser());
+        wizardServer.use(restifyImpl.plugins.queryParser(), restifyImpl.plugins.bodyParser());
         wizardServer.listen(wizardPort, '127.0.0.1');
 
         // You MUST use fat arrow notation for the handler callbacks: passing the

--- a/src/components/clusterprovider/azure/azureclusterprovider.ts
+++ b/src/components/clusterprovider/azure/azureclusterprovider.ts
@@ -11,7 +11,8 @@ import { refreshExplorer } from '../common/explorer';
 
 // TODO: de-globalise
 let wizardServer: restify.Server;
-let wizardPort: number;
+let wizardPort: number | undefined;
+let registered = false;
 
 type HtmlRequestHandler = (
     step: string | undefined,
@@ -20,31 +21,45 @@ type HtmlRequestHandler = (
 ) => Promise<string>;
 
 export async function init(registry: clusterproviderregistry.ClusterProviderRegistry, context: azure.Context): Promise<void> {
-    if (!wizardServer) {
-        const restifyImpl: typeof restify = require('restify');
-        wizardServer = restifyImpl.createServer({
-            formatters: {
-                'text/html': (req, resp, body) => body
-            }
-        });
-
-        wizardPort = await portfinder.getPortPromise({ port: 44000 });
-
-        const htmlServer = new HtmlServer(context);
-
-        wizardServer.use(restifyImpl.plugins.queryParser(), restifyImpl.plugins.bodyParser());
-        wizardServer.listen(wizardPort, '127.0.0.1');
-
-        // You MUST use fat arrow notation for the handler callbacks: passing the
-        // function reference directly will foul up the 'this' pointer.
-        wizardServer.get('/create', (req, resp, n) => htmlServer.handleGetCreate(req, resp, n));
-        wizardServer.post('/create', (req, resp, n) => htmlServer.handlePostCreate(req, resp, n));
-        wizardServer.get('/configure', (req, resp, n) => htmlServer.handleGetConfigure(req, resp, n));
-        wizardServer.post('/configure', (req, resp, n) => htmlServer.handlePostConfigure(req, resp, n));
-
-        registry.register({id: 'aks', displayName: "Azure Kubernetes Service", port: wizardPort, supportedActions: ['create', 'configure']});
-        registry.register({id: 'acs', displayName: "Azure Container Service", port: wizardPort, supportedActions: ['create', 'configure']});
+    if (!registered) {
+        const serve = serveCallback(context);
+        registry.register({id: 'aks', displayName: "Azure Kubernetes Service", supportedActions: ['create', 'configure'], serve: serve});
+        registry.register({id: 'acs', displayName: "Azure Container Service", supportedActions: ['create', 'configure'], serve: serve});
+        registered = true;
     }
+}
+
+function serveCallback(context: azure.Context): () => Promise<number> {
+    return () => serve(context);
+}
+
+async function serve(context: azure.Context): Promise<number> {
+    if (wizardPort) {
+        return wizardPort;
+    }
+
+    const restifyImpl: typeof restify = require('restify');
+    wizardServer = restifyImpl.createServer({
+        formatters: {
+            'text/html': (req, resp, body) => body
+        }
+    });
+
+    wizardPort = await portfinder.getPortPromise({ port: 44000 });
+
+    const htmlServer = new HtmlServer(context);
+
+    wizardServer.use(restifyImpl.plugins.queryParser(), restifyImpl.plugins.bodyParser());
+    wizardServer.listen(wizardPort, '127.0.0.1');
+
+    // You MUST use fat arrow notation for the handler callbacks: passing the
+    // function reference directly will foul up the 'this' pointer.
+    wizardServer.get('/create', (req, resp, n) => htmlServer.handleGetCreate(req, resp, n));
+    wizardServer.post('/create', (req, resp, n) => htmlServer.handlePostCreate(req, resp, n));
+    wizardServer.get('/configure', (req, resp, n) => htmlServer.handleGetConfigure(req, resp, n));
+    wizardServer.post('/configure', (req, resp, n) => htmlServer.handlePostConfigure(req, resp, n));
+
+    return wizardPort;
 }
 
 class HtmlServer {

--- a/src/components/clusterprovider/clusterproviderregistry.ts
+++ b/src/components/clusterprovider/clusterproviderregistry.ts
@@ -3,8 +3,8 @@ export type ClusterProviderAction = 'create' | 'configure';
 export interface ClusterProvider {
     readonly id: string;
     readonly displayName: string;
-    readonly port: number;
     readonly supportedActions: ClusterProviderAction[];
+    serve(): Promise<number>;
 }
 
 export interface ClusterProviderRegistry {
@@ -16,7 +16,7 @@ class RegistryImpl implements ClusterProviderRegistry {
     private readonly providers = new Array<ClusterProvider>();
 
     public register(clusterProvider: ClusterProvider) {
-        console.log(`You registered ${clusterProvider.id} for port ${clusterProvider.port}`);
+        console.log(`You registered cluster type ${clusterProvider.id}`);
         this.providers.push(clusterProvider);
     }
 

--- a/src/components/clusterprovider/clusterproviderserver.ts
+++ b/src/components/clusterprovider/clusterproviderserver.ts
@@ -1,4 +1,4 @@
-import * as restify from 'restify';
+import restify = require('restify');
 import * as portfinder from 'portfinder';
 import * as clusterproviderregistry from './clusterproviderregistry';
 import { styles, script, waitScript } from '../../wizard';
@@ -8,8 +8,9 @@ let cpServer: restify.Server;
 let cpPort: number;
 
 export async function init(): Promise<void> {
+    const restifyImpl: typeof restify = require('restify');
     if (!cpServer) {
-        cpServer = restify.createServer({
+        cpServer = restifyImpl.createServer({
             formatters: {
                 'text/html': (req, resp, body) => body
             }
@@ -17,7 +18,7 @@ export async function init(): Promise<void> {
 
         cpPort = await portfinder.getPortPromise({ port: 44000 });
 
-        cpServer.use(restify.plugins.queryParser());
+        cpServer.use(restifyImpl.plugins.queryParser());
         cpServer.listen(cpPort, '127.0.0.1');
         cpServer.get('/', handleRequest);
     }

--- a/src/components/clusterprovider/minikube/minikubeclusterprovider.ts
+++ b/src/components/clusterprovider/minikube/minikubeclusterprovider.ts
@@ -19,31 +19,47 @@ type HtmlRequestHandler = (
 ) => Promise<string>;
 
 let minikubeWizardServer: restify.Server;
+let minikubeWizardPort: number | undefined;
+let registered = false;
 
 export async function init(registry: clusterproviderregistry.ClusterProviderRegistry, context: Context): Promise<void> {
-    if (!minikubeWizardServer) {
-        const restifyImpl: typeof restify = require('restify');
-        minikubeWizardServer = restifyImpl.createServer({
-            formatters: {
-                'text/html': (req, resp, body) => body
-            }
-        });
-
-        const port = await portfinder.getPortPromise({ port: 44000 });
-
-        const htmlServer = new HtmlServer(context);
-        minikubeWizardServer.use(restifyImpl.plugins.queryParser(), restifyImpl.plugins.bodyParser());
-        minikubeWizardServer.listen(port, '127.0.0.1');
-
-        // You MUST use fat arrow notation for the handler callbacks: passing the
-        // function reference directly will foul up the 'this' pointer.
-        minikubeWizardServer.get('/create', (req, resp, n) => htmlServer.handleGetCreate(req, resp, n));
-        minikubeWizardServer.post('/create', (req, resp, n) => htmlServer.handlePostCreate(req, resp, n));
-        minikubeWizardServer.get('/configure', (req, resp, n) => htmlServer.handleGetConfigure(req, resp, n));
-        minikubeWizardServer.post('/configure', (req, resp, n) => htmlServer.handlePostConfigure(req, resp, n));
-
-        registry.register({id: 'minikube', displayName: "Minikube local cluster", port: port, supportedActions: ['create', 'configure']});
+    if (!registered) {
+        const serve = serveCallback(context);
+        registry.register({id: 'minikube', displayName: "Minikube local cluster", supportedActions: ['create', 'configure'], serve: serve});
+        registered = true;
     }
+}
+
+function serveCallback(context: Context): () => Promise<number> {
+    return () => serve(context);
+}
+
+async function serve(context: Context): Promise<number> {
+    if (minikubeWizardPort) {
+        return minikubeWizardPort;
+    }
+
+    const restifyImpl: typeof restify = require('restify');
+    minikubeWizardServer = restifyImpl.createServer({
+        formatters: {
+            'text/html': (req, resp, body) => body
+        }
+    });
+
+    minikubeWizardPort = await portfinder.getPortPromise({ port: 44000 });
+
+    const htmlServer = new HtmlServer(context);
+    minikubeWizardServer.use(restifyImpl.plugins.queryParser(), restifyImpl.plugins.bodyParser());
+    minikubeWizardServer.listen(minikubeWizardPort, '127.0.0.1');
+
+    // You MUST use fat arrow notation for the handler callbacks: passing the
+    // function reference directly will foul up the 'this' pointer.
+    minikubeWizardServer.get('/create', (req, resp, n) => htmlServer.handleGetCreate(req, resp, n));
+    minikubeWizardServer.post('/create', (req, resp, n) => htmlServer.handlePostCreate(req, resp, n));
+    minikubeWizardServer.get('/configure', (req, resp, n) => htmlServer.handleGetConfigure(req, resp, n));
+    minikubeWizardServer.post('/configure', (req, resp, n) => htmlServer.handlePostConfigure(req, resp, n));
+
+    return minikubeWizardPort;
 }
 
 class HtmlServer {

--- a/src/components/clusterprovider/minikube/minikubeclusterprovider.ts
+++ b/src/components/clusterprovider/minikube/minikubeclusterprovider.ts
@@ -1,4 +1,4 @@
-import * as restify from 'restify';
+import restify = require('restify');
 import * as portfinder from 'portfinder';
 import * as vscode from 'vscode';
 import * as clusterproviderregistry from '../clusterproviderregistry';
@@ -22,7 +22,8 @@ let minikubeWizardServer: restify.Server;
 
 export async function init(registry: clusterproviderregistry.ClusterProviderRegistry, context: Context): Promise<void> {
     if (!minikubeWizardServer) {
-        minikubeWizardServer = restify.createServer({
+        const restifyImpl: typeof restify = require('restify');
+        minikubeWizardServer = restifyImpl.createServer({
             formatters: {
                 'text/html': (req, resp, body) => body
             }
@@ -31,7 +32,7 @@ export async function init(registry: clusterproviderregistry.ClusterProviderRegi
         const port = await portfinder.getPortPromise({ port: 44000 });
 
         const htmlServer = new HtmlServer(context);
-        minikubeWizardServer.use(restify.plugins.queryParser(), restify.plugins.bodyParser());
+        minikubeWizardServer.use(restifyImpl.plugins.queryParser(), restifyImpl.plugins.bodyParser());
         minikubeWizardServer.listen(port, '127.0.0.1');
 
         // You MUST use fat arrow notation for the handler callbacks: passing the

--- a/src/components/download/download.ts
+++ b/src/components/download/download.ts
@@ -1,24 +1,27 @@
-const home = process.env['HOME'];
-
-import * as download_core from 'download';  // NEVER do a naked import of this as it corrupts $HOME on Windows - use wrapper functions from this module (or export the download function from this module if you really need the flexibility of the core implementation)
 import * as path from 'path';
 import * as stream from 'stream';
 import * as tmp from 'tmp';
 
 import { succeeded, Errorable } from '../../errorable';
 
-// Fix download module corrupting HOME environment variable on Windows
-// See https://github.com/Azure/vscode-kubernetes-tools/pull/302#issuecomment-404678781
-// and https://github.com/kevva/npm-conf/issues/13
-if (home) {
-    process.env['HOME'] = home;
-}
-
 type DownloadFunc =
     (url: string, destination?: string, options?: any)
          => Promise<Buffer> & stream.Duplex; // Stream has additional events - see https://www.npmjs.com/package/download
 
-const download: DownloadFunc = download_core;
+let download: DownloadFunc;
+
+function ensureDownloadFunc() {
+    if (!download) {
+        // Fix download module corrupting HOME environment variable on Windows
+        // See https://github.com/Azure/vscode-kubernetes-tools/pull/302#issuecomment-404678781
+        // and https://github.com/kevva/npm-conf/issues/13
+        const home = process.env['HOME'];
+        download = require('download');
+        if (home) {
+            process.env['HOME'] = home;
+        }
+    }
+}
 
 export async function toTempFile(sourceUrl: string): Promise<Errorable<string>> {
     const tempFileObj = tmp.fileSync({ prefix: "vsk-autoinstall-" });
@@ -30,6 +33,7 @@ export async function toTempFile(sourceUrl: string): Promise<Errorable<string>> 
 }
 
 export async function to(sourceUrl: string, destinationFile: string): Promise<Errorable<void>> {
+    ensureDownloadFunc();
     try {
         await download(sourceUrl, path.dirname(destinationFile), { filename: path.basename(destinationFile) });
         return { succeeded: true, result: null };

--- a/src/explainer.ts
+++ b/src/explainer.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import * as k8s from 'k8s';
+import k8s = require('k8s');
 import * as pluralize from 'pluralize';
 import * as kubeconfig from './kubeconfig';
 import { formatComplex, formatOne, Typed, formatType } from "./schema-formatting";
@@ -16,8 +16,9 @@ function fixUrl(kapi: any /* deliberately bypass type checks as .domain is inter
 }
 
 function readSwaggerCore(kc: kubeconfig.KubeConfig): Promise<any> {
+    const k8sImpl: typeof k8s = require('k8s');
     return new Promise((resolve, reject) => {
-        const kapi = k8s.api(apiCredentials(kc));
+        const kapi = k8sImpl.api(apiCredentials(kc));
         fixUrl(kapi);
         kapi.get('swagger.json', (err, data) => {
             if (err) {


### PR DESCRIPTION
Some of our dependencies take a very long time to load.  This PR defers loading these dependencies until they are needed`*`.

Fixes #307.

~~`*` _conditions apply_... specifically, the `restify` dependency is not yet fully deferred, as we currently need to start HTTP servers during activation in order to parcel out ports to the various providers.  I'll keep noodling away on this and push an update if I can see a reliable way to do this.~~  The `restify` dependency is now _even more deferred_.