### PR TITLE
Helm repo explorer context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -444,22 +444,22 @@
                 },
                 {
                     "command": "extension.helmInstall",
-                    "group": "3",
+                    "group": "2",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chart"
                 },
                 {
                     "command": "extension.helmInstall",
-                    "group": "3",
+                    "group": "2",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chartversion"
                 },
                 {
                     "command": "extension.helmDependencies",
-                    "group": "2",
+                    "group": "0@3",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chart"
                 },
                 {
                     "command": "extension.helmDependencies",
-                    "group": "2",
+                    "group": "0@3",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chartversion"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "onCommand:extension.helmCreate",
         "onCommand:extension.helmInsertReq",
         "onCommand:extension.helmDepUp",
+        "onCommand:extension.helmInspectChart",
         "onCommand:extension.helmInspectValues",
         "onCommand:extension.helmGet",
         "onCommand:extension.helmPackage",
@@ -431,22 +432,42 @@
                 },
                 {
                     "command": "extension.helmFetch",
-                    "group": "0",
+                    "group": "1",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chart"
                 },
                 {
                     "command": "extension.helmFetch",
-                    "group": "0",
+                    "group": "1",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chartversion"
                 },
                 {
                     "command": "extension.helmInstall",
-                    "group": "1",
+                    "group": "2",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chart"
                 },
                 {
                     "command": "extension.helmInstall",
-                    "group": "1",
+                    "group": "2",
+                    "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chartversion"
+                },
+                {
+                    "command": "extension.helmInspectChart",
+                    "group": "0@1",
+                    "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chart"
+                },
+                {
+                    "command": "extension.helmInspectChart",
+                    "group": "0@1",
+                    "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chartversion"
+                },
+                {
+                    "command": "extension.helmInspectValues",
+                    "group": "0@2",
+                    "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chart"
+                },
+                {
+                    "command": "extension.helmInspectValues",
+                    "group": "0@2",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chartversion"
                 }
             ],
@@ -494,6 +515,14 @@
                 {
                     "command": "extension.helmInspectValues",
                     "when": "filesExplorerFocus"
+                },
+                {
+                    "command": "extension.helmInspectValues",
+                    "when": "view === extension.vsKubernetesHelmRepoExplorer"
+                },
+                {
+                    "command": "extension.helmInspectChart",
+                    "when": "view === extension.vsKubernetesHelmRepoExplorer"
                 }
             ]
         },
@@ -748,6 +777,12 @@
             },
             {
                 "command": "extension.helmInspectValues",
+                "title": "Inspect Values",
+                "description": "Inspect a Helm Chart",
+                "category": "Helm"
+            },
+            {
+                "command": "extension.helmInspectChart",
                 "title": "Inspect Chart",
                 "description": "Inspect a Helm Chart",
                 "category": "Helm"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "onCommand:extension.helmGet",
         "onCommand:extension.helmPackage",
         "onCommand:extension.helmFetch",
+        "onCommand:extension.helmInstall",
         "onCommand:extension.draftVersion",
         "onCommand:extension.draftCreate",
         "onCommand:extension.draftUp",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         "onCommand:extension.helmPackage",
         "onCommand:extension.helmFetch",
         "onCommand:extension.helmInstall",
+        "onCommand:extension.helmDependencies",
         "onCommand:extension.draftVersion",
         "onCommand:extension.draftCreate",
         "onCommand:extension.draftUp",
@@ -443,11 +444,21 @@
                 },
                 {
                     "command": "extension.helmInstall",
-                    "group": "2",
+                    "group": "3",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chart"
                 },
                 {
                     "command": "extension.helmInstall",
+                    "group": "3",
+                    "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chartversion"
+                },
+                {
+                    "command": "extension.helmDependencies",
+                    "group": "2",
+                    "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chart"
+                },
+                {
+                    "command": "extension.helmDependencies",
                     "group": "2",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chartversion"
                 },
@@ -816,6 +827,12 @@
                 "command": "extension.helmInstall",
                 "title": "Install",
                 "description": "Install a Helm chart into the cluster",
