### PR TITLE
Fix resource linting in JSON and multi-document YAML files

### DIFF
--- a/src/components/json/jsonhierarchicalsymbolprovider.ts
+++ b/src/components/json/jsonhierarchicalsymbolprovider.ts
@@ -1,0 +1,70 @@
+import * as vscode from 'vscode';
+
+export class JsonHierarchicalDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
+    provideDocumentSymbols(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.SymbolInformation[]> {
+        return this.provideDocumentSymbolsImpl(document);
+    }
+
+    async provideDocumentSymbolsImpl(document: vscode.TextDocument): Promise<vscode.SymbolInformation[]> {
+        const sis: any = await vscode.commands.executeCommand('vscode.executeDocumentSymbolProvider', document.uri);
+
+        if (sis && sis.length) {
+            const hnSymbols = hierarchicalContainers(sis);
+            return hnSymbols;
+        }
+
+        return [];
+    }
+}
+
+function hierarchicalContainers(symbols: vscode.SymbolInformation[]): vscode.SymbolInformation[] {
+    return symbols.map((symbol) => {
+        const containingSymbols = symbols.filter((s) => contains(s, symbol));
+        const hierarchisedContainerName = makeHierarchicalContainerName(symbol, containingSymbols);
+        const s = new vscode.SymbolInformation(symbol.name, symbol.kind, hierarchisedContainerName, symbol.location);
+        return s;
+    });
+}
+
+function contains(s: vscode.SymbolInformation, symbol: vscode.SymbolInformation): boolean {
+    return (s !== symbol) && s.location.range.contains(symbol.location.range);
+}
+
+function makeHierarchicalContainerName(symbol: vscode.SymbolInformation, symbols: vscode.SymbolInformation[]): string {
+    if (!symbol.containerName) {
+        return '';
+    }
+    const immediateContainer = findImmediateContainer(symbol, symbols);
+    if (!immediateContainer) {
+        return symbol.containerName;
+    }
+    const immediateContainerHN = makeHierarchicalContainerName(immediateContainer, symbols.filter((s) => contains(s, immediateContainer)));
+    if (immediateContainerHN === '') {
+        return symbol.containerName;
+    }
+    if (symbol.containerName === '0') {
+        return immediateContainerHN;
+    }
+    return `${immediateContainerHN}.${symbol.containerName}`;
+}
+
+function findImmediateContainer(symbol: vscode.SymbolInformation, symbols: vscode.SymbolInformation[]): vscode.SymbolInformation | undefined {
+    const candidates = symbols.filter((s) => s.name === symbol.containerName);
+    if (candidates.length === 1) {
+        return candidates[0];
+    }
+    if (candidates.length === 0) {
+        return undefined;
+    }
+    return mostContained(candidates);
+}
+
+function mostContained(symbols: vscode.SymbolInformation[]): vscode.SymbolInformation | undefined {
+    let candidate = symbols[0];
+    for (const s of symbols) {
+        if (contains(candidate, s)) {
+            candidate = s;
+        }
+    }
+    return candidate;
+}

--- a/src/components/lint/linter.impl.ts
+++ b/src/components/lint/linter.impl.ts
@@ -11,7 +11,7 @@ export function expose(impl: LinterImpl): Linter {
 }
 
 export interface Syntax {
-    load(text: string): any;
+    load(text: string): any[];
     symbolise(document: vscode.TextDocument): Promise<vscode.SymbolInformation[]>;
 }
 
@@ -36,12 +36,12 @@ class StandardLinter implements Linter {
 }
 
 const jsonSyntax = {
-    load(text: string) { return JSON.parse(text); },
+    load(text: string) { return [JSON.parse(text)]; },
     symbolise(document: vscode.TextDocument) { return getSymbols(document); }
 };
 
 const yamlSyntax = {
-    load(text: string) { return yaml.safeLoad(text); },
+    load(text: string) { return yaml.safeLoadAll(text); },
     async symbolise(document: vscode.TextDocument) { return await jsonalikeYamlSymboliser.provideDocumentSymbols(document, new vscode.CancellationTokenSource().token); }
 };
 

--- a/src/components/lint/resourcelimits.ts
+++ b/src/components/lint/resourcelimits.ts
@@ -8,7 +8,18 @@ import { warningOn, childSymbols } from './linter.utils';
 
 export class ResourceLimitsLinter implements LinterImpl {
     async lint(document: vscode.TextDocument, syntax: Syntax): Promise<vscode.Diagnostic[]> {
-        const resource = syntax.load(document.getText());
+        const resources = syntax.load(document.getText());
+        if (!resources) {
+            return [];
+        }
+
+        const symbols = await syntax.symbolise(document);
+
+        const diagnostics = resources.map((r) => this.lintOne(r, symbols));
+        return [].concat(...diagnostics);
+    }
+
+    private lintOne(resource: any, symbols: vscode.SymbolInformation[]): vscode.Diagnostic[] {
         if (!resource) {
             return [];
         }
@@ -21,7 +32,6 @@ export class ResourceLimitsLinter implements LinterImpl {
             return [];
         }
 
-        const symbols = await syntax.symbolise(document);
         const containersSymbols = symbols.filter((s) => s.name === 'containers' && s.containerName === podSpecPrefix);
         if (!containersSymbols) {
             return [];


### PR DESCRIPTION
There was an issue with multi-document YAML files where the linter silently exited instead of providing warnings on pod or deployment resources within the YAML.  This was due to using the `safeLoad` method instead of `safeLoadAll` (`safeLoad` throws on multi-document sources).  With this PR, linting will work on both single and multiple resource YAML files.

As part of testing this fix, I found that JSON linting wasn't working correctly even for single documents (apparently my "JSON-a-like" YAML symbol provider was not as JSON-like as I thought, BUT BETTER SO MUCH BETTER), and fixed that too.

Fixes #359.