### PR TITLE
Fix typo in ReplicationController snippet

### DIFF
--- a/snippets/replicationcontroller.yaml
+++ b/snippets/replicationcontroller.yaml
@@ -19,5 +19,5 @@ body: |2
         containers:
           - name: ${1:myapp}
             image: ${3:<Image>}
-            port:
+            ports:
               - containerPort: ${4:<Port>}


### PR DESCRIPTION
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core
According to API(v1.9, 1.10, 1.11, 1.12, 1.13) Container's port field should be named "port**s**"