### PR TITLE
Warn if a pod or deployment does not specify CPU or memory limits

### DIFF
--- a/src/components/lint/linter.impl.ts
+++ b/src/components/lint/linter.impl.ts
@@ -1,0 +1,60 @@
+import * as vscode from 'vscode';
+import * as yaml from 'js-yaml';
+
+import { JsonALikeYamlDocumentSymbolProvider } from '../../yaml-support/jsonalike-symbol-provider';
+import { Linter } from './linters';
+
+const jsonalikeYamlSymboliser = new JsonALikeYamlDocumentSymbolProvider();
+
+export function expose(impl: LinterImpl): Linter {
+    return new StandardLinter(impl);
+}
+
+export interface Syntax {
+    load(text: string): any;
+    symbolise(document: vscode.TextDocument): Promise<vscode.SymbolInformation[]>;
+}
+
+class StandardLinter implements Linter {
+    constructor(private readonly impl: LinterImpl) {}
+
+    async lint(document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
+        try {
+            switch (document.languageId) {
+                case 'json':
+                    return await this.impl.lint(document, jsonSyntax);
+                case 'yaml':
+                    return await this.impl.lint(document, yamlSyntax);
+                default:
+                    // TODO: do we need to do Helm?
+                    return [];
+            }
+        } catch {
+            return [];
+        }
+    }
+}
+
+const jsonSyntax = {
+    load(text: string) { return JSON.parse(text); },
+    symbolise(document: vscode.TextDocument) { return getSymbols(document); }
+};
+
+const yamlSyntax = {
+    load(text: string) { return yaml.safeLoad(text); },
+    async symbolise(document: vscode.TextDocument) { return await jsonalikeYamlSymboliser.provideDocumentSymbols(document, new vscode.CancellationTokenSource().token); }
+};
+
+export interface LinterImpl {
+    lint(document: vscode.TextDocument, syntax: Syntax): Promise<vscode.Diagnostic[]>;
+}
+
+async function getSymbols(document: vscode.TextDocument): Promise<vscode.SymbolInformation[]> {
+    const sis: any = await vscode.commands.executeCommand('vscode.executeDocumentSymbolProvider', document.uri);
+
+    if (sis && sis.length) {
+        return sis;
+    }
+
+    return [];
+}

--- a/src/components/lint/linter.utils.ts
+++ b/src/components/lint/linter.utils.ts
@@ -1,0 +1,13 @@
+import * as vscode from 'vscode';
+
+export function symbolContains(outer: vscode.SymbolInformation, inner: vscode.SymbolInformation): boolean {
+    return outer.location.range.contains(inner.location.range);  // don't worry about URI
+}
+
+export function childSymbols(allSymbols: vscode.SymbolInformation[], parent: vscode.SymbolInformation, name: string): vscode.SymbolInformation[] {
+    return allSymbols.filter((s) => s.name === name && s.containerName === `${parent.containerName}.${parent.name}` && symbolContains(parent, s));
+}
+
+export function warningOn(symbol: vscode.SymbolInformation, text: string): vscode.Diagnostic {
+    return new vscode.Diagnostic(symbol.location.range, text, vscode.DiagnosticSeverity.Warning);
+}

--- a/src/components/lint/linters.ts
+++ b/src/components/lint/linters.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+
+import { ResourceLimitsLinter } from './resourcelimits';
+
+export interface Linter {
+    lint(document: vscode.TextDocument): Promise<vscode.Diagnostic[]>;
+}
+
+export const linters: Linter[] = [
+    new ResourceLimitsLinter()
+];

