### PR TITLE
Activate if the extension is needed for re-opening live resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
         "onView:extension.vsKubernetesHelmRepoExplorer",
         "onLanguage:helm",
         "onLanguage:yaml",
+        "onFileSystem:k8smsx",
         "onDebug"
     ],
     "main": "./out/src/extension",


### PR DESCRIPTION
If you leave a resource open (from the cluster view) and then close and reopen VS Code, it restarts with the resource tab open, wabbles for a bit and then closes the resource tab.  This occurs because VS Code tries to reopen documents, but when it tries to load the content of the 'resource' document, it can't find anything to handle the `k8smsx` URI scheme.

This PR specifies to activate the extension if Code needs the `k8smsx` URI scheme, thus allowing Code to load the tab content.

(It might arguably be better for Code not to try to reopen the tab at all but I don't think we have that option.)

