### PR TITLE
Fix contributors who were not properly credited on the 0.1.15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 * Fixed an issue where the Windows user profile path was being used when kubectl used %HOMEDRIVE%\%HOMEPATH%
 * Considerable internal refactoring and error handling
 
-Thanks to contributors Brendan Burns, Mostafa Hussein, Matthias Lechner, Dan McCracken, Bhargav Nookala, Stefan Schacherl and Ahmadali Shafiee.
+Thanks to contributors Brendan Burns, Dimitris-Ilias Gkanatsios, Mostafa Hussein, Shreyas Karnik, Matthias Lechner, Dan McCracken, Bhargav Nookala, Stefan Schacherl and Ahmadali Shafiee.
 
 ## 0.1.14
 


### PR DESCRIPTION
I forgot to update the 0.1.15 changelog thanks list to reflect late-breaking contributions to 0.1.15 by @shreyu86 and @dgkanatsios.  This PR restores the due credit.