### PR TITLE
Install Minikube if not present

### DIFF
--- a/src/components/clusterprovider/minikube/minikube.ts
+++ b/src/components/clusterprovider/minikube/minikube.ts
@@ -1,10 +1,80 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { shell, ShellResult } from '../../../shell';
+import { Shell, ShellResult } from '../../../shell';
+import { Host } from '../../../host';
+import { FS } from '../../../fs';
+import * as binutil from '../../../binutil';
+import { Errorable } from '../../../errorable';
+import { fromShellExitCodeOnly, Diagnostic } from '../../../wizard';
 
-export async function startMinikube() {
-    shell.exec('minikube start').then((result: ShellResult) => {
+export interface Minikube {
+    checkPresent(mode: CheckPresentMode): Promise<boolean>;
+    isRunnable(): Promise<Errorable<Diagnostic>>;
+    start(): Promise<Errorable<Diagnostic>>;
+    stop(): Promise<Errorable<Diagnostic>>;
+}
+
+export function create(host: Host, fs: FS, shell: Shell, installDependenciesCallback: () => void): Minikube {
+    return new MinikubeImpl(host, fs, shell, installDependenciesCallback, false);
+}
+
+// TODO: these are the same as we are using for Draft (and kubectl?) -
+// we really need to unify them (and the designs).
+
+export enum CheckPresentMode {
+    Alert,
+    Silent
+}
+
+interface Context {
+    readonly host: Host;
+    readonly fs: FS;
+    readonly shell: Shell;
+    readonly installDependenciesCallback: () => void;
+    binFound: boolean;
+    binPath: string;
+}
+
+class MinikubeImpl implements Minikube {
+    private readonly context: Context;
+
+    constructor(host: Host, fs: FS, shell: Shell, installDependenciesCallback: () => void, toolFound: boolean) {
+        this.context = { host : host, fs : fs, shell : shell, installDependenciesCallback : installDependenciesCallback, binFound : toolFound, binPath : 'minikube' };
+    }
+
+    checkPresent(mode: CheckPresentMode): Promise<boolean> {
+        return checkPresent(this.context, mode);
+    }
+
+    isRunnable(): Promise<Errorable<Diagnostic>> {
+        return isRunnableMinikube(this.context);
+    }
+
+    start(): Promise<Errorable<Diagnostic>> {
+        return startMinikube(this.context);
+    }
+
+    stop(): Promise<Errorable<Diagnostic>> {
+        return stopMinikube(this.context);
+    }
+}
+
+async function isRunnableMinikube(context: Context): Promise<Errorable<Diagnostic>> {
+    if (!await checkPresent(context, CheckPresentMode.Alert)) {
+        return { succeeded: false, error: [ 'Minikube is not installed '] };
+    }
+
+    const sr = await context.shell.exec(`${context.binPath} help`);
+    return fromShellExitCodeOnly(sr);
+}
+
+async function startMinikube(context: Context): Promise<Errorable<Diagnostic>> {
+    if (!await checkPresent(context, CheckPresentMode.Alert)) {
+        return;
+    }
+
+    context.shell.exec(`${context.binPath} start`).then((result: ShellResult) => {
         if (result.code === 0) {
             vscode.window.showInformationMessage('Cluster started.');
         } else {
@@ -15,8 +85,12 @@ export async function startMinikube() {
     });
 }
 
-export async function stopMinikube() {
-    shell.exec('minikube stop').then((result: ShellResult) => {
+async function stopMinikube(context: Context): Promise<Errorable<Diagnostic>> {
+    if (!await checkPresent(context, CheckPresentMode.Alert)) {
+        return;
+    }
+
+    context.shell.exec(`${context.binPath} stop`).then((result: ShellResult) => {
         if (result.code === 0) {
             vscode.window.showInformationMessage('Cluster stopped.');
         } else {
@@ -25,4 +99,21 @@ export async function stopMinikube() {
     }).catch((err) => {
         vscode.window.showErrorMessage(`Error stopping cluster: ${err}`);
     });
+}
+
+async function checkPresent(context: Context, mode: CheckPresentMode): Promise<boolean> {
+    if (context.binFound) {
+        return true;
+    }
+
+    return await checkForMinikubeInternal(context, mode);
+}
+
+async function checkForMinikubeInternal(context: Context, mode: CheckPresentMode): Promise<boolean> {
+    const binName = 'minikube';
+    const bin = context.host.getConfiguration('vs-kubernetes')[`vs-kubernetes.${binName}-path`];
+
+    const inferFailedMessage = 'Could not find "minikube" binary.';
+    const configuredFileMissingMessage = bin + ' does not exist!';
+    return binutil.checkForBinary(context, bin, binName, inferFailedMessage, configuredFileMissingMessage, mode === CheckPresentMode.Alert);
 }

--- a/src/components/clusterprovider/minikube/minikube.ts
+++ b/src/components/clusterprovider/minikube/minikube.ts
@@ -11,8 +11,8 @@ import { fromShellExitCodeOnly, Diagnostic } from '../../../wizard';
 export interface Minikube {
     checkPresent(mode: CheckPresentMode): Promise<boolean>;
     isRunnable(): Promise<Errorable<Diagnostic>>;
-    start(): Promise<Errorable<Diagnostic>>;
-    stop(): Promise<Errorable<Diagnostic>>;
+    start(): Promise<void>;
+    stop(): Promise<void>;
 }
 
 export function create(host: Host, fs: FS, shell: Shell, installDependenciesCallback: () => void): Minikube {
@@ -51,11 +51,11 @@ class MinikubeImpl implements Minikube {
         return isRunnableMinikube(this.context);
     }
 
-    start(): Promise<Errorable<Diagnostic>> {
+    start(): Promise<void> {
         return startMinikube(this.context);
     }
 
-    stop(): Promise<Errorable<Diagnostic>> {
+    stop(): Promise<void> {
         return stopMinikube(this.context);
     }
 }
@@ -69,7 +69,7 @@ async function isRunnableMinikube(context: Context): Promise<Errorable<Diagnosti
     return fromShellExitCodeOnly(sr);
 }
 
-async function startMinikube(context: Context): Promise<Errorable<Diagnostic>> {
+async function startMinikube(context: Context): Promise<void> {
     if (!await checkPresent(context, CheckPresentMode.Alert)) {
         return;
     }
@@ -85,7 +85,7 @@ async function startMinikube(context: Context): Promise<Errorable<Diagnostic>> {
     });
 }
 
-async function stopMinikube(context: Context): Promise<Errorable<Diagnostic>> {
+async function stopMinikube(context: Context): Promise<void> {
     if (!await checkPresent(context, CheckPresentMode.Alert)) {
         return;
     }

--- a/src/components/installer/installer.ts
+++ b/src/components/installer/installer.ts
@@ -75,7 +75,9 @@ export async function installMinikube(shell: Shell): Promise<Errorable<void>> {
         return { succeeded: false, error: ['Failed to download Minikube: error was ' + downloadResult.error[0]] };
     }
 
-    // TODO: on Unixes, do a chmod +x per https://github.com/kubernetes/minikube/releases
+    if (shell.isUnix()) {
+        await shell.exec(`chmod +x ${executableFullPath}`);
+    }
     const configKey = `vs-kubernetes.${tool}-path`;
     await addPathToConfig(configKey, executableFullPath);
 

--- a/src/components/installer/installer.ts
+++ b/src/components/installer/installer.ts
@@ -65,7 +65,7 @@ export async function installMinikube(shell: Shell): Promise<Errorable<void>> {
     if (!os) {
         return { succeeded: false, error: ['Not supported on this OS'] };
     }
-    const urlTemplate = "https://storage.googleapis.com/minikube/releases/v0.28.0/minikube-{os_placeholder}-amd64" + shell.isWindows() ? '.exe' : '';
+    const urlTemplate = "https://storage.googleapis.com/minikube/releases/v0.28.0/minikube-{os_placeholder}-amd64" + (shell.isWindows() ? '.exe' : '');
     const url = urlTemplate.replace('{os_placeholder}', os);
     const installFolder = getInstallFolder(shell, tool);
     const executable = formatBin(tool, shell.platform());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,6 +34,7 @@ import { create as kubectlCreate } from './kubectl';
 import * as kubectlUtils from './kubectlUtils';
 import * as explorer from './explorer';
 import { create as draftCreate, CheckPresentMode as DraftCheckPresentMode } from './draft/draft';
+import { create as minikubeCreate, CheckPresentMode as MinikubeCheckPresentMode } from './components/clusterprovider/minikube/minikube';
 import * as logger from './logger';
 import * as helm from './helm';
 import * as helmexec from './helm.exec';
@@ -47,7 +48,6 @@ import * as extensionapi from './extension.api';
 import { dashboardKubernetes } from './components/kubectl/dashboard';
 import { portForwardKubernetes } from './components/kubectl/port-forward';
 import { logsKubernetes, LogsDisplayMode } from './components/kubectl/logs';
-import { startMinikube, stopMinikube } from './components/clusterprovider/minikube/minikube';
 import { Errorable, failed, succeeded } from './errorable';
 import { Git } from './components/git/git';
 import { DebugSession } from './debug/debugSession';
@@ -61,7 +61,7 @@ import { refreshExplorer } from './components/clusterprovider/common/explorer';
 import { KubernetesCompletionProvider } from "./yaml-support/yaml-snippet";
 import { showWorkspaceFolderPick } from './hostutils';
 import { DraftConfigurationProvider } from './draft/draftConfigurationProvider';
-import { installHelm, installDraft, installKubectl } from './components/installer/installer';
+import { installHelm, installDraft, installKubectl, installMinikube } from './components/installer/installer';
 import { KubernetesResourceVirtualFileSystemProvider, K8S_RESOURCE_SCHEME, KUBECTL_RESOURCE_AUTHORITY } from './kuberesources.virtualfs';
 import { Container, isKubernetesResource, KubernetesCollection, Pod, KubernetesResource } from './kuberesources.objectmodel';
 
@@ -70,6 +70,7 @@ let swaggerSpecPromise = null;
 
 const kubectl = kubectlCreate(host, fs, shell, installDependencies);
 const draft = draftCreate(host, fs, shell, installDependencies);
+const minikube = minikubeCreate(host, fs, shell, installDependencies);
 const configureFromClusterUI = configureFromCluster.uiProvider();
 const createClusterUI = createCluster.uiProvider();
 const clusterProviderRegistry = clusterproviderregistry.get();
@@ -153,8 +154,8 @@ export async function activate(context): Promise<extensionapi.ExtensionAPI> {
         registerCommand('extension.vsKubernetesDeleteContext', deleteContextKubernetes),
         registerCommand('extension.vsKubernetesUseNamespace', (explorerNode: explorer.KubernetesObject) => { useNamespaceKubernetes(kubectl, explorerNode); } ),
         registerCommand('extension.vsKubernetesDashboard', () => { dashboardKubernetes(kubectl); }),
-        registerCommand('extension.vsMinikubeStop', stopMinikube),
-        registerCommand('extension.vsMinikubeStart', startMinikube),
+        registerCommand('extension.vsMinikubeStop', () => minikube.stop()),
+        registerCommand('extension.vsMinikubeStart', () => minikube.start()),
         registerCommand('extension.vsKubernetesCopy', copyKubernetes),
         registerCommand('extension.vsKubernetesPortForward', (explorerNode: explorer.ResourceNode) => { portForwardKubernetes(kubectl, explorerNode); }),
         registerCommand('extension.vsKubernetesLoadConfigMapData', configmaps.loadConfigMapData),
@@ -217,7 +218,7 @@ export async function activate(context): Promise<extensionapi.ExtensionAPI> {
     ];
 
     await azureclusterprovider.init(clusterProviderRegistry, { shell: shell, fs: fs });
-    await minikubeclusterprovider.init(clusterProviderRegistry, { shell: shell });
+    await minikubeclusterprovider.init(clusterProviderRegistry, { shell: shell, minikube: minikube });
     // On save, refresh the Helm YAML preview.
     vscode.workspace.onDidSaveTextDocument((e: vscode.TextDocument) => {
         if (!editorIsActive()) {
@@ -1686,11 +1687,13 @@ export async function installDependencies() {
     const gotKubectl = await kubectl.checkPresent('silent');
     const gotHelm = helmexec.ensureHelm(helmexec.EnsureMode.Silent);
     const gotDraft = await draft.checkPresent(DraftCheckPresentMode.Silent);
+    const gotMinikube = await minikube.checkPresent(MinikubeCheckPresentMode.Silent);
 
     // TODO: parallelise
     await installDependency("kubectl", gotKubectl, installKubectl);
     await installDependency("Helm", gotHelm, installHelm);
     await installDependency("Draft", gotDraft, installDraft);
+    await installDependency("Minikube", gotMinikube, installMinikube);
 
     kubeChannel.showOutput("Done");
 }

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -116,7 +116,7 @@ function execCore(cmd: string, opts: any, stdin?: string): Promise<ShellResult> 
 export function shellEnvironment(baseEnvironment: any): any {
     const env = Object.assign({}, baseEnvironment);
     const pathVariable = pathVariableName(env);
-    for (const tool of ['kubectl', 'helm', 'draft']) {
+    for (const tool of ['kubectl', 'helm', 'draft', 'minikube']) {
         const toolPath = vscode.workspace.getConfiguration('vs-kubernetes')[`vs-kubernetes.${tool}-path`];
         if (toolPath) {
             const toolDirectory = path.dirname(toolPath);


### PR DESCRIPTION
This adds Minikube to the 'Install dependencies' prompt, and adds missing dependency detection to the Minikube 'create cluster' wizard.  As dependencies are installed in a private location rather than on the path, this also requires some hardening of the Minikube detection and launch logic which brings it more in line with kubectl and Draft.

Fixes #300.