--- a/src/components/lint/linters.ts
+++ b/src/components/lint/linters.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { expose } from './linter.impl';
 import { ResourceLimitsLinter } from './resourcelimits';
 
 export interface Linter {
@@ -8,4 +9,4 @@ export interface Linter {
 
 export const linters: Linter[] = [
     new ResourceLimitsLinter()
-];
+].map(expose);

--- a/src/components/lint/resourcelimits.ts
+++ b/src/components/lint/resourcelimits.ts
@@ -1,0 +1,117 @@
+import * as vscode from 'vscode';
+import * as yaml from 'js-yaml';
+
+import { Linter } from './linters';
+import { JsonALikeYamlDocumentSymbolProvider } from '../../yaml-support/jsonalike-symbol-provider';
+
+const jsonalikeYamlSymboliser = new JsonALikeYamlDocumentSymbolProvider();
+
+interface Syntax {
+    load(text: string): any;
+    symbolise(document: vscode.TextDocument): Promise<vscode.SymbolInformation[]>;
+}
+
+const jsonSyntax = {
+    load(text: string) { return JSON.parse(text); },
+    symbolise(document: vscode.TextDocument) { return getSymbols(document); }
+};
+
+const yamlSyntax = {
+    load(text: string) { return yaml.safeLoad(text); },
+    async symbolise(document: vscode.TextDocument) { return await jsonalikeYamlSymboliser.provideDocumentSymbols(document, new vscode.CancellationTokenSource().token); }
+};
+
+// Pod->spec (which can also be found as Deployment->spec.template.spec)
+// .containers[each].resources.limits.{cpu,memory}
+
+export class ResourceLimitsLinter implements Linter {
+    async lint(document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
+        try {
+            switch (document.languageId) {
+                case 'json':
+                    return await this.lintCore(document, jsonSyntax);
+                case 'yaml':
+                    return await this.lintCore(document, yamlSyntax);
+                default:
+                    // TODO: do we need to do Helm?
+                    return [];
+            }
+        } catch {
+            return [];
+        }
+    }
+
+    async lintCore(document: vscode.TextDocument, syntax: Syntax): Promise<vscode.Diagnostic[]> {
+        const resource = syntax.load(document.getText());
+        if (!resource) {
+            return [];
+        }
+
+        const podSpecPrefix =
+            resource.kind === 'Pod' ? 'spec' :
+            resource.kind === 'Deployment' ? 'spec.template.spec' :
+            undefined;
+        if (!podSpecPrefix) {
+            return [];
+        }
+
+        const symbols = await syntax.symbolise(document);
+        const containersSymbols = symbols.filter((s) => s.name === 'containers' && s.containerName === podSpecPrefix);
+        if (!containersSymbols) {
+            return [];
+        }
+
+        const warnings: vscode.Diagnostic[] = [];
+        const warnOn = (symbol: vscode.SymbolInformation, text: string) => {
+            warnings.push(warningOn(symbol, text));
+        };
+
+        for (const containersSymbol of containersSymbols) {
+            const imagesSymbols = childSymbols(symbols, containersSymbol, 'image');
+            const resourcesSymbols = childSymbols(symbols, containersSymbol, 'resources');
+            if (resourcesSymbols.length < imagesSymbols.length) {
+                warnOn(containersSymbol, 'One or more containers do not have resource limits - this could starve other processes');
+            }
+            for (const resourcesSymbol of resourcesSymbols) {
+                const limitsSymbols = childSymbols(symbols, resourcesSymbol, 'limits');
+                if (limitsSymbols.length === 0) {
+                    warnOn(resourcesSymbol, 'No resource limits specified for this container - this could starve other processes');
+                }
+                for (const limitsSymbol of limitsSymbols) {
+                    const cpuSymbols = childSymbols(symbols, limitsSymbol, 'cpu');
+                    if (cpuSymbols.length === 0) {
+                        warnOn(limitsSymbol, 'No CPU limit specified for this container - this could starve other processes');
+                    }
+                    const memorySymbols = childSymbols(symbols, limitsSymbol, 'memory');
+                    if (memorySymbols.length === 0) {
+                        warnOn(limitsSymbol, 'No memory limit specified for this container - this could starve other processes');
+                    }
+                }
+            }
+        }
+
+        return warnings;
+    }
+}
+
+async function getSymbols(document: vscode.TextDocument): Promise<vscode.SymbolInformation[]> {
+    const sis: any = await vscode.commands.executeCommand('vscode.executeDocumentSymbolProvider', document.uri);
+
+    if (sis && sis.length) {
+        return sis;
+    }
+
+    return [];
+}
+
+function symbolContains(outer: vscode.SymbolInformation, inner: vscode.SymbolInformation): boolean {
+    return outer.location.range.contains(inner.location.range);  // don't worry about URI
+}
+
+function childSymbols(allSymbols: vscode.SymbolInformation[], parent: vscode.SymbolInformation, name: string): vscode.SymbolInformation[] {
+    return allSymbols.filter((s) => s.name === name && s.containerName === `${parent.containerName}.${parent.name}` && symbolContains(parent, s));
+}
+
+function warningOn(symbol: vscode.SymbolInformation, text: string): vscode.Diagnostic {
+    return new vscode.Diagnostic(symbol.location.range, text, vscode.DiagnosticSeverity.Warning);
+}

--- a/src/components/lint/resourcelimits.ts
+++ b/src/components/lint/resourcelimits.ts
@@ -1,47 +1,13 @@
 import * as vscode from 'vscode';
-import * as yaml from 'js-yaml';
 
-import { Linter } from './linters';
-import { JsonALikeYamlDocumentSymbolProvider } from '../../yaml-support/jsonalike-symbol-provider';
-
-const jsonalikeYamlSymboliser = new JsonALikeYamlDocumentSymbolProvider();
-
-interface Syntax {
-    load(text: string): any;
-    symbolise(document: vscode.TextDocument): Promise<vscode.SymbolInformation[]>;
-}
-
-const jsonSyntax = {
-    load(text: string) { return JSON.parse(text); },
-    symbolise(document: vscode.TextDocument) { return getSymbols(document); }
-};
-
-const yamlSyntax = {
-    load(text: string) { return yaml.safeLoad(text); },
-    async symbolise(document: vscode.TextDocument) { return await jsonalikeYamlSymboliser.provideDocumentSymbols(document, new vscode.CancellationTokenSource().token); }
-};
+import { LinterImpl, Syntax } from './linter.impl';
+import { warningOn, childSymbols } from './linter.utils';
 
 // Pod->spec (which can also be found as Deployment->spec.template.spec)
 // .containers[each].resources.limits.{cpu,memory}
 
-export class ResourceLimitsLinter implements Linter {
-    async lint(document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
-        try {
-            switch (document.languageId) {
-                case 'json':
-                    return await this.lintCore(document, jsonSyntax);
-                case 'yaml':
-                    return await this.lintCore(document, yamlSyntax);
-                default:
-                    // TODO: do we need to do Helm?
-                    return [];
-            }
-        } catch {
-            return [];
-        }
-    }
-
-    async lintCore(document: vscode.TextDocument, syntax: Syntax): Promise<vscode.Diagnostic[]> {
+export class ResourceLimitsLinter implements LinterImpl {
+    async lint(document: vscode.TextDocument, syntax: Syntax): Promise<vscode.Diagnostic[]> {
         const resource = syntax.load(document.getText());
         if (!resource) {
             return [];
@@ -92,26 +58,4 @@ export class ResourceLimitsLinter implements Linter {
 
         return warnings;
     }
-}
-
-async function getSymbols(document: vscode.TextDocument): Promise<vscode.SymbolInformation[]> {
-    const sis: any = await vscode.commands.executeCommand('vscode.executeDocumentSymbolProvider', document.uri);
-
-    if (sis && sis.length) {
-        return sis;
-    }
-
-    return [];
-}
-
-function symbolContains(outer: vscode.SymbolInformation, inner: vscode.SymbolInformation): boolean {
-    return outer.location.range.contains(inner.location.range);  // don't worry about URI
-}
-
-function childSymbols(allSymbols: vscode.SymbolInformation[], parent: vscode.SymbolInformation, name: string): vscode.SymbolInformation[] {
-    return allSymbols.filter((s) => s.name === name && s.containerName === `${parent.containerName}.${parent.name}` && symbolContains(parent, s));
-}
-
-function warningOn(symbol: vscode.SymbolInformation, text: string): vscode.Diagnostic {
-    return new vscode.Diagnostic(symbol.location.range, text, vscode.DiagnosticSeverity.Warning);
 }

--- a/src/yaml-support/jsonalike-symbol-provider.ts
+++ b/src/yaml-support/jsonalike-symbol-provider.ts
@@ -1,0 +1,163 @@
+import * as vscode from 'vscode';
+import * as yp from 'yaml-ast-parser';
+import * as _ from 'lodash';
+
+export class JsonALikeYamlDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
+    provideDocumentSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.SymbolInformation[]> {
+        return this.provideDocumentSymbolsImpl(document, token);
+    }
+
+    async provideDocumentSymbolsImpl(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.SymbolInformation[]> {
+        const fakeText = document.getText().replace(/{{[^}]*}}/g, (s) => encodeWithTemplateMarkers(s));
+        const root = yp.safeLoad(fakeText);
+        const syms: vscode.SymbolInformation[] = [];
+        walk(root, '', document, document.uri, syms);
+        return syms;
+    }
+}
+
+// These MUST be the same lengths as the strings they replace
+// ('{{', '}}' and '"'") - we rely on the text ranges staying
+// the same in order to detect and substitute back the actual
+// template expression.
+const ENCODE_TEMPLATE_START = 'AA';
+const ENCODE_TEMPLATE_END = 'ZZ';
+const ENCODE_TEMPLATE_QUOTE = 'Q';
+
+// This is pretty horrible, but the YAML parser can't handle embedded Go template
+// expressions.  So we transform Go template expressions to (reasonably) distinctive
+// strings with the EXACT SAME position and length, run the YAML parser, then when we
+// construct the Helm AST, if we see such a string we check back to the original YAML
+// document to fix it up if necessary.
+function encodeWithTemplateMarkers(s: string): string {
+    return s.replace(/{{/g, ENCODE_TEMPLATE_START)
+            .replace(/}}/g, ENCODE_TEMPLATE_END)
+            .replace(/"/g, ENCODE_TEMPLATE_QUOTE);
+}
+
+function hasEncodedTemplateMarkers(s: string): boolean {
+    return (s.startsWith(ENCODE_TEMPLATE_START) && s.endsWith(ENCODE_TEMPLATE_END))
+        || (s.startsWith('"' + ENCODE_TEMPLATE_START) && s.endsWith(ENCODE_TEMPLATE_END + '"'));
+}
+
+export interface FoundKeyPath {
+    readonly found: vscode.SymbolInformation | undefined;
+    readonly remaining: string[];
+}
+
+export function findKeyPath(keyPath: string[], sis: vscode.SymbolInformation[]): FoundKeyPath {
+    return findKeyPathAcc(keyPath, sis, undefined);
+}
+
+function findKeyPathAcc(keyPath: string[], sis: vscode.SymbolInformation[], acc: vscode.SymbolInformation | undefined): FoundKeyPath {
+    const parentSym = findKey(keyPath[0], sis);
+    if (!parentSym) {
+        return { found: acc, remaining: keyPath };
+    }
+    if (keyPath.length === 1) {
+        return { found: parentSym, remaining: [] };
+    }
+    const childSyms = sis.filter((s) => parentSym.location.range.contains(s.location.range));
+    return findKeyPathAcc(keyPath.slice(1), childSyms, parentSym);
+}
+
+function findKey(key: string, sis: vscode.SymbolInformation[]): vscode.SymbolInformation | undefined {
+    const fields = sis.filter((si) => si.kind === vscode.SymbolKind.Field && si.name === key);
+    if (fields.length === 0) {
+        return undefined;
+    }
+    return outermost(fields);
+}
+
+function outermost(sis: vscode.SymbolInformation[]): vscode.SymbolInformation {
+    return _.maxBy(sis, (s) => containmentChain(s, sis));
+}
+
+export function containmentChain(s: vscode.SymbolInformation, sis: vscode.SymbolInformation[]): vscode.SymbolInformation[] {
+    const containers = sis.filter((si) => si.kind === vscode.SymbolKind.Field)
+                          .filter((si) => si.location.range.contains(s.location.range))
+                          .filter((si) => si !== s);
+    if (containers.length === 0) {
+        return [];
+    }
+    const nextUp = minimalSymbol(containers);
+    const fromThere = containmentChain(nextUp, sis);
+    return [nextUp, ...fromThere];
+}
+
+export function symbolAt(position: vscode.Position, sis: vscode.SymbolInformation[]): vscode.SymbolInformation | undefined {
+    const containers = sis.filter((si) => si.location.range.contains(position));
+    if (containers.length === 0) {
+        return undefined;
+    }
+    return minimalSymbol(containers);
+}
+
+function minimalSymbol(sis: vscode.SymbolInformation[]): vscode.SymbolInformation {
+    let m = sis[0];
+    for (const si of sis) {
+        if (m.location.range.contains(si.location.range)) {
+            m = si;
+        }
+    }
+    return m;
+}
+
+function symbolInfo(node: yp.YAMLNode, containerName: string, d: vscode.TextDocument, uri: vscode.Uri): vscode.SymbolInformation[] {
+    const start = node.startPosition;
+    const end = node.endPosition;
+    const loc = new vscode.Location(uri, new vscode.Range(d.positionAt(start), d.positionAt(end)));
+    switch (node.kind) {
+        case yp.Kind.ANCHOR_REF:
+            return [];
+        case yp.Kind.INCLUDE_REF:
+            return [];
+        case yp.Kind.MAP:
+            return [];
+        case yp.Kind.MAPPING:
+            const mp = node as yp.YAMLMapping;
+            let sk = vscode.SymbolKind.String;
+            switch (mp.value.kind) {
+                case yp.Kind.MAP: sk = vscode.SymbolKind.Module; break;  // go figure
+                case yp.Kind.MAPPING: sk = vscode.SymbolKind.Object; break;
+                case yp.Kind.SEQ: sk = vscode.SymbolKind.Array; break;
+            }
+            return [new vscode.SymbolInformation(`${mp.key.rawValue}`, sk, containerName, loc)];
+        case yp.Kind.SCALAR:
+            return [];
+        case yp.Kind.SEQ:
+            return [];
+    }
+    return [];
+}
+
+function walk(node: yp.YAMLNode, containerName: string, d: vscode.TextDocument, uri: vscode.Uri, syms: vscode.SymbolInformation[]) {
+    const sym = symbolInfo(node, containerName, d, uri);
+    syms.push(...sym);
+    switch (node.kind) {
+        case yp.Kind.ANCHOR_REF:
+            return;
+        case yp.Kind.INCLUDE_REF:
+            return;
+        case yp.Kind.MAP:
+            const m = node as yp.YamlMap;
+            for (const mm of m.mappings) {
+                walk(mm, containerName, d, uri, syms);
+            }
+            return;
+        case yp.Kind.MAPPING:
+            const mp = node as yp.YAMLMapping;
+            if (mp.value) {
+                walk(mp.value, `${containerName}${containerName ? '.' : ''}${sym[0].name}`, d, uri, syms);
+            }
+            return;
+        case yp.Kind.SCALAR:
+            return;
+        case yp.Kind.SEQ:
+            const s = node as yp.YAMLSequence;
+            for (const y of s.items) {
+                walk(y, containerName, d, uri, syms);
+            }
+            return;
+    }
+}


### PR DESCRIPTION
We're finding that a common mistake that people make with Kubernetes is to deploy workloads with no limits on memory or CPU consumption.  This PR displays green wigglies and a 'Problem' indicator in VS Code when the user opens a YAML file for a pod or deployment which does not limit memory and CPU in this way.

This is an initial posting for review and feedback - I don't think things like wording are final.  We should probably sanity check things like the CPU limit as well...

Fixes #344.