### PR TITLE
Fix JSONPath parsing error when checking containers in a pod

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1006,7 +1006,11 @@ function parseName(line) {
 }
 
 async function getContainers(pod: PodSummary): Promise<Container[] | undefined> {
-    let cmd = `get pod/${pod.name} -o jsonpath="{'NAME\\tIMAGE\\n'}{range .spec.containers[*]}{.name}{'\\t'}{.image}{'\\n'}{end}"`;
+    const q = shell.isWindows() ? `'` : `"`;
+    const lit = (l: string) => `{${q}${l}${q}}`;
+    const query = `${lit("NAME\\tIMAGE\\n")}{range .spec.containers[*]}{.name}${lit("\\t")}{.image}${lit("\\n")}{end}`;
+    const queryArg = shell.isWindows() ? `"${query}"` : `'${query}'`;
+    let cmd = `get pod/${pod.name} -o jsonpath=${queryArg}`;
     if (pod.namespace && pod.namespace.length > 0) {
         cmd += ' --namespace=' + pod.namespace;
     }


### PR DESCRIPTION
As part of showing or following logs, we need to check whether the pod contains multiple containers (so we can prompt for which container's logs the user is interested in).  We do this using a `get pod` query with a JSONPath that lists the container names and images in the pod.

Unfortunately, it turns out that JSONPath expressions are portable across Windows and Linux, but _not_ to Mac - they need a different quoting style on Mac.  Linux also accepts the Mac style, so this PR modifies the JSONPath to use Windows-friendly quoting on Windows and Mac-friendly quoting on both Unices.  So it now appears to work okay on all three OSes.

Fixes #315.