### PR TITLE
Trade up a version of mixin-deep with a known vulnerability for one which is excitingly unknown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -297,7 +297,7 @@
                 "component-emitter": "1.2.1",
                 "define-property": "1.0.0",
                 "isobject": "3.0.1",
-                "mixin-deep": "1.3.0",
+                "mixin-deep": "1.3.1",
                 "pascalcase": "0.1.1"
             },
             "dependencies": {
@@ -1361,8 +1361,7 @@
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-            "dev": true
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
         },
         "for-own": {
             "version": "0.1.5",
@@ -2787,7 +2786,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
-            "dev": true,
             "requires": {
                 "isobject": "3.0.1"
             },
@@ -2795,8 +2793,7 @@
                 "isobject": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                    "dev": true
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 }
             }
         },
@@ -3597,10 +3594,9 @@
             }
         },
         "mixin-deep": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.0.tgz",
-            "integrity": "sha1-R6hzK6l3mUV8jB7KKPlRMtfoFQo=",
-            "dev": true,
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "requires": {
                 "for-in": "1.0.2",
                 "is-extendable": "1.0.1"
@@ -3609,8 +3605,7 @@
                 "is-extendable": {
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-                    "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
-                    "dev": true,
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "requires": {
                         "is-plain-object": "2.0.4"
                     }

--- a/package.json
+++ b/package.json
@@ -909,6 +909,7 @@
         "js-yaml": "^3.8.2",
         "k8s": "^0.4.12",
         "lodash": "^4.17.10",
+        "mixin-deep": "^1.3.1",
         "mkdirp": "^0.5.1",
         "natives": "^1.1.3",
         "node-yaml-parser": "^0.0.9",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "onCommand:extension.helmDepUp",
         "onCommand:extension.helmInspectValues",
         "onCommand:extension.helmGet",
-	    "onCommand:extension.helmPackage",
+        "onCommand:extension.helmPackage",
         "onCommand:extension.draftVersion",
         "onCommand:extension.draftCreate",
         "onCommand:extension.draftUp",
@@ -744,11 +744,11 @@
                 "category": "Helm"
             },
             {
-		        "command": "extension.helmPackage",
-		        "title": "Package",
-		        "description": "Package a chart directory into a versioned chart archive file.",
-		        "category": "Helm"
-	        }
+                "command": "extension.helmPackage",
+                "title": "Package",
+                "description": "Package a chart directory into a versioned chart archive file.",
+                "category": "Helm"
+            }
         ],
         "languages": [
             {


### PR DESCRIPTION
We have an indirect dependency on something called mixin-deep (through about five levels of weirdly named stuff, so no idea why or how).  This has had a vulnerability report raised against it.  So we need to update it to a new version.  Whee.