### PR TITLE
Cluster type telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,10 +198,10 @@ See the [change log](CHANGELOG.md).
 ## Telemetry
 This extension collects telemetry data to help us build a better experience for building applications with Kubernetes and VS Code. We only collect the following data:
 
-* Which commands are executed
+* Which commands are executed, and whether they are executed against an Azure, Minikube or other type of cluster.
 * For the `Create Cluster` and `Configure from Cluster` commands, the cluster type selected.
 
-We do not collect any information about image names, paths, etc. The extension respects the `telemetry.enableTelemetry` setting which you can learn more about in our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
+We do not collect any information about image names, paths, etc. We collect cluster type information only if the cluster is Azure or Minikube. The extension respects the `telemetry.enableTelemetry` setting which you can learn more about in our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
 
 # Contributing
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -342,7 +342,7 @@ export async function activate(context): Promise<extensionapi.ExtensionAPI> {
 export const deactivate = () => { };
 
 function registerCommand(command: string, callback: (...args: any[]) => any): vscode.Disposable {
-    const wrappedCallback = telemetry.telemetrise(command, callback);
+    const wrappedCallback = telemetry.telemetrise(command, kubectl, callback);
     return vscode.commands.registerCommand(command, wrappedCallback);
 }
 
@@ -1708,6 +1708,7 @@ async function useContextKubernetes(explorerNode: explorer.KubernetesObject) {
     const shellResult = await kubectl.invokeAsync(`config use-context ${targetContext}`);
     if (shellResult.code === 0) {
         refreshExplorer();
+        telemetry.invalidateClusterType(targetContext);
     } else {
         vscode.window.showErrorMessage(`Failed to set '${targetContext}' as current cluster: ${shellResult.stderr}`);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -251,6 +251,8 @@ export async function activate(context): Promise<extensionapi.ExtensionAPI> {
         registerTelemetry(context)
     ];
 
+    telemetry.invalidateClusterType(undefined, kubectl);
+
     await azureclusterprovider.init(clusterProviderRegistry, { shell: shell, fs: fs });
     await minikubeclusterprovider.init(clusterProviderRegistry, { shell: shell, minikube: minikube });
     // On save, refresh the Helm YAML preview.
@@ -1707,8 +1709,8 @@ async function useContextKubernetes(explorerNode: explorer.KubernetesObject) {
     const targetContext = contextObj.contextName;
     const shellResult = await kubectl.invokeAsync(`config use-context ${targetContext}`);
     if (shellResult.code === 0) {
-        refreshExplorer();
         telemetry.invalidateClusterType(targetContext);
+        refreshExplorer();
     } else {
         vscode.window.showErrorMessage(`Failed to set '${targetContext}' as current cluster: ${shellResult.stderr}`);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1678,6 +1678,7 @@ async function useKubeconfigKubernetes(kubeconfig?: string): Promise<void> {
         return;
     }
     await setActiveKubeconfig(kc);
+    telemetry.invalidateClusterType(undefined, kubectl);
 }
 
 async function getKubeconfigSelection(kubeconfig?: string): Promise<string | undefined> {

--- a/src/telemetry-helper.ts
+++ b/src/telemetry-helper.ts
@@ -1,8 +1,86 @@
 import { reporter } from './telemetry';
+import { Kubectl } from './kubectl';
 
-export function telemetrise(command: string, callback: (...args: any[]) => any): (...args: any[]) => any {
-    return (a) => {
-        reporter.sendTelemetryEvent("command", { command: command });
+export function telemetrise(command: string, kubectl: Kubectl, callback: (...args: any[]) => any): (...args: any[]) => any {
+    return async (a) => {
+        reporter.sendTelemetryEvent("command", { command: command, clusterType: await clusterType(kubectl) });
         return callback(a);
     };
+}
+
+export enum ClusterType {
+    Azure,
+    Minikube,
+    Other
+}
+
+let latestContextName: string | null;
+let cachedClusterType: ClusterType | null = null;
+const knownClusters: any = {};
+
+export function invalidateClusterType(newContext: string): void {
+    latestContextName = newContext || null;
+    cachedClusterType = null;
+}
+
+async function clusterType(kubectl: Kubectl): Promise<string> {
+    if (latestContextName && knownClusters[latestContextName]) {
+        cachedClusterType = knownClusters[latestContextName];
+    }
+    if (!cachedClusterType) {
+        cachedClusterType = await inferCurrentClusterType(kubectl, latestContextName);
+        if (latestContextName) {
+            knownClusters[latestContextName] = cachedClusterType;
+        }
+    }
+    switch (cachedClusterType) {
+        case ClusterType.Azure:
+            return 'azure';
+        case ClusterType.Minikube:
+            return 'minikube';
+        case ClusterType.Other:
+            return 'other';
+    }
+}
+
+async function inferCurrentClusterType(kubectl: Kubectl, contextNameHint: string | null): Promise<ClusterType | null> {
+    if (!latestContextName) {
+        const ctxsr = await kubectl.invokeAsync('config current-context');
+        if (ctxsr.code === 0) {
+            latestContextName = ctxsr.stdout.trim();
+        } else {
+            return ClusterType.Other;  // something is terribly wrong; we don't want to retry
+        }
+    }
+
+    if (latestContextName === 'minikube') {
+        return ClusterType.Minikube;
+    }
+
+    const cisr = await kubectl.invokeAsync('cluster-info');
+    if (cisr.code !== 0) {
+        return null;
+    }
+    const masterInfos = cisr.stdout.split('\n')
+                                   .filter((s) => s.indexOf('master is running at') >= 0);
+
+    if (masterInfos.length === 0) {
+        return ClusterType.Other;  // something is terribly wrong; we don't want to retry
+    }
+
+    const masterInfo = masterInfos[0];
+    if (masterInfo.indexOf('azure.com') >= 0) {
+        return ClusterType.Azure;
+    }
+
+    if (latestContextName) {
+        const gcsr = await kubectl.invokeAsync(`config get-contexts ${latestContextName}`);
+        if (gcsr.code === 0) {
+            if (gcsr.stdout.indexOf('minikube') >= 0) {
+                return ClusterType.Minikube;  // It's pretty heuristic, so don't spend time parsing the table
+            }
+        }
+    }
+
+    return ClusterType.Other;
 }


### PR DESCRIPTION
Adds information about whether a cluster is Azure, Minikube or 'other' to command telemetry.

~~**IMPORTANT NOTE TO SELF:** Do not merge until we have updated the disclosure statement in the readme!~~ Disclosure updated.