### PR TITLE
Do not show spurious Get command on Helm Releases tree folder

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -428,10 +428,9 @@ class HelmReleaseResource implements KubernetesObject {
     }
 }
 
-class HelmReleasesFolder extends KubernetesResourceFolder {
+class HelmReleasesFolder extends KubernetesFolder {
     constructor() {
-        // TODO: this is not a true Kubernetes resource kind - need to refactor
-        super(new kuberesources.ResourceKind("Helm Release", "Helm Releases", "helmrelease"));
+        super("Helm Release", "Helm Releases", "vsKubernetes.nonResourceFolder");
     }
 
     async getChildren(kubectl: Kubectl, host: Host): Promise<KubernetesObject[]> {


### PR DESCRIPTION
A follow-up comment on #291 identified that the Helm Releases tree node provided a Get command which, when invoked, tried to retrieve Helm releases using `kubectl`.  This occurred because the Helm Releases node was implemented using the Kubernetes resource folder infrastructure and inherited the common behaviour of that infrastructure.  This PR removes the kludge; the folder is now treated as a non-resource folder, and does not display a Get command.

Thanks @mozesmagyar for reporting the issue!