### PR TITLE
Enable extension features for *.yml files

### DIFF
--- a/package.json
+++ b/package.json
@@ -762,8 +762,10 @@
                     "Chart.yaml",
                     "requirements.yaml",
                     "**/templates/*.yaml",
+                    "**/templates/*.yml",
                     "**/templates/*.tpl",
                     "**/templates/**/*.yaml",
+                    "**/templates/**/*.yml",
                     "**/templates/**/*.tpl"
                 ],
                 "configuration": "./language-configuration.json"


### PR DESCRIPTION
Make helm template extension features work on `*.yml` files