### PR TITLE
Create Helm templates from resource manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Minikube tools to be installed and available on your PATH.
      * `Helm: Insert Dependency` - Insert a dependency YAML fragment
      * `Helm: Dependency Update` - Update a chart's dependencies
      * `Helm: Package` - Package a chart directory into a chart archive
+     * `Helm: Convert to Template` - Create a template based on an existing resource or manifest
+     * `Helm: Convert to Template Parameter` - Convert a fixed value in a template to a parameter in the `values.yaml` file
    * Code lenses for:
      * requirements.yaml (Add and update dependencies)
    * Right-click on a chart .tgz file, and choose inspect chart to preview all configurable chart values.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6089,6 +6089,11 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
             "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         },
+        "yaml-ast-parser": {
+            "version": "0.0.40",
+            "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.40.tgz",
+            "integrity": "sha1-CFNtTnPTIrHJziB6uN1w4E0grm4="
+        },
         "yamljs": {
             "version": "0.2.10",
             "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.2.10.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
         "onCommand:extension.helmInstall",
         "onCommand:extension.helmDependencies",
         "onCommand:extension.helmConvertToTemplate",
+        "onCommand:extension.helmParameterise",
         "onCommand:extension.draftVersion",
         "onCommand:extension.draftCreate",
         "onCommand:extension.draftUp",
@@ -857,6 +858,12 @@
                 "command": "extension.helmConvertToTemplate",
                 "title": "Convert to Template",
                 "description": "Convert this manifest to a Helm template",
+                "category": "Helm"
+            },
+            {
+                "command": "extension.helmParameterise",
+                "title": "Convert to Template Parameter",
+                "description": "Convert this value to a Helm template parameter",
                 "category": "Helm"
             },
             {

--- a/package.json
+++ b/package.json
@@ -331,6 +331,11 @@
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource"
                 },
                 {
+                    "command": "extension.helmConvertToTemplate",
+                    "group": "2",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource"
+                },
+                {
                     "command": "extension.vsKubernetesLoad",
                     "group": "0",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
@@ -376,6 +381,11 @@
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
                 },
                 {
+                    "command": "extension.helmConvertToTemplate",
+                    "group": "2",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
+                },
+                {
                     "command": "extension.vsKubernetesShowLogs",
                     "group": "3",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
@@ -411,6 +421,11 @@
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.configmap"
                 },
                 {
+                    "command": "extension.helmConvertToTemplate",
+                    "group": "2",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.configmap"
+                },
+                {
                     "command": "extension.vsKubernetesAddFile",
                     "group": "3",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.configmap"
@@ -428,6 +443,11 @@
                 {
                     "command": "extension.vsKubernetesGet",
                     "group": "2@1",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.secret"
+                },
+                {
+                    "command": "extension.helmConvertToTemplate",
+                    "group": "2",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.secret"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         "onCommand:extension.helmFetch",
         "onCommand:extension.helmInstall",
         "onCommand:extension.helmDependencies",
+        "onCommand:extension.helmConvertToTemplate",
         "onCommand:extension.draftVersion",
         "onCommand:extension.draftCreate",
         "onCommand:extension.draftUp",
@@ -175,6 +176,11 @@
                 {
                     "when": "",
                     "command": "extension.helmInspectValues",
+                    "group": "2_helm@98"
+                },
+                {
+                    "when": "",
+                    "command": "extension.helmConvertToTemplate",
                     "group": "2_helm@98"
                 }
             ],
@@ -825,6 +831,12 @@
                 "command": "extension.helmCreate",
                 "title": "Create Chart",
                 "description": "Create a new Helm Chart",
+                "category": "Helm"
+            },
+            {
+                "command": "extension.helmConvertToTemplate",
+                "title": "Convert to Template",
+                "description": "Convert this manifest to a Helm template",
                 "category": "Helm"
             },
             {

--- a/package.json
+++ b/package.json
@@ -1067,6 +1067,7 @@
         "vscode-debugprotocol": "1.27.0",
         "vscode-extension-telemetry": "^0.0.6",
         "vscode-uri": "^1.0.1",
+        "yaml-ast-parser": "^0.0.40",
         "yamljs": "0.2.10"
     },
     "devDependencies": {

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -7,6 +7,7 @@ import { Host } from './host';
 import * as kuberesources from './kuberesources';
 import { failed } from './errorable';
 import * as helmexec from './helm.exec';
+import { K8S_RESOURCE_SCHEME, KUBECTL_RESOURCE_AUTHORITY, kubefsUri } from './kuberesources.virtualfs';
 
 const KUBERNETES_CLUSTER = "vsKubernetes.cluster";
 const MINIKUBE_CLUSTER = "vsKubernetes.minikubeCluster";
@@ -49,7 +50,12 @@ export interface KubernetesObject {
 export interface ResourceNode {
     readonly id: string;
     readonly resourceId: string;
+    uri(outputFormat: string): vscode.Uri;
     namespace: string | null;
+}
+
+export function isKubernetesExplorerResourceNode(obj: any): obj is ResourceNode {
+    return obj && obj.id && obj.resourceId;
 }
 
 export class KubernetesExplorer implements vscode.TreeDataProvider<KubernetesObject> {
@@ -236,6 +242,10 @@ class KubernetesResource implements KubernetesObject, ResourceNode {
 
     get namespace(): string | null {
         return (this.metadata && this.metadata.namespace) ? this.metadata.namespace : null;
+    }
+
+    uri(outputFormat: string): vscode.Uri {
+        return kubefsUri(this.namespace, this.resourceId, outputFormat);
     }
 
     getChildren(kubectl: Kubectl, host: Host): vscode.ProviderResult<KubernetesObject[]> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1897,11 +1897,12 @@ async function helmParameterise() {
         return;
     }
 
-    const convertResult = await helmauthoring.convertToParameter(document, selection);
+    const convertResult = await helmauthoring.convertToParameter(fs, host, document, selection);
 
     if (succeeded(convertResult)) {
-        activeEditor.revealRange(convertResult.result.range);
-        activeEditor.selection = new vscode.Selection(convertResult.result.range.start, convertResult.result.range.end);
+        // TODO: this is no longer the active editor - would need to show values.yaml (if that's the UI we want)
+        // activeEditor.revealRange(convertResult.result.range);
+        // activeEditor.selection = new vscode.Selection(convertResult.result.range.start, convertResult.result.range.end);
     } else {
         vscode.window.showErrorMessage(convertResult.error[0]);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,7 +66,7 @@ import { KubernetesCompletionProvider } from "./yaml-support/yaml-snippet";
 import { showWorkspaceFolderPick } from './hostutils';
 import { DraftConfigurationProvider } from './draft/draftConfigurationProvider';
 import { installHelm, installDraft, installKubectl, installMinikube } from './components/installer/installer';
-import { KubernetesResourceVirtualFileSystemProvider, K8S_RESOURCE_SCHEME, KUBECTL_RESOURCE_AUTHORITY } from './kuberesources.virtualfs';
+import { KubernetesResourceVirtualFileSystemProvider, K8S_RESOURCE_SCHEME, KUBECTL_RESOURCE_AUTHORITY, kubefsUri } from './kuberesources.virtualfs';
 import { Container, isKubernetesResource, KubernetesCollection, Pod, KubernetesResource } from './kuberesources.objectmodel';
 import { setActiveKubeconfig, getKnownKubeconfigs, addKnownKubeconfig } from './components/config/config';
 
@@ -664,11 +664,8 @@ function loadKubernetes(explorerNode?: explorer.ResourceNode) {
 
 function loadKubernetesCore(namespace: string | null, value: string) {
     const outputFormat = vscode.workspace.getConfiguration('vs-kubernetes')['vs-kubernetes.outputFormat'];
-    const docname = `${value.replace('/', '-')}.${outputFormat}`;
-    const nonce = new Date().getTime();
-    const nsquery = namespace ? `ns=${namespace}&` : '';
-    const uri = `${K8S_RESOURCE_SCHEME}://${KUBECTL_RESOURCE_AUTHORITY}/${docname}?${nsquery}value=${value}&_=${nonce}`;
-    vscode.workspace.openTextDocument(vscode.Uri.parse(uri)).then((doc) => {
+    const uri = kubefsUri(namespace, value, outputFormat);
+    vscode.workspace.openTextDocument(uri).then((doc) => {
         if (doc) {
             vscode.window.showTextDocument(doc);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1900,9 +1900,10 @@ async function helmParameterise() {
     const convertResult = await helmauthoring.convertToParameter(fs, host, document, selection);
 
     if (succeeded(convertResult)) {
-        // TODO: this is no longer the active editor - would need to show values.yaml (if that's the UI we want)
-        // activeEditor.revealRange(convertResult.result.range);
-        // activeEditor.selection = new vscode.Selection(convertResult.result.range.start, convertResult.result.range.end);
+        const editor = await vscode.window.showTextDocument(convertResult.result.document);
+        const edit = convertResult.result.edits[0];
+        editor.revealRange(edit.range);
+        editor.selection = new vscode.Selection(edit.range.start, edit.range.end);  // TODO: this isn't quite right because it gives us the insert-at selection not the resultant edit
     } else {
         vscode.window.showErrorMessage(convertResult.error[0]);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,7 @@ import { create as minikubeCreate, CheckPresentMode as MinikubeCheckPresentMode 
 import * as logger from './logger';
 import * as helm from './helm';
 import * as helmexec from './helm.exec';
+import * as helmauthoring from './helm.authoring';
 import { HelmRequirementsCodeLensProvider } from './helm.requirementsCodeLens';
 import { HelmTemplateHoverProvider } from './helm.hoverProvider';
 import { HelmTemplatePreviewDocumentProvider, HelmInspectDocumentProvider, HelmDependencyDocumentProvider } from './helm.documentProvider';
@@ -188,6 +189,7 @@ export async function activate(context): Promise<extensionapi.ExtensionAPI> {
         registerCommand('extension.helmFetch', helmexec.helmFetch),
         registerCommand('extension.helmInstall', (o) => helmexec.helmInstall(kubectl, o)),
         registerCommand('extension.helmDependencies', helmexec.helmDependencies),
+        registerCommand('extension.helmConvertToTemplate', helmConvertToTemplate),
 
         // Commands - Draft
         registerCommand('extension.draftVersion', execDraftVersion),
@@ -1865,4 +1867,12 @@ async function execDraftUp() {
 function editorIsActive(): boolean {
     // force type coercion
     return (vscode.window.activeTextEditor) ? true : false;
+}
+
+async function helmConvertToTemplate(arg?: any) {
+    const workspace = await showWorkspaceFolderPick();
+    if (!workspace) {
+        return;
+    }
+    helmauthoring.convertToTemplate(fs, host, workspace.uri.fsPath, arg);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1901,7 +1901,7 @@ async function helmParameterise() {
 
     if (succeeded(convertResult)) {
         const editor = await vscode.window.showTextDocument(convertResult.result.document);
-        const edit = convertResult.result.edits[0];
+        const edit = convertResult.result.edit;
         editor.revealRange(edit.range);
         editor.selection = new vscode.Selection(edit.range.start, edit.range.end);  // TODO: this isn't quite right because it gives us the insert-at selection not the resultant edit
     } else {

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -11,6 +11,7 @@ export interface FS {
     unlinkAsync(path: string): Promise<void>;
     existsAsync(path: string): Promise<boolean>;
     openAsync(path: string, flags: string): Promise<void>;
+    statSync(path: string): sysfs.Stats;
 }
 
 export const fs: FS = {
@@ -54,5 +55,7 @@ export const fs: FS = {
                 resolve();
             });
         });
-    }
+    },
+
+    statSync: (path) => sysfs.statSync(path)
 };

--- a/src/helm.authoring.ts
+++ b/src/helm.authoring.ts
@@ -183,7 +183,7 @@ export async function convertToParameter(fs: FS, host: Host, document: vscode.Te
         return { succeeded: false, error: ['Selection is not a YAML field'] };
     }
 
-    const chartName = path.parse(document.fileName).name;
+    const templateName = path.parse(document.fileName).name;
 
     const valueLocation = property.location.range;
     const valueText = document.getText(valueLocation);
@@ -193,10 +193,10 @@ export async function convertToParameter(fs: FS, host: Host, document: vscode.Te
         return { succeeded: false, error: ['Cannot locate property name'] };
     }
 
-    const rawKeyPath = [chartName, valueSymbolContainmentChain[0].name];
+    const rawKeyPath = [templateName, valueSymbolContainmentChain[0].name];
     const keyPath = rawKeyPath.map(sanitiseForGoTemplate);
-    const valuePath = keyPath.join('.');
-    const replaceValueWithParamRef = new vscode.TextEdit(valueLocation, `{{ .Values.${valuePath} }}`);
+    const keyReference = keyPath.join('.');
+    const replaceValueWithParamRef = new vscode.TextEdit(valueLocation, `{{ .Values.${keyReference} }}`);
 
     const insertParamEdit = await addEntryToValuesFile(fs, host, document, keyPath, valueText);
     if (failed(insertParamEdit)) {

--- a/src/helm.authoring.ts
+++ b/src/helm.authoring.ts
@@ -89,10 +89,6 @@ function foldSpindleAndMutilate(template: any): void {
     template.metadata.name = NAME_EXPRESSION;
     template.metadata.labels.chart = CHART_LABEL_EXPRESSION;
 
-    // TODO: should we auto parameterise certain fields depending on the kind?
-    // E.g. spec.template.metadata.labels.app, is that always meant to be set?
-    // (Is there always a spec?)
-
     delete template.status;
 }
 
@@ -186,8 +182,6 @@ export async function convertToParameter(fs: FS, host: Host, document: vscode.Te
     if (!property || property.kind !== vscode.SymbolKind.Constant) {
         return { succeeded: false, error: ['Selection is not a YAML field'] };
     }
-
-    // TODO: we probably want to do this only for leaf properties
 
     const chartName = path.parse(document.fileName).name;
 

--- a/src/helm.authoring.ts
+++ b/src/helm.authoring.ts
@@ -199,7 +199,8 @@ export async function convertToParameter(fs: FS, host: Host, document: vscode.Te
         return { succeeded: false, error: ['Cannot locate property name'] };
     }
 
-    const keyPath = [chartName, valueSymbolContainmentChain[0].name];
+    const rawKeyPath = [chartName, valueSymbolContainmentChain[0].name];
+    const keyPath = rawKeyPath.map(sanitiseForGoTemplate);
     const valuePath = keyPath.join('.');
     const replaceValueWithParamRef = new vscode.TextEdit(valueLocation, ` {{ .Values.${valuePath} }}`);
 
@@ -306,4 +307,8 @@ function makeTree(indentLevel: number, keys: string[], value: string, eol: strin
 
     const subtree = makeTree(indentLevel + 2, keys.slice(1), value, eol);
     return `${indent}${keys[0]}:${eol}${subtree}`;
+}
+
+function sanitiseForGoTemplate(s: string): string {
+    return s.replace(/-/g, '_');
 }

--- a/src/helm.authoring.ts
+++ b/src/helm.authoring.ts
@@ -171,12 +171,12 @@ async function createChart(context: Context): Promise<Chart | undefined> {
     return createResult.result;
 }
 
-interface TextEdit {
+export interface TextEdit {
     readonly document: vscode.TextDocument;
     readonly edits: vscode.TextEdit[];
 }
 
-export async function convertToParameter(fs: FS, host: Host, document: vscode.TextDocument, selection: vscode.Selection): Promise<Errorable<vscode.TextEdit>> {
+export async function convertToParameter(fs: FS, host: Host, document: vscode.TextDocument, selection: vscode.Selection): Promise<Errorable<TextEdit>> {
     const helmSymbols = await getHelmSymbols(document);
     if (helmSymbols.length === 0) {
         return { succeeded: false, error: ['Active document is not a Helm template'] };
@@ -216,7 +216,7 @@ export async function convertToParameter(fs: FS, host: Host, document: vscode.Te
         return { succeeded: false, error: ['Unable to update the template and/or values file'] };
     }
 
-    return { succeeded: true, result: insertParamEdit.result.edits[0] };
+    return { succeeded: true, result: insertParamEdit.result };
 }
 
 async function applyEdits(...edits: TextEdit[]): Promise<boolean> {

--- a/src/helm.authoring.ts
+++ b/src/helm.authoring.ts
@@ -196,7 +196,7 @@ export async function convertToParameter(fs: FS, host: Host, document: vscode.Te
     const rawKeyPath = [chartName, valueSymbolContainmentChain[0].name];
     const keyPath = rawKeyPath.map(sanitiseForGoTemplate);
     const valuePath = keyPath.join('.');
-    const replaceValueWithParamRef = new vscode.TextEdit(valueLocation, ` {{ .Values.${valuePath} }}`);
+    const replaceValueWithParamRef = new vscode.TextEdit(valueLocation, `{{ .Values.${valuePath} }}`);
 
     const insertParamEdit = await addEntryToValuesFile(fs, host, document, keyPath, valueText);
     if (failed(insertParamEdit)) {

--- a/src/helm.authoring.ts
+++ b/src/helm.authoring.ts
@@ -339,5 +339,5 @@ function makeTree(indentLevel: number, keys: string[], value: string, eol: strin
 }
 
 function sanitiseForGoTemplate(s: string): string {
-    return s.replace(/-/g, '_');
+    return s.replace(/-./g, (h) => h.substring(1).toUpperCase());
 }

--- a/src/helm.authoring.ts
+++ b/src/helm.authoring.ts
@@ -75,7 +75,7 @@ enum QuoteMode {
 }
 
 const NAME_EXPRESSION = '{{ template "fullname" . }}';
-const CHART_LABEL_EXPRESSION = '{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}}';
+const CHART_LABEL_EXPRESSION = '{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}';
 
 const QUOTE_CONTROL_INFO = [
     { text: NAME_EXPRESSION, mode: QuoteMode.None },

--- a/src/helm.authoring.ts
+++ b/src/helm.authoring.ts
@@ -1,0 +1,82 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { FS } from './fs';
+import { Host } from './host';
+
+interface Context {
+    readonly fs: FS;
+    readonly host: Host;
+    readonly projectPath: string;
+}
+
+export function convertToTemplate(fs: FS, host: Host, projectPath: string, uri: vscode.Uri | undefined): void {
+    const context = { fs, host, projectPath };
+    const activeDocument = host.activeDocument();
+    if (uri) {
+        // it's a file explorer click
+        addChartFrom(context, uri.fsPath);
+    } else if (activeDocument) {
+        addChart(context, activeDocument.getText());
+    } else {
+        host.showErrorMessage("This command requires a YAML file open or selected in the Explorer.");
+    }
+}
+
+// What it needs to do:
+// * How many charts already exist in this project?  (A chart is a diorectory containing
+//   a Chart.yaml file.)
+//   - None - we need to helm create one.  (But this will create scaffolding - do we want that?)
+//   - One - we need to add the template to that chart.
+//   - Several - we need to prompt for which chart to add it to.
+// * Then we create a file in chart_dir/templates
+//   - Do we need to create anything in chart_dir/charts?  (No - this is for dependent charts.)
+// * Copy the resource/active doc YAML to the new file
+// * Strip out output-only stuff such as status
+// * Paramterise anything we can reliably parameterise
+//   - Change it to a values.* (or something-else.*?) reference
+//   - Add the * to values.yaml if required
+// * Add Helm boilerplate such as chart: labels
+
+async function addChartFrom(context: Context, fsPath: string): Promise<void> {
+    const yaml = context.fs.readFileSync(fsPath, 'utf-8');
+    await addChart(context, yaml);
+}
+
+async function addChart(context: Context, resourceYaml: string): Promise<void> {
+    // TODO: check text is valid YAML
+    const chart = await pickOrCreateChart(context);
+    if (!chart) {
+        return;
+    }
+    context.host.showInformationMessage(`create for ${resourceYaml.substring(0, 80)} in ${chart}`);
+}
+
+function chartsInProject(context: Context): string[] {
+    const fs = context.fs;
+    return subdirectories(fs, context.projectPath)
+             .filter((d) => fs.existsSync(path.join(d, "Chart.yaml")))
+             .map((d) => path.basename(d));
+}
+
+function subdirectories(fs: FS, directory: string): string[] {
+    const immediate = fs.dirSync(directory)
+                        .map((e) => path.join(directory, e))
+                        .filter((e) => fs.statSync(e).isDirectory());
+    const indirect = immediate.map((d) => subdirectories(fs, d));
+    return immediate.concat(...indirect);
+}
+
+async function pickOrCreateChart(context: Context): Promise<string | undefined> {
+    // TODO: refactor helmexec.pickChart so we can leverage it here
+    const charts = chartsInProject(context);
+    switch (charts.length) {
+        case 0:
+            // for now.  Sad!
+            context.host.showErrorMessage("No charts found.");
+            return undefined;
+        case 1:
+            return charts[0];
+        default:
+            return await context.host.showQuickPick(charts, { placeHolder: 'Select chart to add the new template to'  });
+    }
+}

--- a/src/helm.symbolProvider.ts
+++ b/src/helm.symbolProvider.ts
@@ -1,0 +1,131 @@
+import * as vscode from 'vscode';
+import * as yp from 'yaml-ast-parser';
+
+export class HelmDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
+    provideDocumentSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.SymbolInformation[]> {
+        return this.provideDocumentSymbolsImpl(document, token);
+    }
+
+    async provideDocumentSymbolsImpl(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.SymbolInformation[]> {
+        const fakeText = document.getText().replace(/{{[^}]*}}/g, (s) => azap(s));  // TODO: expiate sins
+        const root = yp.safeLoad(fakeText);
+        const syms: vscode.SymbolInformation[] = [];
+        walk(root, '', document, document.uri, syms);
+        for (const sym of syms) {
+            const cc = containmentChain(sym, syms);
+            const cctext = cc.map((s) => s.name).reverse().join('.');
+            console.log(`[${rfmt(sym)}]  ${symkind(sym)} ${cctext}.${sym.name}`);
+        }
+        return syms;
+    }
+}
+
+// TODO: OH LORD THIS IS HORRIBLE SO HORRIBLE
+function azap(s: string): string {
+    return s.replace(/{{/g, 'AA')
+            .replace(/}}/g, 'ZZ')
+            .replace(/"/g, 'Q');
+}
+
+function rfmt(s: vscode.SymbolInformation): string {
+    const r = s.location.range;
+    return `${r.start.line}:${r.start.character}-${r.end.line}:${r.end.character}`;
+}
+
+function symkind(s: vscode.SymbolInformation): string {
+    switch (s.kind) {
+        case vscode.SymbolKind.Field: return "[FI]";
+        case vscode.SymbolKind.Variable: return "[VA]";
+        case vscode.SymbolKind.Object: return "[TX]";
+        case vscode.SymbolKind.Constant: return "[CO]";
+        default: return "[??]";
+    }
+}
+
+export function containmentChain(s: vscode.SymbolInformation, sis: vscode.SymbolInformation[]): vscode.SymbolInformation[] {
+    const containers = sis.filter((si) => si.kind === vscode.SymbolKind.Field)
+                          .filter((si) => si.location.range.contains(s.location.range))
+                          .filter((si) => si !== s);
+    if (containers.length === 0) {
+        return [];
+    }
+    const nextUp = minimal(containers);
+    const fromThere = containmentChain(nextUp, sis);
+    return [nextUp, ...fromThere];
+}
+
+export function symbolAt(position: vscode.Position, sis: vscode.SymbolInformation[]): vscode.SymbolInformation | undefined {
+    const containers = sis.filter((si) => si.location.range.contains(position));
+    if (containers.length === 0) {
+        return undefined;
+    }
+    return minimal(containers);
+}
+
+function minimal(sis: vscode.SymbolInformation[]): vscode.SymbolInformation {
+    let m = sis[0];
+    for (const si of sis) {
+        if (m.location.range.contains(si.location.range)) {
+            m = si;
+        }
+    }
+    return m;
+}
+
+function symInfo(node: yp.YAMLNode, containerName: string, d: vscode.TextDocument, uri: vscode.Uri): vscode.SymbolInformation {
+    const start = node.startPosition;
+    const end = node.endPosition;
+    const loc = new vscode.Location(uri, new vscode.Range(d.positionAt(start), d.positionAt(end)));
+    switch (node.kind) {
+        case yp.Kind.ANCHOR_REF:
+            return new vscode.SymbolInformation(`ANCHOR_REF`, vscode.SymbolKind.Variable, containerName, loc);
+        case yp.Kind.INCLUDE_REF:
+            return new vscode.SymbolInformation(`INCLUDE_REF`, vscode.SymbolKind.Variable, containerName, loc);
+        case yp.Kind.MAP:
+            const m = node as yp.YamlMap;
+            return new vscode.SymbolInformation(`{map}`, vscode.SymbolKind.Variable, containerName, loc);
+        case yp.Kind.MAPPING:
+            const mp = node as yp.YAMLMapping;
+            return new vscode.SymbolInformation(`${mp.key.rawValue}`, vscode.SymbolKind.Field, containerName, loc);
+        case yp.Kind.SCALAR:
+            const sc = node as yp.YAMLScalar;
+            const isTemplateExpr = sc.rawValue.startsWith('AA') && sc.rawValue.endsWith('ZZ');
+            return new vscode.SymbolInformation(`"${sc.rawValue}"`, isTemplateExpr ? vscode.SymbolKind.Object : vscode.SymbolKind.Constant, containerName, loc);
+        case yp.Kind.SEQ:
+            const s = node as yp.YAMLSequence;
+            return new vscode.SymbolInformation(`[seq]`, vscode.SymbolKind.Variable, containerName, loc);
+    }
+    return new vscode.SymbolInformation(`###ARSEBISCUITS###`, vscode.SymbolKind.Variable, containerName, loc);
+}
+
+function walk(node: yp.YAMLNode, containerName: string, d: vscode.TextDocument, uri: vscode.Uri, syms: vscode.SymbolInformation[]) {
+    // console.log(`WALKIN' ${node.startPosition}-${node.endPosition}: ${node.kind}`);
+    const sym = symInfo(node, containerName, d, uri);
+    syms.push(sym);
+    switch (node.kind) {
+        case yp.Kind.ANCHOR_REF:
+            return;
+        case yp.Kind.INCLUDE_REF:
+            return;
+        case yp.Kind.MAP:
+            const m = node as yp.YamlMap;
+            for (const mm of m.mappings) {
+                walk(mm, sym.name, d, uri, syms);
+            }
+            return;
+        case yp.Kind.MAPPING:
+            const mp = node as yp.YAMLMapping;
+            if (mp.value) {
+                walk(mp.value, sym.name, d, uri, syms);
+            }
+            return;
+        case yp.Kind.SCALAR:
+            return;
+        case yp.Kind.SEQ:
+            const s = node as yp.YAMLSequence;
+            for (const y of s.items) {
+                walk(y, sym.name, d, uri, syms);
+            }
+            return;
+    }
+}

--- a/src/helm.symbolProvider.ts
+++ b/src/helm.symbolProvider.ts
@@ -80,7 +80,7 @@ export function containmentChain(s: vscode.SymbolInformation, sis: vscode.Symbol
     if (containers.length === 0) {
         return [];
     }
-    const nextUp = minimal(containers);
+    const nextUp = minimalSymbol(containers);
     const fromThere = containmentChain(nextUp, sis);
     return [nextUp, ...fromThere];
 }
@@ -90,10 +90,10 @@ export function symbolAt(position: vscode.Position, sis: vscode.SymbolInformatio
     if (containers.length === 0) {
         return undefined;
     }
-    return minimal(containers);
+    return minimalSymbol(containers);
 }
 
-function minimal(sis: vscode.SymbolInformation[]): vscode.SymbolInformation {
+function minimalSymbol(sis: vscode.SymbolInformation[]): vscode.SymbolInformation {
     let m = sis[0];
     for (const si of sis) {
         if (m.location.range.contains(si.location.range)) {
@@ -103,7 +103,7 @@ function minimal(sis: vscode.SymbolInformation[]): vscode.SymbolInformation {
     return m;
 }
 
-function symInfo(node: yp.YAMLNode, containerName: string, d: vscode.TextDocument, uri: vscode.Uri): vscode.SymbolInformation {
+function symbolInfo(node: yp.YAMLNode, containerName: string, d: vscode.TextDocument, uri: vscode.Uri): vscode.SymbolInformation {
     const start = node.startPosition;
     const end = node.endPosition;
     const loc = new vscode.Location(uri, new vscode.Range(d.positionAt(start), d.positionAt(end)));
@@ -134,7 +134,7 @@ function symInfo(node: yp.YAMLNode, containerName: string, d: vscode.TextDocumen
 }
 
 function walk(node: yp.YAMLNode, containerName: string, d: vscode.TextDocument, uri: vscode.Uri, syms: vscode.SymbolInformation[]) {
-    const sym = symInfo(node, containerName, d, uri);
+    const sym = symbolInfo(node, containerName, d, uri);
     syms.push(sym);
     switch (node.kind) {
         case yp.Kind.ANCHOR_REF:

--- a/src/helm.symbolProvider.ts
+++ b/src/helm.symbolProvider.ts
@@ -40,11 +40,16 @@ function hasEncodedTemplateMarkers(s: string): boolean {
         || (s.startsWith('"' + ENCODE_TEMPLATE_START) && s.endsWith(ENCODE_TEMPLATE_END + '"'));
 }
 
-export function findKeyPath(keyPath: string[], sis: vscode.SymbolInformation[]): { found: vscode.SymbolInformation | undefined, remaining: string[] } {
+export interface FoundKeyPath {
+    readonly found: vscode.SymbolInformation | undefined;
+    readonly remaining: string[];
+}
+
+export function findKeyPath(keyPath: string[], sis: vscode.SymbolInformation[]): FoundKeyPath {
     return findKeyPathAcc(keyPath, sis, undefined);
 }
 
-function findKeyPathAcc(keyPath: string[], sis: vscode.SymbolInformation[], acc: vscode.SymbolInformation | undefined): { found: vscode.SymbolInformation | undefined, remaining: string[] } {
+function findKeyPathAcc(keyPath: string[], sis: vscode.SymbolInformation[], acc: vscode.SymbolInformation | undefined): FoundKeyPath {
     const parentSym = findKey(keyPath[0], sis);
     if (!parentSym) {
         return { found: acc, remaining: keyPath };

--- a/src/helm.symbolProvider.ts
+++ b/src/helm.symbolProvider.ts
@@ -24,7 +24,11 @@ const ENCODE_TEMPLATE_START = 'AA';
 const ENCODE_TEMPLATE_END = 'ZZ';
 const ENCODE_TEMPLATE_QUOTE = 'Q';
 
-// TODO: OH LORD THIS IS HORRIBLE SO HORRIBLE
+// This is pretty horrible, but the YAML parser can't handle embedded Go template
+// expressions.  So we transform Go template expressions to (reasonably) distinctive
+// strings with the EXACT SAME position and length, run the YAML parser, then when we
+// construct the Helm AST, if we see such a string we check back to the original YAML
+// document to fix it up if necessary.
 function encodeWithTemplateMarkers(s: string): string {
     return s.replace(/{{/g, ENCODE_TEMPLATE_START)
             .replace(/}}/g, ENCODE_TEMPLATE_END)

--- a/src/host.ts
+++ b/src/host.ts
@@ -14,7 +14,8 @@ export interface Host {
     onDidCloseTerminal(listener: (e: vscode.Terminal) => any): vscode.Disposable;
     onDidChangeConfiguration(listener: (ch: vscode.ConfigurationChangeEvent) => any): vscode.Disposable;
     activeDocument(): vscode.TextDocument | undefined;
-    openDocument(uri: vscode.Uri): Promise<vscode.TextDocument>;
+    showDocument(uri: vscode.Uri): Promise<vscode.TextDocument>;
+    readDocument(uri: vscode.Uri): Promise<vscode.TextDocument>;
 }
 
 export const host: Host = {
@@ -29,7 +30,8 @@ export const host: Host = {
     onDidChangeConfiguration : onDidChangeConfiguration,
     showInputBox : showInputBox,
     activeDocument : activeDocument,
-    openDocument : openDocument
+    showDocument : showDocument,
+    readDocument : readDocument
 };
 
 function showInputBox(options: vscode.InputBoxOptions, token?: vscode.CancellationToken): Thenable<string> {
@@ -107,8 +109,14 @@ function activeDocument(): vscode.TextDocument | undefined {
     return undefined;
 }
 
-async function openDocument(uri: vscode.Uri): Promise<vscode.TextDocument> {
+async function showDocument(uri: vscode.Uri): Promise<vscode.TextDocument> {
     const document = await vscode.workspace.openTextDocument(uri);
-    await vscode.window.showTextDocument(document);
+    if (document) {
+        await vscode.window.showTextDocument(document);
+    }
     return document;
+}
+
+async function readDocument(uri: vscode.Uri): Promise<vscode.TextDocument> {
+    return await vscode.workspace.openTextDocument(uri);
 }

--- a/src/host.ts
+++ b/src/host.ts
@@ -14,6 +14,7 @@ export interface Host {
     onDidCloseTerminal(listener: (e: vscode.Terminal) => any): vscode.Disposable;
     onDidChangeConfiguration(listener: (ch: vscode.ConfigurationChangeEvent) => any): vscode.Disposable;
     activeDocument(): vscode.TextDocument | undefined;
+    openDocument(uri: vscode.Uri): Promise<vscode.TextDocument>;
 }
 
 export const host: Host = {
@@ -27,7 +28,8 @@ export const host: Host = {
     onDidCloseTerminal : onDidCloseTerminal,
     onDidChangeConfiguration : onDidChangeConfiguration,
     showInputBox : showInputBox,
-    activeDocument : activeDocument
+    activeDocument : activeDocument,
+    openDocument : openDocument
 };
 
 function showInputBox(options: vscode.InputBoxOptions, token?: vscode.CancellationToken): Thenable<string> {
@@ -103,4 +105,10 @@ function activeDocument(): vscode.TextDocument | undefined {
         return activeEditor.document;
     }
     return undefined;
+}
+
+async function openDocument(uri: vscode.Uri): Promise<vscode.TextDocument> {
+    const document = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(document);
+    return document;
 }

--- a/src/host.ts
+++ b/src/host.ts
@@ -13,6 +13,7 @@ export interface Host {
     createTerminal(name?: string, shellPath?: string, shellArgs?: string[]): vscode.Terminal;
     onDidCloseTerminal(listener: (e: vscode.Terminal) => any): vscode.Disposable;
     onDidChangeConfiguration(listener: (ch: vscode.ConfigurationChangeEvent) => any): vscode.Disposable;
+    activeDocument(): vscode.TextDocument | undefined;
 }
 
 export const host: Host = {
@@ -25,7 +26,8 @@ export const host: Host = {
     createTerminal : createTerminal,
     onDidCloseTerminal : onDidCloseTerminal,
     onDidChangeConfiguration : onDidChangeConfiguration,
-    showInputBox : showInputBox
+    showInputBox : showInputBox,
+    activeDocument : activeDocument
 };
 
 function showInputBox(options: vscode.InputBoxOptions, token?: vscode.CancellationToken): Thenable<string> {
@@ -93,4 +95,12 @@ function onDidCloseTerminal(listener: (e: vscode.Terminal) => any): vscode.Dispo
 
 function onDidChangeConfiguration(listener: (e: vscode.ConfigurationChangeEvent) => any): vscode.Disposable {
     return vscode.workspace.onDidChangeConfiguration(listener);
+}
+
+function activeDocument(): vscode.TextDocument | undefined {
+    const activeEditor = vscode.window.activeTextEditor;
+    if (activeEditor) {
+        return activeEditor.document;
+    }
+    return undefined;
 }

--- a/src/kuberesources.virtualfs.ts
+++ b/src/kuberesources.virtualfs.ts
@@ -12,6 +12,14 @@ export const K8S_RESOURCE_SCHEME = "k8smsx";
 export const KUBECTL_RESOURCE_AUTHORITY = "loadkubernetescore";
 export const HELM_RESOURCE_AUTHORITY = "helmget";
 
+export function kubefsUri(namespace: string | null, value: string, outputFormat: string): Uri {
+    const docname = `${value.replace('/', '-')}.${outputFormat}`;
+    const nonce = new Date().getTime();
+    const nsquery = namespace ? `ns=${namespace}&` : '';
+    const uri = `${K8S_RESOURCE_SCHEME}://${KUBECTL_RESOURCE_AUTHORITY}/${docname}?${nsquery}value=${value}&_=${nonce}`;
+    return Uri.parse(uri);
+}
+
 export class KubernetesResourceVirtualFileSystemProvider implements FileSystemProvider {
     constructor(private readonly kubectl: Kubectl, private readonly host: Host, private readonly rootPath: string) { }
 


### PR DESCRIPTION
This PR provides support for authoring Helm templates based on existing resources.  The intended workflow is as follows:

* Open a resource in the cluster explorer tree view and invoke the `Helm: Convert to Template` command.  (You can also right-click the resource and choose `Convert to Template` from the context menu.
* You are prompted for a template name (and, if necessary, a chart to add it to).
* A template is created in the chart's `templates` directory.  Initially, we only 'templatise' the `metadata.name` and `metadata.labels.chart` fields.
* You can now move the cursor to any value in the template and invoke the `Helm: Convert to Template Parameter` command.
* The extension replaces the value with a template expression (`{{ .Values.widget.snoofles }}`) and creates a corresponding entry and value (`widget: > snoofles: mysnooflevalue`) in values.yaml.
* You can continue converting values to parameters until your template is PERFECT IN EVERY WAY.

The scope for this is 'basic getting started'.  It's not intended to be a means of maintaining complex charts - just a way for someone to take an existing resource and say "this does what I want but I just need to be able to vary these knobs."

Now, I have plenty of questions about my implementation.

* Is this a useful workflow for Helm chart authors?
* Are there any values which should _always_ be parameterised in predictable ways?
* Is it okay to infer a parameter name or is it important to offer fine control?
* Is the structure of the generated parameters reasonable?  It's a bit flatter than the manifest YAML but that seems consistent with some of the sample templates.
* Are the resultant templates and `values.yaml` entries correct, or have I missed some subtlety of how Helm wires these things up?
* Does anything about the output make you flinch and go "ugh, we don't want people doing it like _that_"?  (The implementation code _will_ make you flinch but let's skate delicately past that.)

It would be great if folks could have a play with it and see if it feels natural and helpful.  Please also report bugs as it's not been extensively tested, though at this stage I'm most concerned about getting the right flow - squashing the edge cases can come later.  Things in the 'and it would be great if it could do X' category might be best raised as issues so that we don't try to boil the ocean in one PR - it's already large and complicated enough - but I can incorporate them if they're must-have.