### PR TITLE
add configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,10 @@
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"
             ],
-            "preLaunchTask": "npm: watch"
+            "preLaunchTask": "npm: watch",
+            "skipFiles": [
+                "<node_internals>/**/*.js"
+            ]
         },
         {
             "name": "Extension Tests",

--- a/debug-on-kubernetes.md
+++ b/debug-on-kubernetes.md
@@ -13,6 +13,10 @@ One of the key features of VS Code Kubernetes Extension is its one-click debuggi
 ## 3. Extension Settings for debugging
    * `vs-kubernetes` - Parent for Kubernetes-related extension settings
       * `vs-kubernetes.autoCleanupOnDebugTerminate` - The flag to control whether to auto cleanup the created Deployment and associated Pod by the command "Kubernetes: Debug (Launch)". The cleanup action occurs when it failed to start debug session or debug session terminated. If not specified, the extension will prompt for whether to clean up or not. You might choose not to clean up if you wanted to view pod logs, etc.
+      * `vs-kubernetes.nodejs-autodetect-remote-root` - If true will try to automatically get the root location of the source code in the container. The detection attempts to get the CWD of the nodejs process.  
+      * `vs-kubernetes.nodejs-remote-root` - User specified root location of the source code in the container. Remote root is passed to the debug configuration to allow vscode to map local files to files in the container. If `vs-kubernetes.nodejs-autodetect-remote-root` is set to `false` and `vs-kubernetes.nodejs-remote-root` is empty, no remoteRoot is set in the debug configuration. For more info on nodejs remote debugging see [vscode documentation](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_remote-debugging)
+      * `vs-kubernetes.nodejs-debug-port` - Sets the nodejs remote debugging port. The default for node is 9229.
+
    * `vsdocker.imageUser` - Image prefix for docker images e.g. 'docker.io/brendanburns'.
 
 ## 4. How to use it for Java debugging

--- a/package.json
+++ b/package.json
@@ -180,6 +180,18 @@
                             "type": "string",
                             "description": "Output format for Kubernetes specs. One of 'json' or 'yaml' (default)."
                         },
+                        "vs-kubernetes.nodejs-autodetect-remote-root": {
+                            "type": "boolean",
+                            "description": "If true will try to automatically get the root location of the source code in the container."
+                        },
+                        "vs-kubernetes.nodejs-remote-root": {
+                            "type": "string",
+                            "description": "User specified root location of the source code in the container."
+                        },
+                        "vs-kubernetes.nodejs-debug-port": {
+                            "type": "string",
+                            "description": "Remote debugging port for nodejs. Usually 9229."
+                        },
                         "disable-lint": {
                             "type": "boolean",
                             "description": "Disable all linting of Kubernetes files"
@@ -198,7 +210,10 @@
                         "vs-kubernetes.outputFormat": "yaml",
                         "vs-kubernetes.kubeconfig": "",
                         "vs-kubernetes.knownKubeconfigs": [],
-                        "vs-kubernetes.autoCleanupOnDebugTerminate": false
+                        "vs-kubernetes.autoCleanupOnDebugTerminate": false,
+                        "vs-kubernetes.nodejs-autodetect-remote-root": true,
+                        "vs-kubernetes.nodejs-remote-root": "",
+                        "vs-kubernetes.nodejs-debug-port": "9229"
                     }
                 },
                 "vsdocker.imageUser": {

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -156,3 +156,18 @@ export function getDisabledLinters(): string[] {
     const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY);
     return config['disable-linters'] as string[];
 }
+
+// nodejs debugger attach  options
+
+// if true will try to automatically get the root location of the source code in the container
+export function getNodejsAutoDetectRemoteRoot(): boolean {
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.nodejs-autodetect-remote-root'];
+}
+// user specified root location of the source code in the container
+export function getNodejsRemoteRoot(): string {
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.nodejs-remote-root'];
+}
+// remote debugging port for nodejs. Usually 9229
+export function getNodejsDebugPort(): string {
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.nodejs-debug-port'];
+}