+                "category": "Helm"
+            },
+            {
+                "command": "extension.helmDependencies",
+                "title": "Show Dependencies",
+                "description": "List the dependencies of a Helm chart",
                 "category": "Helm"
             }
         ],

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "onCommand:extension.helmInspectValues",
         "onCommand:extension.helmGet",
         "onCommand:extension.helmPackage",
+        "onCommand:extension.helmFetch",
         "onCommand:extension.draftVersion",
         "onCommand:extension.draftCreate",
         "onCommand:extension.draftUp",
@@ -427,6 +428,16 @@
                     "command": "extension.vsKubernetesDeleteFile",
                     "group": "3",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.file"
+                },
+                {
+                    "command": "extension.helmFetch",
+                    "group": "0",
+                    "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chart"
+                },
+                {
+                    "command": "extension.helmFetch",
+                    "group": "0",
+                    "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chartversion"
                 }
             ],
             "commandPalette": [
@@ -747,6 +758,12 @@
                 "command": "extension.helmPackage",
                 "title": "Package",
                 "description": "Package a chart directory into a versioned chart archive file.",
+                "category": "Helm"
+            },
+            {
+                "command": "extension.helmFetch",
+                "title": "Fetch",
+                "description": "Fetch a Helm chart into the current project",
                 "category": "Helm"
             }
         ],

--- a/package.json
+++ b/package.json
@@ -438,6 +438,16 @@
                     "command": "extension.helmFetch",
                     "group": "0",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chartversion"
+                },
+                {
+                    "command": "extension.helmInstall",
+                    "group": "1",
+                    "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chart"
+                },
+                {
+                    "command": "extension.helmInstall",
+                    "group": "1",
+                    "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem == vsKubernetes.chartversion"
                 }
             ],
             "commandPalette": [
@@ -764,6 +774,12 @@
                 "command": "extension.helmFetch",
                 "title": "Fetch",
                 "description": "Fetch a Helm chart into the current project",
+                "category": "Helm"
+            },
+            {
+                "command": "extension.helmInstall",
+                "title": "Install",
+                "description": "Install a Helm chart into the cluster",
                 "category": "Helm"
             }
         ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,7 +41,7 @@ import * as helm from './helm';
 import * as helmexec from './helm.exec';
 import { HelmRequirementsCodeLensProvider } from './helm.requirementsCodeLens';
 import { HelmTemplateHoverProvider } from './helm.hoverProvider';
-import { HelmTemplatePreviewDocumentProvider, HelmInspectDocumentProvider } from './helm.documentProvider';
+import { HelmTemplatePreviewDocumentProvider, HelmInspectDocumentProvider, HelmDependencyDocumentProvider } from './helm.documentProvider';
 import { HelmTemplateCompletionProvider } from './helm.completionProvider';
 import { Reporter } from './telemetry';
 import * as telemetry from './telemetry-helper';
