### PR TITLE
Support space in path to minikube bin #441

### DIFF
--- a/src/components/clusterprovider/minikube/minikube.ts
+++ b/src/components/clusterprovider/minikube/minikube.ts
@@ -91,7 +91,7 @@ async function minikubeUpgradeAvailable(context: Context) {
         return;
     }
 
-    const sr = await context.shell.exec(`${context.binPath} update-check`);
+    const sr = await context.shell.exec(`"${context.binPath}" update-check`);
     if (sr.code !== 0) {
         vscode.window.showErrorMessage(`Error checking for minikube updates: ${sr.stderr}`);
         return;
@@ -127,7 +127,7 @@ async function isRunnableMinikube(context: Context): Promise<Errorable<Diagnosti
         return { succeeded: false, error: ['Minikube is not installed'] };
     }
 
-    const sr = await context.shell.exec(`${context.binPath} help`);
+    const sr = await context.shell.exec(`"${context.binPath}" help`);
     return fromShellExitCodeOnly(sr);
 }
 
@@ -158,7 +158,7 @@ async function startMinikube(context: Context, options: MinikubeOptions): Promis
     if (options.vmDriver && options.vmDriver.length > 0) {
         flags += ` --vm-driver=${options.vmDriver} `;
     }
-    context.shell.exec(`${context.binPath} ${flags} start`).then((result: ShellResult) => {
+    context.shell.exec(`"${context.binPath}" ${flags} start`).then((result: ShellResult) => {
         if (result.code === 0) {
             vscode.window.showInformationMessage('Cluster started.');
             item.text = 'minikube-running';
@@ -186,7 +186,7 @@ async function stopMinikube(context: Context): Promise<void> {
         return;
     }
 
-    context.shell.exec(`${context.binPath} stop`).then((result: ShellResult) => {
+    context.shell.exec(`"${context.binPath}" stop`).then((result: ShellResult) => {
         if (result.code === 0) {
             vscode.window.showInformationMessage('Cluster stopped.');
             item.hide();
@@ -206,7 +206,7 @@ async function minikubeStatus(context: Context): Promise<MinikubeInfo> {
     }
 
     const result = await context.shell.exec(
-        `${context.binPath} status --format '["{{.MinikubeStatus}}","{{.ClusterStatus}}","{{.KubeconfigStatus}}"]'`);
+        `"${context.binPath}" status --format '["{{.MinikubeStatus}}","{{.ClusterStatus}}","{{.KubeconfigStatus}}"]'`);
     if (result.stderr.length === 0) {
         const obj = JSON.parse(result.stdout);
         return {

--- a/src/draft/draft.ts
+++ b/src/draft/draft.ts
@@ -75,7 +75,7 @@ async function checkPresent(context: Context, mode: CheckPresentMode): Promise<b
 
 async function packs(context: Context): Promise<string[] | undefined> {
     if (await checkPresent(context, CheckPresentMode.Alert)) {
-        const dpResult = await context.shell.exec(`${context.binPath} pack list`);
+        const dpResult = await context.shell.exec(`"${context.binPath}" pack list`);
         if (dpResult.code === 0) {
             // Packs may be of the form path/to/the/actual/name
             // We also may have spurious ones under github.com/Azure/draft/{cmd|pkg}
@@ -97,7 +97,7 @@ async function invokeCreate(context: Context, appName: string, pack: string | un
     if (await checkPresent(context, CheckPresentMode.Alert)) {
         const packOpt = pack ? ` -p ${pack}` : '';
         const cmd = `create -a ${appName} ${packOpt} "${path}"`;
-        const result = await context.shell.exec(`${context.binPath} ${cmd}`);
+        const result = await context.shell.exec(`"${context.binPath}" ${cmd}`);
         if (result.code === 0 && result.stdout.indexOf('chart directory charts/ already exists') >= 0) {
             const draftManifestFile = syspath.join(path, 'draft.toml');
             const hasDraftManifest = context.fs.existsSync(draftManifestFile);
@@ -134,7 +134,7 @@ async function up(context: Context): Promise<void> {
 
 async function version(context: Context): Promise<Errorable<string>> {
     if (await checkPresent(context, CheckPresentMode.Alert)) {
-        const result = await context.shell.exec(`${context.binPath} version`);
+        const result = await context.shell.exec(`"${context.binPath}" version`);
         if (result.code === 0) {
             return { succeeded: true, result: result.stdout.trim() };
         }


### PR DESCRIPTION
is there a way to modify test to have a bin path with space?

please note that i'm unable to launch the test suite localy. Seems that i have a compile error (not related to this PR)
`src/components/kubectl/port-forward.ts(237,13): error TS2322: Type '{ succeeded: boolean; pod: string; namespace: string; fromOpenDocument: true; }' is not assignable to type 'PortForwardFindPodsResult'.`