### PR TITLE
Helm 'update dependencies' code lens should use active file, not prompt

### DIFF
--- a/src/helm.requirementsCodeLens.ts
+++ b/src/helm.requirementsCodeLens.ts
@@ -16,7 +16,8 @@ export class HelmRequirementsCodeLensProvider implements vscode.CodeLensProvider
 
         const update = new vscode.CodeLens(range, {
             title: "update dependencies",
-            command: "extension.helmDepUp"
+            command: "extension.helmDepUp",
+            arguments: [doc]
         });
         const insert = new vscode.CodeLens(range, {
             title: "insert dependency",


### PR DESCRIPTION
Currently if you open a Helm `requirements.yaml` and click the Update Dependencies code lens, it prompts you for which chart to update, just as if you had issued the command from the palette.  It should apply to the chart in which the user clicked the lens.