### PR TITLE
Support rapid switching between multiple kubeconfigs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ If you are building and running the extension from source, see [CONTRIBUTING.md]
    * `Kubernetes: Add Existing Cluster` - Install and configure the Kubernetes command line tool (kubectl) from a cloud cluster, such as an Azure Container Service (ACS) or Azure Kubernetes Service (AKS) cluster
    * `Kubernetes: Set as Current Cluster` - Select from a list of configured clusters to set the "current" cluster. Used for searching, displaying, and deploying Kubernetes resources.
    * `Kubernetes: Delete Context` - Remove a cluster's configuration from the kubeconfig file.
+   * `Kubernetes: Set Kubeconfig` - Select from a list of known kubeconfig files (for users who keep different kubeconfig files for different environments).
    * `Kubernetes: Show Cluster Info` - For a cluster, show the status of Kubernetes Components (API Server, etcd, KubeDNS, etc.) in a terminal window.
    * `Kubernetes: Use Namespace` - Select from a list of namespaces to set the "current" namespace. Used for searching, displaying, and deploying Kubernetes resources.
 
@@ -172,9 +173,16 @@ Minikube tools to be installed and available on your PATH.
        * `vs-kubernetes.helm-path` - File path to the helm binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
        * `vs-kubernetes.draft-path` - File path to the draft binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension (note current versions of Draft are not supported on Windows).
        * `vs-kubernetes.kubeconfig` - File path to the kubeconfig file you want to use. This overrides both the default kubeconfig and the KUBECONFIG environment variable.
+       * `vs-kubernetes.knownKubeconfigs` - An array of file paths of kubeconfig files that you want to be able to quickly switch between using the Set Kubeconfig command.
        * `vs-kubernetes.autoCleanupOnDebugTerminate` - The flag to control whether to auto cleanup the created deployment and associated pod by the command "Kubernetes: Debug (Launch)". The cleanup action occurs when it failed to start debug session or debug session terminated. If not specified, the extension will prompt for whether to clean up or not. You might choose not to clean up if you wanted to view pod logs, etc.
        * `vs-kubernetes.outputFormat` - The output format that you prefer to view Kubernetes manifests in. One of "yaml" or "json". Defaults to "yaml".
    * `vsdocker.imageUser` - Image prefix for docker images e.g. 'docker.io/brendanburns'
+
+## Keybinding Support
+
+The following commands support arguments in keybindings:
+
+  * **Set Kubeconfig** (command ID `extension.vsKubernetesUseKubeconfig`) - the keybinding can specify a string argument which is the kubeconfig file path to switch to.  This allows you to set up specific keybindings for your favourite kubeconfigs.
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "onCommand:extension.vsKubernetesRemoveDebug",
         "onCommand:extension.vsKubernetesConfigureFromCluster",
         "onCommand:extension.vsKubernetesCreateCluster",
+        "onCommand:extension.vsKubernetesUseKubeconfig",
         "onCommand:extension.vsKubernetesDashboard",
         "onCommand:extension.vsMinikubeStop",
         "onCommand:extension.vsMinikubeStart",
@@ -107,6 +108,10 @@
                             "type": "string",
                             "description": "File path to the kubeconfig file."
                         },
+                        "vs-kubernetes.knownKubeconfigs": {
+                            "type": "array",
+                            "description": "File paths to kubeconfig files from which you can select."
+                        },
                         "vs-kubernetes.autoCleanupOnDebugTerminate": {
                             "type": "boolean",
                             "description": "Once the debug session is terminated, automatically clean up the created Deployment and associated Pod by the command \"Kubernetes: Debug (Launch)\"."
@@ -127,6 +132,7 @@
                         "vs-kubernetes.draft-path": "",
                         "vs-kubernetes.outputFormat": "yaml",
                         "vs-kubernetes.kubeconfig": "",
+                        "vs-kubernetes.knownKubeconfigs": [],
                         "vs-kubernetes.autoCleanupOnDebugTerminate": false
                     }
                 },
