### PR TITLE
Fix for running Helm Update Dependencies from the file explorer

### DIFF
--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -81,19 +81,20 @@ export function helmTemplatePreview() {
     helm.recordPreviewHasBeenShown();
 }
 
-export function helmDepUp(arg: any) {
-    if (arg) {
-        const doc = arg as vscode.TextDocument;
-        if (doc.uri.scheme !== 'file') {
-            vscode.window.showErrorMessage('Chart is not on the filesystem');
-            return;
-        }
-        const path = filepath.dirname(doc.fileName);
-        helmDepUpCore(path);
+export function helmDepUp(arg: any /* Uri | TextDocument | undefined */) {
+    if (!arg) {
+        pickChart((path) => helmDepUpCore(path));
         return;
     }
 
-    pickChart((path) => helmDepUpCore(path));
+    const uri: vscode.Uri = arg.uri || arg;
+
+    if (uri.scheme !== 'file') {
+        vscode.window.showErrorMessage('Chart is not on the filesystem');
+        return;
+    }
+    const path = filepath.dirname(uri.fsPath);
+    helmDepUpCore(path);
 }
 
 function helmDepUpCore(path: string) {


### PR DESCRIPTION
In the olden days, if you right-clicked `requirements.yaml` in the file explorer and chose Update Dependencies, it would ignore the context and prompt you for which chart to update.  This was bad.  With the coming of #426, this was improved by making it misinterpret the context and silently error out of the command.  This was worse.

This PR makes it update the dependencies of the chart containing the clicked `requirements.yaml`, without prompting or crashing or any of that fun stuff.  This... _glances to side at PM, blinks rapidly to reader in Morse code_... this is better.