--- a/src/debug/nodejsDebugProvider.ts
+++ b/src/debug/nodejsDebugProvider.ts
@@ -1,0 +1,102 @@
+import * as path from "path";
+import * as vscode from "vscode";
+import { ChildProcess } from "child_process";
+
+import { IDebugProvider, PortInfo } from "./debugProvider";
+import * as config from '../components/config/config';
+import { Kubectl } from "../kubectl";
+import { IDockerfile } from "../docker/parser";
+import { kubeChannel } from "../kubeChannel";
+
+interface ExecResult {
+    readonly proxyProcess: ChildProcess;
+}
+const debuggerType = 'nodejs';
+
+export class NodejsDebugProvider implements IDebugProvider {
+    remoteRoot: String;
+    shell: string;
+    public getDebuggerType(): string {
+        return debuggerType;
+    }
+    public async isDebuggerInstalled(): Promise<boolean> {
+        return true;
+    }
+    public async startDebugging(workspaceFolder: string, sessionName: string, port: number): Promise<boolean> {
+
+        const debugConfiguration = {
+            type: "node",
+            request: "attach",
+            name: sessionName,
+            hostName: "localhost",
+            skipFiles: [
+                "<node_internals>/**/*.js"
+            ],
+            port
+        };
+        if (this.remoteRoot) {
+            debugConfiguration['remoteRoot'] = this.remoteRoot;
+        }
+        const currentFolder = vscode.workspace.workspaceFolders.find((folder) => folder.name === path.basename(workspaceFolder));
+        return await vscode.debug.startDebugging(currentFolder, debugConfiguration);
+    }
+    isSupportedImage(baseImage: string): boolean {
+        throw new Error("Method not implemented.");
+    }
+
+    resolvePortsFromFile(dockerfile: IDockerfile, env: {}): Promise<PortInfo> {
+        throw new Error("Method not implemented.");
+    }
+
+    public async resolvePortsFromContainer(kubectl: Kubectl, pod: string, podNamespace: string, container: string): Promise<PortInfo> {
+        this.shell = await this.suggestedShellForContainer(kubectl, pod, podNamespace, container);
+        await this.setNodeInspectMode(kubectl, pod, podNamespace, container);
+        this.remoteRoot = await this.tryGetRemoteRoot(kubectl, pod, podNamespace, container);
+        const rawDebugPortInfo = config.getNodejsDebugPort() || '9229';
+        return {
+            debugPort: Number(rawDebugPortInfo)
+        };
+    }
+
+    async setNodeInspectMode(kubectl: Kubectl, pod: string, podNamespace: string, container: string): Promise<Boolean> {
+        kubeChannel.showOutput('Switching node to debug mode in container');
+        const nsarg = podNamespace ? `--namespace ${podNamespace}` : '';
+        const execCmd = `exec ${pod} ${nsarg} ${container ? "-c ${selectedContainer}" : ""} -- ${this.shell} -c 'kill -SIGUSR1 1'`;
+        const execResult = await kubectl.invokeAsync(execCmd);
+        return execResult.code == 0; 
+    }
+
+    async tryGetRemoteRoot(kubectl: Kubectl, podName: string, podNamespace: string | undefined, containerName: string | undefined): Promise<String> {
+        let remoteRoot: String;
+        if (config.getNodejsAutoDetectRemoteRoot()) {
+            kubeChannel.showOutput("Trying to detect remote root.");
+            const nsarg = podNamespace ? `--namespace ${podNamespace}` : '';
+            const execCmd = `exec ${podName} ${nsarg} ${containerName ? "-c ${selectedContainer}" : ""} -- ${this.shell} -c 'readlink /proc/1/cwd'`;
+            const execResult = await kubectl.invokeAsync(execCmd);
+            if (execResult.code == 0) {
+                remoteRoot = execResult.stdout.replace(/(\r\n|\n|\r)/gm, '');
+                kubeChannel.showOutput(`Got remote root from container: ${remoteRoot}`);
+            }
+        }
+        else if (config.getNodejsRemoteRoot()) {
+            remoteRoot = config.getNodejsRemoteRoot();
+            kubeChannel.showOutput(`Setting remote root to ${remoteRoot}`);
+        }
+        return remoteRoot;
+    }
+
+    async isBashOnContainer(kubectl: Kubectl, podName: string, podNamespace: string | undefined, containerName: string | undefined): Promise<boolean> {
+        const nsarg = podNamespace ? `--namespace ${podNamespace}` : '';
+        const result = await kubectl.invokeAsync(`exec ${podName} ${nsarg} ${containerName ? "-c ${selectedContainer}" : ""} -- ls -la /bin/bash`);
+        return !result.code;
+    }
+
+    async suggestedShellForContainer(kubectl: Kubectl, podName: string, podNamespace: string | undefined, containerName: string | undefined): Promise<string> {
+        if (await this.isBashOnContainer(kubectl, podName, podNamespace, containerName)) {
+            return 'bash';
+        }
+        return 'sh';
+    }
+
+
+}

--- a/src/debug/providerRegistry.ts
+++ b/src/debug/providerRegistry.ts
@@ -2,9 +2,10 @@ import * as vscode from "vscode";
 
 import { IDebugProvider } from "./debugProvider";
 import { JavaDebugProvider } from "./javaDebugProvider";
-
+import { NodejsDebugProvider } from "./nodejsDebugProvider";
 const supportedProviders: IDebugProvider[] = [
-    new JavaDebugProvider()
+    new JavaDebugProvider(),
+    new NodejsDebugProvider()
 ];
 
 async function showProviderPick(): Promise<IDebugProvider> {
@@ -16,11 +17,11 @@ async function showProviderPick(): Promise<IDebugProvider> {
         };
     });
 
-    const pickedProvider = await vscode.window.showQuickPick(<vscode.QuickPickItem[]> providerItems, { placeHolder: "Select the environment" });
+    const pickedProvider = await vscode.window.showQuickPick(<vscode.QuickPickItem[]>providerItems, { placeHolder: "Select the environment" });
     if (!pickedProvider) {
         return null;
     }
-    return (<any> pickedProvider).provider;
+    return (<any>pickedProvider).provider;
 }
 
 export async function getDebugProvider(baseImage?: string): Promise<IDebugProvider> {


### PR DESCRIPTION
Hi
First let me say that I really like the extension. I use it all the time.
I've noticed that currently attaching a debugger to pod only works for java.
In this pull request, I've added support for nodejs