### PR TITLE
Fix for Helm Insert Dependency command not working on Windows

### DIFF
--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -623,7 +623,7 @@ export function searchForChart(name: string, version?: string): Requirement {
 }
 
 export function helmHome(): string {
-    const h = process.env.HOME;
+    const h = sh.home();
     return process.env["HELM_HOME"] || filepath.join(h, '.helm');
 }
 


### PR DESCRIPTION
Somehow I did this and then forgot to send the PR!

Fixes #363.