@@ -658,6 +664,11 @@
             {
                 "command": "extension.vsKubernetesUseContext",
                 "title": "Set as Current Cluster",
+                "category": "Kubernetes"
+            },
+            {
+                "command": "extension.vsKubernetesUseKubeconfig",
+                "title": "Set Kubeconfig",
                 "category": "Kubernetes"
             },
             {

--- a/src/components/clusterprovider/azure/azure.ts
+++ b/src/components/clusterprovider/azure/azure.ts
@@ -7,6 +7,7 @@ import { ActionResult, fromShellJson, fromShellExitCodeAndStandardError, fromShe
 import { Errorable, failed } from '../../../errorable';
 import * as compareVersions from 'compare-versions';
 import { sleep } from '../../../sleep';
+import { getActiveKubeconfig } from '../../config/config';
 
 export interface Context {
     readonly fs: FS;
@@ -334,7 +335,7 @@ async function downloadKubectlCli(context: Context, clusterType: string): Promis
 }
 
 async function getCredentials(context: Context, clusterType: string, clusterName: string, clusterGroup: string, maxAttempts: number): Promise<any> {
-    const kubeconfig: string = vscode.workspace.getConfiguration('vs-kubernetes')['vs-kubernetes.kubeconfig'];
+    const kubeconfig = getActiveKubeconfig();
     const kubeconfigFileOption = kubeconfig ? `-f "${kubeconfig}"` : '';
     let attempts = 0;
     while (true) {

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode';
+
+export async function addPathToConfig(configKey: string, value: string): Promise<void> {
+    const config = vscode.workspace.getConfiguration().inspect("vs-kubernetes");
+    await addPathToConfigAtScope(configKey, value, vscode.ConfigurationTarget.Global, config.globalValue, true);
+    await addPathToConfigAtScope(configKey, value, vscode.ConfigurationTarget.Workspace, config.workspaceValue, false);
+    await addPathToConfigAtScope(configKey, value, vscode.ConfigurationTarget.WorkspaceFolder, config.workspaceFolderValue, false);
+}
+
+async function addPathToConfigAtScope(configKey: string, value: string, scope: vscode.ConfigurationTarget, valueAtScope: any, createIfNotExist: boolean): Promise<void> {
+    if (!createIfNotExist) {
+        if (!valueAtScope || !(valueAtScope[configKey])) {
+            return;
+        }
+    }
+
+    let newValue: any = {};
+    if (valueAtScope) {
+        newValue = Object.assign({}, valueAtScope);
+    }
+    newValue[configKey] = value;
+    await vscode.workspace.getConfiguration().update("vs-kubernetes", newValue, scope);
+}

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -21,3 +21,27 @@ async function addPathToConfigAtScope(configKey: string, value: string, scope: v
     newValue[configKey] = value;
     await vscode.workspace.getConfiguration().update("vs-kubernetes", newValue, scope);
 }
+
+export async function addValueToConfigArray(configKey: string, value: string): Promise<void> {
+    const config = vscode.workspace.getConfiguration().inspect("vs-kubernetes");
+    await addValueToConfigArrayAtScope(configKey, value, vscode.ConfigurationTarget.Global, config.globalValue, true);
+    await addValueToConfigArrayAtScope(configKey, value, vscode.ConfigurationTarget.Workspace, config.workspaceValue, false);
+    await addValueToConfigArrayAtScope(configKey, value, vscode.ConfigurationTarget.WorkspaceFolder, config.workspaceFolderValue, false);
+}
+
+async function addValueToConfigArrayAtScope(configKey: string, value: string, scope: vscode.ConfigurationTarget, valueAtScope: any, createIfNotExist: boolean): Promise<void> {
+    if (!createIfNotExist) {
+        if (!valueAtScope || !(valueAtScope[configKey])) {
+            return;
+        }
+    }
+
+    let newValue: any = {};
+    if (valueAtScope) {
+        newValue = Object.assign({}, valueAtScope);
+    }
+    const arrayEntry: string[] = newValue[configKey] || [];
+    arrayEntry.push(value);
+    newValue[configKey] = arrayEntry;
+    await vscode.workspace.getConfiguration().update("vs-kubernetes", newValue, scope);
+}

--- a/src/components/installer/installer.ts
+++ b/src/components/installer/installer.ts
@@ -8,6 +8,7 @@ import * as tar from 'tar';
 import * as vscode from 'vscode';
 import { Shell, Platform } from '../../shell';
 import { Errorable, failed, succeeded } from '../../errorable';
+import { addPathToConfig } from '../config/config';
 
 export async function installKubectl(shell: Shell): Promise<Errorable<void>> {
     const tool = 'kubectl';
@@ -162,26 +163,4 @@ async function untar(sourceFile: string, destinationFolder: string): Promise<Err
     } catch (e) {
         return { succeeded: false, error: [ "tar extract failed" ] /* TODO: extract error from exception */ };
     }
-}
-
-async function addPathToConfig(configKey: string, executableFullPath: string): Promise<void> {
-    const config = vscode.workspace.getConfiguration().inspect("vs-kubernetes");
-    await addPathToConfigAtScope(configKey, executableFullPath, vscode.ConfigurationTarget.Global, config.globalValue, true);
-    await addPathToConfigAtScope(configKey, executableFullPath, vscode.ConfigurationTarget.Workspace, config.workspaceValue, false);
-    await addPathToConfigAtScope(configKey, executableFullPath, vscode.ConfigurationTarget.WorkspaceFolder, config.workspaceFolderValue, false);
-}
-
-async function addPathToConfigAtScope(configKey: string, value: string, scope: vscode.ConfigurationTarget, valueAtScope: any, createIfNotExist: boolean): Promise<void> {
-    if (!createIfNotExist) {
-        if (!valueAtScope || !(valueAtScope[configKey])) {
-            return;
-        }
-    }
-
-    let newValue: any = {};
-    if (valueAtScope) {
-        newValue = Object.assign({}, valueAtScope);
-    }
-    newValue[configKey] = value;
-    await vscode.workspace.getConfiguration().update("vs-kubernetes", newValue, scope);
 }

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -3,6 +3,7 @@
 import * as vscode from 'vscode';
 import * as shelljs from 'shelljs';
 import * as path from 'path';
+import { getActiveKubeconfig } from './components/config/config';
 
 export enum Platform {
     Windows,
@@ -134,7 +135,7 @@ export function shellEnvironment(baseEnvironment: any): any {
         }
     }
 
-    const kubeconfig: string = vscode.workspace.getConfiguration('vs-kubernetes')['vs-kubernetes.kubeconfig'];
+    const kubeconfig = getActiveKubeconfig();
     if (kubeconfig) {
         env['KUBECONFIG'] = kubeconfig;
     }


### PR DESCRIPTION
Some users have multiple Kubernetes environments which they keep in separate kubeconfig files.  For working with relatively static kubeconfigs (e.g. single alternate kubeconfig, kubeconfig per project, etc.) we have the `vs-kubernetes.kubeconfig` setting which can be applied at global or workspace level.  But if the user wants to be able to swap more dynamically then they have to keep changing that setting and that is a bit niggly.

This PR adds a `Set Kubeconfig` command.  This command displays a list of 'known kubeconfigs' from which the user can choose.  The user can also choose to add a new known kubeconfig, which immediately becomes selected and is added to the list of known kubeconfigs.

In addition, the command supports passing a kubeconfig file path as an argument.  This means that a user can set up keybindings for their favourite kubeconfig files, e.g. in `keybindings.json` write:

```json
    {
        "key": "ctrl+shift+alt+k",
        "command": "extension.vsKubernetesUseKubeconfig",
        "args": "d:\\temp\\kubectl\\my.other.kubeconfig"
    }
```

The user can then instantly (well... fairly instantly) switch to that kubeconfig using their chosen key combo.