### PR TITLE
Unify snippet structure and add new snippets

### DIFF
--- a/snippets/configmap.yaml
+++ b/snippets/configmap.yaml
@@ -1,0 +1,10 @@
+name: service
+label: Kubernetes ConfigMap
+description: Kubernetes ConfigMap
+body: |2
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: ${1:myapp}
+  data:
+    ${2:key}: ${3:value}

--- a/snippets/pod.yaml
+++ b/snippets/pod.yaml
@@ -2,8 +2,8 @@ name: pod
 label: Kubernetes Pod
 description: Kubernetes Pod
 body: |2
-  kind: Pod
   apiVersion: v1
+  kind: Pod
   metadata:
     name: ${1:myapp}
     labels:

--- a/snippets/replicationcontroller.yaml
+++ b/snippets/replicationcontroller.yaml
@@ -1,0 +1,23 @@
+name: replicationcontroller
+label: Kubernetes ReplicationController
+description: Kubernetes ReplicationController
+body: |2
+  apiVersion: v1
+  kind: ReplicationController
+  metadata:
+    name: ${1:myapp}
+  spec:
+    replicas: ${2:<Replicas>}
+    selector:
+      app: ${1:myapp}
+    template:
+      metadata:
+        name: ${1:myapp}
+        labels:
+          app: ${1:myapp}
+      spec:
+        containers:
+          - name: ${1:myapp}
+            image: ${3:<Image>}
+            port:
+              - containerPort: ${4:<Port>}

--- a/snippets/service.yaml
+++ b/snippets/service.yaml
@@ -2,8 +2,8 @@ name: service
 label: Kubernetes Service
 description: Kubernetes Service
 body: |2
-  kind: Service
   apiVersion: v1
+  kind: Service
   metadata:
     name: ${1:myapp}
   spec:


### PR DESCRIPTION
Maybe it is just me, but I think it would be good to follow the same structure in every snippet. Since available `kind` is somewhat dependent on `apiVersion` I decided to switch it in two existing templates (I know yaml doesn't care).

I also added two new snippets for ConfigMap and ReplicationController