### PR TITLE
Fix error listing charts in Helm repo if repo URL contained a path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,11 @@
                 "@types/node": "6.0.96"
             }
         },
+        "@types/lodash": {
+            "version": "4.14.113",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.113.tgz",
+            "integrity": "sha512-CINMgfKUnif7fWBqPuGUsZrkER8jGU+ufyhD7FuotPqC1rRViHOJVgPuanN2Y8Vv1TqRnHDKlMnyEQLNq9eMjA=="
+        },
         "@types/minimatch": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -3267,9 +3272,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.4",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+            "version": "4.17.10",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+            "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "lodash._basecopy": {
             "version": "3.0.1",
@@ -4525,7 +4530,7 @@
                 "ewma": "2.0.1",
                 "formidable": "1.1.1",
                 "http-signature": "1.2.0",
-                "lodash": "4.17.4",
+                "lodash": "4.17.10",
                 "lru-cache": "4.1.1",
                 "mime": "1.6.0",
                 "negotiator": "0.6.1",
@@ -4557,7 +4562,7 @@
             "integrity": "sha1-ZocX4QBoPuxs4NUV+J/x2+wlSo0=",
             "requires": {
                 "assert-plus": "1.0.0",
-                "lodash": "4.17.4",
+                "lodash": "4.17.10",
                 "safe-json-stringify": "1.0.4",
                 "verror": "1.10.0"
             }

--- a/package.json
+++ b/package.json
@@ -888,6 +888,7 @@
         "redhat.vscode-yaml"
     ],
     "dependencies": {
+        "@types/lodash": "^4.14.113",
         "@types/restify": "^5.0.7",
         "@types/shelljs": "^0.7.8",
         "await-notify": "^1.0.1",
@@ -900,7 +901,7 @@
         "graceful-fs": "^4.1.11",
         "js-yaml": "^3.8.2",
         "k8s": "^0.4.12",
-        "lodash": ">3",
+        "lodash": "^4.17.10",
         "mkdirp": "^0.5.1",
         "natives": "^1.1.3",
         "node-yaml-parser": "^0.0.9",

--- a/src/helm.repoExplorer.ts
+++ b/src/helm.repoExplorer.ts
@@ -44,7 +44,7 @@ export class HelmRepoExplorer implements vscode.TreeDataProvider<HelmObject> {
     private async getHelmRepos(): Promise<HelmObject[]> {
         const repos = await listHelmRepos();
         if (failed(repos)) {
-            return [ new HelmError('Unable to list Helm repos') ];
+            return [ new HelmError('Unable to list Helm repos', repos.error[0]) ];
         }
         return repos.result;
     }
@@ -55,10 +55,12 @@ export class HelmRepoExplorer implements vscode.TreeDataProvider<HelmObject> {
 }
 
 class HelmError implements HelmObject {
-    constructor(private readonly text: string) {}
+    constructor(private readonly text: string, private readonly detail: string) {}
 
     getTreeItem(): vscode.TreeItem {
-        return new vscode.TreeItem(this.text);
+        const treeItem = new vscode.TreeItem(this.text);
+        treeItem.tooltip = this.detail;
+        return treeItem;
     }
 
     async getChildren(): Promise<HelmObject[]> {
@@ -81,7 +83,7 @@ class HelmRepo implements HelmObject {
     async getChildren(): Promise<HelmObject[]> {
         const charts = await listHelmRepoCharts(this.name, this.url);
         if (failed(charts)) {
-            return [ new HelmError('Error fetching charts') ];
+            return [ new HelmError('Error fetching charts', charts.error[0]) ];
         }
         return charts.result;
     }

--- a/src/helm.repoExplorer.ts
+++ b/src/helm.repoExplorer.ts
@@ -160,7 +160,7 @@ async function listHelmRepos(): Promise<Errorable<HelmRepo[]>> {
 }
 
 async function listHelmRepoCharts(repoName: string, repoUrl: string): Promise<Errorable<HelmRepoChart[]>> {
-    const indexUrl = vscode.Uri.parse(repoUrl).with({ path: 'index.yaml' }).toString();
+    const indexUrl = append(vscode.Uri.parse(repoUrl), 'index.yaml').toString();
     try {
         const charts = await listHelmRepoChartsCore(repoName, indexUrl);
         return { succeeded: true, result: charts };
@@ -187,4 +187,12 @@ async function listHelmRepoChartsCore(repoName: string, indexUrl: string): Promi
     const entries = chartData.entries;
     const charts = Object.keys(entries).map((k) => new HelmRepoChart(repoName, k, entries[k]));
     return charts;
+}
+
+function append(uri: vscode.Uri, resourceName: string): vscode.Uri {
+    const basePath = uri.path;
+    const separator = basePath.endsWith('/') ? '' : '/';
+    const resourcePath = basePath + separator + resourceName;
+    const resourceUri = uri.with({ path: resourcePath });
+    return resourceUri;
 }


### PR DESCRIPTION
If a Helm repo URL contained a path, e.g. `https://azure.github.io/brigade`, we were blatting that path with `index.yaml` instead of appending `index.yaml` to the end of the path.  This prevented us from listing the charts in the repo.  This PR fixes that issue, and also adds hover detail for errors should there be any more lurking in there.  WHICH THERE ARE NOT.