### PR TITLE
If we can't check compatibility, we shouldn't check if that's a compatibility issue

### DIFF
--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -175,8 +175,15 @@ async function invokeAsync(context: Context, command: string, stdin?: string): P
     }
 }
 
+// TODO: invalidate this when the context changes or if we know kubectl has changed (e.g. config)
+let checkedCompatibility = false;  // We don't want to spam the user (or CPU!) repeatedly running the version check
+
 async function checkPossibleIncompatibility(context: Context): Promise<void> {
+    if (checkedCompatibility) {
+        return;
+    }
     const compat = await compatibility.check((cmd) => asJson<compatibility.Version>(context, cmd));
+    checkedCompatibility = true;
     if (!compatibility.isGuaranteedCompatible(compat) && compat.didCheck) {
         const versionAlert = `kubectl version ${compat.clientVersion} may be incompatible with cluster Kubernetes version ${compat.serverVersion}`;
         context.host.showWarningMessage(versionAlert);

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -182,8 +182,8 @@ async function checkPossibleIncompatibility(context: Context): Promise<void> {
     if (checkedCompatibility) {
         return;
     }
-    const compat = await compatibility.check((cmd) => asJson<compatibility.Version>(context, cmd));
     checkedCompatibility = true;
+    const compat = await compatibility.check((cmd) => asJson<compatibility.Version>(context, cmd));
     if (!compatibility.isGuaranteedCompatible(compat) && compat.didCheck) {
         const versionAlert = `kubectl version ${compat.clientVersion} may be incompatible with cluster Kubernetes version ${compat.serverVersion}`;
         context.host.showWarningMessage(versionAlert);


### PR DESCRIPTION
Because that way madness lies.

We had a situation where if a `kubectl` command failed, we would call `kubectl version` to see if the failure might be down to a client-server mismatch.  But if `kubectl` itself errored in response to `kubectl version -o json` (for example, if `kubectl-path` pointed to a binary other than the true kubectl), then this counted as a failure that would trigger the client-server compatibility check.

As we run `kubectl config` on startup to find out what context we're in, this resulted in the extension going into an infinite loop on activation if confronted with an uncooperative kubectl.

We fix this by recording that the compatibility check has been initiated _before_ calling `kubectl version`, and not repeating it if the check has already been initiated.

Fixes #450.