### PR TITLE
Prefer %HOMEDRIVE%%HOMEPATH% over %USERPROFILE%

### DIFF
--- a/src/shell.ts
+++ b/src/shell.ts
@@ -65,8 +65,14 @@ function platform(): Platform {
     }
 }
 
+function concatIfBoth(s1: string | undefined, s2: string | undefined): string | undefined {
+    return s1 && s2 ? s1.concat(s2) : undefined;
+}
+
 function home(): string {
-    return process.env['HOME'] || process.env['HOMEDRIVE'].concat(process.env['HOMEPATH']) || process.env['USERPROFILE'];
+    return process.env['HOME'] ||
+        concatIfBoth(process.env['HOMEDRIVE'], process.env['HOMEPATH']) ||
+        process.env['USERPROFILE'];
 }
 
 function combinePath(basePath: string, relativePath: string) {

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -66,7 +66,7 @@ function platform(): Platform {
 }
 
 function home(): string {
-    return process.env['HOME'] || process.env['USERPROFILE'];
+    return process.env['HOME'] || process.env['HOMEDRIVE'].concat(process.env['HOMEPATH']) || process.env['USERPROFILE'];
 }
 
 function combinePath(basePath: string, relativePath: string) {


### PR DESCRIPTION
The implementation of kubectl prefers %HOMEDRIVE%%HOMEPATH% over %USERPROFILE% to determine the user's home directory. While the first alternative may point to a directory located on a network drive, the second alternative always points to a directory on a local drive. The VS code extension should follow the lookup behavior of kubectl in order to maintain a consistent user experience (when ran from a shell, kubectl picks up a different config file).