@@ -115,6 +115,7 @@ export async function activate(context): Promise<extensionapi.ExtensionAPI> {
     const resourceDocProvider = new KubernetesResourceVirtualFileSystemProvider(kubectl, host, vscode.workspace.rootPath);
     const previewProvider = new HelmTemplatePreviewDocumentProvider();
     const inspectProvider = new HelmInspectDocumentProvider();
+    const dependenciesProvider = new HelmDependencyDocumentProvider();
     const completionProvider = new HelmTemplateCompletionProvider();
     const completionFilter = [
         "helm",
@@ -197,6 +198,7 @@ export async function activate(context): Promise<extensionapi.ExtensionAPI> {
         vscode.workspace.registerTextDocumentContentProvider(helm.PREVIEW_SCHEME, previewProvider),
         vscode.workspace.registerTextDocumentContentProvider(helm.INSPECT_VALUES_SCHEME, inspectProvider),
         vscode.workspace.registerTextDocumentContentProvider(helm.INSPECT_CHART_SCHEME, inspectProvider),
+        vscode.workspace.registerTextDocumentContentProvider(helm.DEPENDENCIES_SCHEME, dependenciesProvider),
 
         // Completion providers
         vscode.languages.registerCompletionItemProvider(completionFilter, completionProvider),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -181,6 +181,7 @@ export async function activate(context): Promise<extensionapi.ExtensionAPI> {
         registerCommand('extension.helmPackage', helmexec.helmPackage),
         registerCommand('extension.helmFetch', helmexec.helmFetch),
         registerCommand('extension.helmInstall', (o) => helmexec.helmInstall(kubectl, o)),
+        registerCommand('extension.helmDependencies', helmexec.helmDependencies),
 
         // Commands - Draft
         registerCommand('extension.draftVersion', execDraftVersion),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -172,6 +172,7 @@ export async function activate(context): Promise<extensionapi.ExtensionAPI> {
         registerCommand('extension.helmTemplatePreview', helmexec.helmTemplatePreview),
         registerCommand('extension.helmLint', helmexec.helmLint),
         registerCommand('extension.helmInspectValues', helmexec.helmInspectValues),
+        registerCommand('extension.helmInspectChart', helmexec.helmInspectChart),
         registerCommand('extension.helmDryRun', helmexec.helmDryRun),
         registerCommand('extension.helmDepUp', helmexec.helmDepUp),
         registerCommand('extension.helmInsertReq', helmexec.insertRequirement),
@@ -193,7 +194,7 @@ export async function activate(context): Promise<extensionapi.ExtensionAPI> {
         vscode.workspace.registerTextDocumentContentProvider(configureFromCluster.uriScheme, configureFromClusterUI),
         vscode.workspace.registerTextDocumentContentProvider(createCluster.uriScheme, createClusterUI),
         vscode.workspace.registerTextDocumentContentProvider(helm.PREVIEW_SCHEME, previewProvider),
-        vscode.workspace.registerTextDocumentContentProvider(helm.INSPECT_SCHEME, inspectProvider),
+        vscode.workspace.registerTextDocumentContentProvider(helm.INSPECT_VALUES_SCHEME, inspectProvider),
         vscode.workspace.registerTextDocumentContentProvider(helm.INSPECT_CHART_SCHEME, inspectProvider),
 
         // Completion providers

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -179,6 +179,7 @@ export async function activate(context): Promise<extensionapi.ExtensionAPI> {
         registerCommand('extension.helmGet', helmexec.helmGet),
         registerCommand('extension.helmPackage', helmexec.helmPackage),
         registerCommand('extension.helmFetch', helmexec.helmFetch),
+        registerCommand('extension.helmInstall', (o) => helmexec.helmInstall(kubectl, o)),
 
         // Commands - Draft
         registerCommand('extension.draftVersion', execDraftVersion),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -178,6 +178,7 @@ export async function activate(context): Promise<extensionapi.ExtensionAPI> {
         registerCommand('extension.helmCreate', helmexec.helmCreate),
         registerCommand('extension.helmGet', helmexec.helmGet),
         registerCommand('extension.helmPackage', helmexec.helmPackage),
+        registerCommand('extension.helmFetch', helmexec.helmFetch),
 
         // Commands - Draft
         registerCommand('extension.draftVersion', execDraftVersion),

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -128,21 +128,40 @@ export function helmLint() {
 // If a non-tgz, non-directory file is passed, this tries to find a parent chart.
 export function helmInspectValues(arg: any) {
     if (!arg) {
-        vscode.window.showErrorMessage("Helm Inspect Values is primarily for inspecting packaged charts and directories. Launch the command from a file or directory in the Explorer pane.");
+        vscode.window.showErrorMessage("Helm Inspect Values is for packaged charts and directories. Launch the command from a file or directory in the file explorer. or a chart or version in the Helm Repos explorer.");
         return;
     }
     if (!ensureHelm(EnsureMode.Alert)) {
         return;
     }
 
-    if (arg.kind && arg.kind === helm.INSPECT_CHART_REPO_AUTHORITY) {
-        const id: string = arg.id;
-        const version: string = arg.version;
-        const uri = vscode.Uri.parse(`${helm.INSPECT_CHART_SCHEME}://${helm.INSPECT_CHART_REPO_AUTHORITY}/${id}?${version}`);
+    if (helmrepoexplorer.isHelmRepoChart(arg) || helmrepoexplorer.isHelmRepoChartVersion(arg)) {
+        const id = arg.id;
+        const version = helmrepoexplorer.isHelmRepoChartVersion(arg) ? arg.version : undefined;
+        const versionQuery = version ? `?${version}` : '';
+        const uri = vscode.Uri.parse(`${helm.INSPECT_VALUES_SCHEME}://${helm.INSPECT_REPO_AUTHORITY}/${id}${versionQuery}`);
         vscode.commands.executeCommand("vscode.previewHtml", uri, vscode.ViewColumn.Two, "Inspect");
     } else {
         const u = arg as vscode.Uri;
-        const uri = vscode.Uri.parse("helm-inspect-values://" + u.fsPath);
+        const uri = vscode.Uri.parse(`${helm.INSPECT_VALUES_SCHEME}://${helm.INSPECT_FILE_AUTHORITY}/?${u.fsPath}`);
+        vscode.commands.executeCommand("vscode.previewHtml", uri, vscode.ViewColumn.Two, "Inspect");
+    }
+}
+
+export function helmInspectChart(arg: any) {
+    if (!arg) {
+        vscode.window.showErrorMessage("Helm Inspect Chart is for packaged charts and directories. Launch the command from a chart or version in the Helm Repos explorer.");
+        return;
+    }
+    if (!ensureHelm(EnsureMode.Alert)) {
+        return;
+    }
+
+    if (helmrepoexplorer.isHelmRepoChart(arg) || helmrepoexplorer.isHelmRepoChartVersion(arg)) {
+        const id: string = arg.id;
+        const version = helmrepoexplorer.isHelmRepoChartVersion(arg) ? arg.version : undefined;
+        const versionQuery = version ? `?${version}` : '';
+        const uri = vscode.Uri.parse(`${helm.INSPECT_CHART_SCHEME}://${helm.INSPECT_REPO_AUTHORITY}/${id}${versionQuery}`);
         vscode.commands.executeCommand("vscode.previewHtml", uri, vscode.ViewColumn.Two, "Inspect");
     }
 }

--- a/src/helm.repoExplorer.ts
+++ b/src/helm.repoExplorer.ts
@@ -4,7 +4,7 @@ import * as _ from 'lodash';
 
 import { Host } from './host';
 import * as helm from './helm.exec';
-import { INSPECT_CHART_REPO_AUTHORITY, HELM_OUTPUT_COLUMN_SEPARATOR } from './helm';
+import { HELM_OUTPUT_COLUMN_SEPARATOR } from './helm';
 import { Errorable, failed } from './errorable';
 import { parseLineOutput } from './outputUtils';
 
@@ -169,9 +169,9 @@ class HelmRepoChartVersionImpl implements HelmRepoChartVersion {
         const treeItem = new vscode.TreeItem(this.version);
         treeItem.tooltip = this.tooltip();
         treeItem.command = {
-            command: "extension.helmInspectValues",
+            command: "extension.helmInspectChart",
             title: "Inspect",
-            arguments: [{ kind: INSPECT_CHART_REPO_AUTHORITY, id: this.id, version: this.version }]
+            arguments: [this]
         };
         treeItem.contextValue = 'vsKubernetes.chartversion';
         return treeItem;

--- a/src/helm.repoExplorer.ts
+++ b/src/helm.repoExplorer.ts
@@ -49,7 +49,8 @@ export class HelmRepoExplorer implements vscode.TreeDataProvider<HelmObject> {
         return repos.result;
     }
 
-    refresh(): void {
+    async refresh(): Promise<void> {
+        await helm.helmExecAsync('repo update');
         this.onDidChangeTreeDataEmitter.fire();
     }
 }

--- a/src/helm.repoExplorer.ts
+++ b/src/helm.repoExplorer.ts
@@ -78,6 +78,7 @@ class HelmRepo implements HelmObject {
             light: vscode.Uri.file(path.join(__dirname, "../../images/light/helm-blue-vector.svg")),
             dark: vscode.Uri.file(path.join(__dirname, "../../images/dark/helm-white-vector.svg")),
         };
+        treeItem.contextValue = 'vsKubernetes.repo';
         return treeItem;
     }
 
@@ -105,7 +106,9 @@ class HelmRepoChart implements HelmObject {
     }
 
     getTreeItem(): vscode.TreeItem {
-        return new vscode.TreeItem(this.name, vscode.TreeItemCollapsibleState.Collapsed);
+        const treeItem = new vscode.TreeItem(this.name, vscode.TreeItemCollapsibleState.Collapsed);
+        treeItem.contextValue = 'vskubernetes.chart';
+        return treeItem;
     }
 
     async getChildren(): Promise<HelmObject[]> {
@@ -129,6 +132,7 @@ class HelmRepoChartVersion implements HelmObject {
             title: "Inspect",
             arguments: [{ kind: INSPECT_CHART_REPO_AUTHORITY, id: this.id, version: this.version }]
         };
+        treeItem.contextValue = 'vsKubernetes.chartversion';
         return treeItem;
     }
 

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -4,6 +4,8 @@ export const INSPECT_VALUES_SCHEME = 'helm-inspect-values';
 export const INSPECT_CHART_SCHEME = 'helm-inspect-chart';
 export const INSPECT_REPO_AUTHORITY = 'repo-chart';
 export const INSPECT_FILE_AUTHORITY = 'chart-file';
+export const DEPENDENCIES_SCHEME = 'helm-dependencies';
+export const DEPENDENCIES_REPO_AUTHORITY = 'repo-chart';
 export const HELM_OUTPUT_COLUMN_SEPARATOR = /\t+/g;
 
 let previewShown = false;

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -1,9 +1,10 @@
 export const PREVIEW_SCHEME = 'helm-template-preview';
 export const PREVIEW_URI = PREVIEW_SCHEME + '://preview';
-export const INSPECT_SCHEME = 'helm-inspect-values';
+export const INSPECT_VALUES_SCHEME = 'helm-inspect-values';
 export const HELM_OUTPUT_COLUMN_SEPARATOR = /\t+/g;
 export const INSPECT_CHART_SCHEME = 'helm-inspect-chart';
-export const INSPECT_CHART_REPO_AUTHORITY = 'repo-chart';
+export const INSPECT_REPO_AUTHORITY = 'repo-chart';
+export const INSPECT_FILE_AUTHORITY = 'chart-file';
 
 let previewShown = false;
 

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -1,10 +1,10 @@
 export const PREVIEW_SCHEME = 'helm-template-preview';
 export const PREVIEW_URI = PREVIEW_SCHEME + '://preview';
 export const INSPECT_VALUES_SCHEME = 'helm-inspect-values';
-export const HELM_OUTPUT_COLUMN_SEPARATOR = /\t+/g;
 export const INSPECT_CHART_SCHEME = 'helm-inspect-chart';
 export const INSPECT_REPO_AUTHORITY = 'repo-chart';
 export const INSPECT_FILE_AUTHORITY = 'chart-file';
+export const HELM_OUTPUT_COLUMN_SEPARATOR = /\t+/g;
 
 let previewShown = false;
 


### PR DESCRIPTION
This provides a context menu for charts and chart versions in the new Helm repo explorer tree view.  Commands implemented so far:

* `Install`
* `Fetch`
* `Inspect Chart`
* `Inspect Values`
* `Show Dependencies`

~~The original issue also asks for `Dependencies` but there's a question mark over how to implement that - will push an update and remove the WIP tag when that's resolved (or parked).~~

Fixes #323.