### PR TITLE
Fix kubectl versioning woes

### DIFF
--- a/src/components/kubectl/compatibility.ts
+++ b/src/components/kubectl/compatibility.ts
@@ -1,4 +1,4 @@
-import { Kubectl } from '../../kubectl';
+import { ShellResult } from '../../shell';
 
 interface CompatibilityGuaranteed {
     readonly guaranteed: true;
@@ -17,8 +17,8 @@ export function isGuaranteedCompatible(c: Compatibility): c is CompatibilityGuar
     return c.guaranteed;
 }
 
-export async function check(kubectl: Kubectl): Promise<Compatibility> {
-    const sr = await kubectl.invokeAsync('version --short');
+export async function check(kubectlInvokeAsync: (cmd: string) => Promise<ShellResult>): Promise<Compatibility> {
+    const sr = await kubectlInvokeAsync('version --short');
     if (sr.code !== 0) {
         return {
             guaranteed: false,

--- a/src/components/kubectl/compatibility.ts
+++ b/src/components/kubectl/compatibility.ts
@@ -1,0 +1,65 @@
+import { Kubectl } from '../../kubectl';
+
+interface CompatibilityGuaranteed {
+    readonly guaranteed: true;
+}
+
+interface CompatibilityNotGuaranteed {
+    readonly guaranteed: false;
+    readonly didCheck: boolean;
+    readonly clientVersion: string;
+    readonly serverVersion: string;
+}
+
+export type Compatibility = CompatibilityGuaranteed | CompatibilityNotGuaranteed;
+
+export function isGuaranteedCompatible(c: Compatibility): c is CompatibilityGuaranteed {
+    return c.guaranteed;
+}
+
+export async function check(kubectl: Kubectl): Promise<Compatibility> {
+    const sr = await kubectl.invokeAsync('version --short');
+    if (sr.code !== 0) {
+        return {
+            guaranteed: false,
+            didCheck: false,
+            clientVersion: '',
+            serverVersion: ''
+        };
+    }
+
+    const lines = sr.stdout.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+    const versionMappings = lines.map((l) => parseVersion(l));
+    const clientVersion = versionMappings.find((m) => m[0] === 'client')[1];
+    const serverVersion = versionMappings.find((m) => m[0] === 'server')[1];
+
+    if (isCompatible(clientVersion, serverVersion)) {
+        return { guaranteed: true };
+    }
+
+    return {
+        guaranteed: false,
+        didCheck: true,
+        clientVersion: clientVersion,
+        serverVersion: serverVersion
+    };
+}
+
+function isCompatible(clientVersionStr: string, serverVersionStr: string): boolean {
+    const clientVersion = clientVersionStr.split('.');
+    const serverVersion = serverVersionStr.split('.');
+    if (clientVersion[0] === serverVersion[0]) {
+        const clientMinor = Number.parseInt(clientVersion[1]);
+        const serverMinor = Number.parseInt(serverVersion[1]);
+        if (Math.abs(clientMinor - serverMinor) <= 1) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function parseVersion(versionLine: string): [string, string] {
+    // Format: Xxx Version: vN.N.N
+    const bits = versionLine.split(' ');
+    return [bits[0].toLowerCase(), bits[bits.length - 1]];
+}

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -6,6 +6,7 @@ import { Shell, ShellHandler, ShellResult } from './shell';
 import * as binutil from './binutil';
 import { Errorable } from './errorable';
 import { parseLineOutput } from './outputUtils';
+import * as compatibility from './components/kubectl/compatibility';
 
 const KUBECTL_OUTPUT_COLUMN_SEPARATOR = /\s+/g;
 
@@ -159,9 +160,21 @@ async function invokeAsync(context: Context, command: string, stdin?: string): P
     if (await checkPresent(context, 'command')) {
         const bin = baseKubectlPath(context);
         const cmd = `${bin} ${command}`;
-        return await context.shell.exec(cmd, stdin);
+        const sr = await context.shell.exec(cmd, stdin);
+        if (sr.code !== 0) {
+            checkPossibleIncompatibility(context);
+        }
+        return sr;
     } else {
         return { code: -1, stdout: '', stderr: '' };
+    }
+}
+
+async function checkPossibleIncompatibility(context: Context): Promise<void> {
+    const compat = await compatibility.check((cmd) => invokeAsync(context, cmd));
+    if (!compatibility.isGuaranteedCompatible(compat) && compat.didCheck) {
+        const versionAlert = `kubectl version ${compat.clientVersion} may be incompatible with cluster Kubernetes version ${compat.serverVersion}`;
+        context.host.showWarningMessage(versionAlert);
     }
 }
 
@@ -207,6 +220,7 @@ function kubectlDone(context: Context): ShellHandler {
         if (result !== 0) {
             context.host.showErrorMessage('Kubectl command failed: ' + stderr);
             console.log(stderr);
+            checkPossibleIncompatibility(context);
             return;
         }
 

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -171,7 +171,7 @@ async function invokeAsync(context: Context, command: string, stdin?: string): P
 }
 
 async function checkPossibleIncompatibility(context: Context): Promise<void> {
-    const compat = await compatibility.check((cmd) => invokeAsync(context, cmd));
+    const compat = await compatibility.check((cmd) => asJson<compatibility.Version>(context, cmd));
     if (!compatibility.isGuaranteedCompatible(compat) && compat.didCheck) {
         const versionAlert = `kubectl version ${compat.clientVersion} may be incompatible with cluster Kubernetes version ${compat.serverVersion}`;
         context.host.showWarningMessage(versionAlert);

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -121,7 +121,7 @@ export function shellEnvironment(baseEnvironment: any): any {
         if (toolPath) {
             const toolDirectory = path.dirname(toolPath);
             const currentPath = env[pathVariable];
-            env[pathVariable] = (currentPath ? `${currentPath}${pathEntrySeparator()}` : '') + toolDirectory;
+            env[pathVariable] = toolDirectory + (currentPath ? `${pathEntrySeparator()}${currentPath}` : '');
         }
     }
 


### PR DESCRIPTION
This PR addresses two versioning issues with `kubectl`:

1. Terminals could use a different version of `kubectl` from "behind-the-scenes" calls, if the user had set a location for `kubectl` in their VS Code configuration.  This occurred because "behind-the-scenes" would directly invoke the program at the configured location, whereas terminals would append the configured location to the path (so that the user could issue follow-up commands without having to type out the configured path) -- so if `'kubectl` was _also_ on the path then the path version would take precedence.  This meant the kubectl terminal was consistent with a system terminal, but made it hard to diagnose/reproduce the behaviour of "behind-the-scenes" commands.  Terminals now _prepend_ the configured location to the path, so that the configured location takes precedence.

2. Kubernetes only guarantees compatibility with at most one minor version of skew between client and server.  For example, `kubectl get pods` in v1.11 fails with server version v1.7.  This would lead to enigmatic errors, for example when expanding the tree (an Error node and toast saying something about being Not Acceptable).  We now check `kubectl` failures and, if the versions are too far out of sync, display an additional warning to this effect.  (This may be too aggressive at the moment, e.g. might not want to warn more than once per cluster, for both performance and user annoyance reasons; but `kubectl` failures should be relatively rare and a versioning issue is likely to be non-obvious when it hits.)

Fixes #306 and #298.