### PR TITLE
Add persistent volumes, PV claims and storage classes to tree view

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -139,6 +139,7 @@ class KubernetesContextNode implements KubernetesObject {
             new KubernetesWorkloadFolder(),
             new KubernetesServiceFolder(),
             new KubernetesResourceFolder(kuberesources.allKinds.ingress),
+            new KubernetesStorageFolder(),
             new KubernetesConfigFolder(),
             new HelmReleasesFolder(),
         ];
@@ -205,6 +206,20 @@ class KubernetesConfigFolder extends KubernetesFolder {
         return [
             new KubernetesDataHolderFolder(kuberesources.allKinds.configMap),
             new KubernetesDataHolderFolder(kuberesources.allKinds.secret)
+        ];
+    }
+}
+
+class KubernetesStorageFolder extends KubernetesFolder {
+    constructor() {
+        super("storage", "Storage");
+    }
+
+    getChildren(kubectl: Kubectl, host: Host): vscode.ProviderResult<KubernetesObject[]> {
+        return [
+            new KubernetesResourceFolder(kuberesources.allKinds.persistentVolume),
+            new KubernetesResourceFolder(kuberesources.allKinds.persistentVolumeClaim),
+            new KubernetesResourceFolder(kuberesources.allKinds.storageClass),
         ];
     }
 }

--- a/src/kuberesources.ts
+++ b/src/kuberesources.ts
@@ -20,6 +20,9 @@ export const allKinds = {
     configMap: new ResourceKind("ConfigMap", "ConfigMaps", "configmap"),
     secret: new ResourceKind("Secret", "Secrets", "secret"),
     ingress: new ResourceKind("Ingress", "Ingress", "ingress"),
+    persistentVolume: new ResourceKind("Persistent Volume", "Persistent Volumes", "pv"),
+    persistentVolumeClaim: new ResourceKind("Persistent Volume Claim", "Persistent Volume Claims", "pvc"),
+    storageClass: new ResourceKind("Storage Class", "Storage Classes", "sc"),
 };
 
 export const commonKinds = [


### PR DESCRIPTION
First cut of an update for storage-related resource types - it just adds them to the tree view with the same set of verbs as other resources.  Should there be other/different operations, and are any other resource types required?

Fixes #338.