### PR TITLE
Update to latest VS Code engine and Node 10 types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,14 +114,14 @@
         "@types/minimatch": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-            "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0="
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
         },
         "@types/mkdirp": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
             "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
             "requires": {
-                "@types/node": "6.14.2"
+                "@types/node": "10.12.25"
             }
         },
         "@types/mocha": {
@@ -131,16 +131,16 @@
             "dev": true
         },
         "@types/node": {
-            "version": "6.14.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.2.tgz",
-            "integrity": "sha512-JWB3xaVfsfnFY8Ofc9rTB/op0fqqTSqy4vBcVk1LuRJvta7KTX+D//fCkiTMeLGhdr2EbFZzQjC97gvmPilk9Q=="
+            "version": "10.12.25",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.25.tgz",
+            "integrity": "sha512-IcvnGLGSQFDvC07Bz2I8SX+QKErDZbUdiQq7S2u3XyzTyJfUmT0sWJMbeQkMzpTAkO7/N7sZpW/arUM2jfKsbQ=="
         },
         "@types/opn": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/@types/opn/-/opn-5.1.0.tgz",
             "integrity": "sha512-TNPrB7Y1xl06zDI0aGyqkgxjhIev3oJ+cdqlZ52MTAHauWpEL/gIUdHebIfRHFZk9IqSBpE2ci1DT48iZH81yg==",
             "requires": {
-                "@types/node": "6.14.2"
+                "@types/node": "10.12.25"
             }
         },
         "@types/pluralize": {
@@ -207,7 +207,7 @@
         "@types/spdy": {
             "version": "3.4.4",
             "resolved": "https://registry.npmjs.org/@types/spdy/-/spdy-3.4.4.tgz",
-            "integrity": "sha1-MoL9StjEYDqkn3AX3VIKCKNFsrw=",
+            "integrity": "sha512-N9LBlbVRRYq6HgYpPkqQc3a9HJ/iEtVZToW6xlTtJiMhmRJ7jJdV7TaZQJw/Ve/1ePUsQiCTDc4JMuzzag94GA==",
             "requires": {
                 "@types/node": "10.12.12"
             },
@@ -224,7 +224,7 @@
             "resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.0.tgz",
             "integrity": "sha512-YybbEHNngcHlIWVCYsoj7Oo1JU9JqONuAlt1LlTH/lmL8BMhbzdFUgReY87a05rY1j8mfK47Del+TCkaLAXwLw==",
             "requires": {
-                "@types/node": "6.14.2"
+                "@types/node": "10.12.25"
             }
         },
         "@types/tmp": {
@@ -242,7 +242,7 @@
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
             "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
             "requires": {
-                "@types/node": "6.14.2"
+                "@types/node": "10.12.25"
             }
         },
         "@types/websocket": {
@@ -251,7 +251,7 @@
             "integrity": "sha512-ldteZwWIgl9cOy7FyvYn+39Ah4+PfpVE72eYKw75iy2L0zTbhbcwvzeJ5IOu6DQP93bjfXq0NGHY6FYtmYoqFQ==",
             "requires": {
                 "@types/events": "1.2.0",
-                "@types/node": "6.14.2"
+                "@types/node": "10.12.25"
             }
         },
         "@types/yamljs": {
@@ -393,7 +393,7 @@
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
         },
         "arr-map": {
@@ -658,7 +658,7 @@
         "base": {
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-            "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
                 "cache-base": "1.0.1",
@@ -736,7 +736,7 @@
         },
         "bl": {
             "version": "1.2.2",
-            "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
             "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
             "requires": {
                 "readable-stream": "2.3.6",
@@ -878,7 +878,7 @@
         "cache-base": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-            "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
                 "collection-visit": "1.0.0",
@@ -906,7 +906,7 @@
         "caw": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
-            "integrity": "sha1-bDygcfwZRyCIPC3F2psHS/x+npU=",
+            "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
             "requires": {
                 "get-proxy": "2.1.0",
                 "isurl": "1.0.0",
@@ -959,7 +959,7 @@
         "class-utils": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-            "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
                 "arr-union": "3.1.0",
@@ -982,7 +982,7 @@
         "clipboardy": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
-            "integrity": "sha1-BSY2G/eHJMHyC+JI1CjjZUM8B+8=",
+            "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
             "requires": {
                 "arch": "2.1.1",
                 "execa": "0.8.0"
@@ -1294,7 +1294,7 @@
         "decompress-tar": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-            "integrity": "sha1-cYy9P8sWIJcW5womuE57pFkuWvE=",
+            "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
             "requires": {
                 "file-type": "5.2.0",
                 "is-stream": "1.1.0",
@@ -1304,7 +1304,7 @@
         "decompress-tarbz2": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-            "integrity": "sha1-MIKluIDqQEOBY0nzeLVsUWvho5s=",
+            "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
             "requires": {
                 "decompress-tar": "4.1.1",
                 "file-type": "6.2.0",
@@ -1316,14 +1316,14 @@
                 "file-type": {
                     "version": "6.2.0",
                     "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-                    "integrity": "sha1-5QzXXTVv/tTjBtxPW89Sp5kDqRk="
+                    "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
                 }
             }
         },
         "decompress-targz": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-            "integrity": "sha1-wJvDXE0R894J8tLaU+neI+fOHu4=",
+            "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
             "requires": {
                 "decompress-tar": "4.1.1",
                 "file-type": "5.2.0",
@@ -1484,7 +1484,7 @@
         "download": {
             "version": "6.2.5",
             "resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",
-            "integrity": "sha1-rNalQuTNC7Qspwz8mMnkOwcDlxQ=",
+            "integrity": "sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA==",
             "requires": {
                 "caw": "2.0.1",
                 "content-disposition": "0.5.2",
@@ -1684,7 +1684,7 @@
         "ewma": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/ewma/-/ewma-2.0.1.tgz",
-            "integrity": "sha1-mHbBxJGsVzPIZmABo5YaBMl88eg=",
+            "integrity": "sha512-MYYK17A76cuuyvkR7MnqLW4iFYPEi5Isl2qb8rXiWpLiwFS9dxW/rncuNnjjgSENuVqZQkIuR4+DChVL4g1lnw==",
             "requires": {
                 "assert-plus": "1.0.0"
             }
@@ -1765,7 +1765,7 @@
         "ext-list": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
-            "integrity": "sha1-C5jmTtgvWs8PKTG6v2khLvUt3Tc=",
+            "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
             "requires": {
                 "mime-db": "1.37.0"
             }
@@ -1773,7 +1773,7 @@
         "ext-name": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
-            "integrity": "sha1-cHgZgdGD7hXROZPIgiBFxQbI8KY=",
+            "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
             "requires": {
                 "ext-list": "2.2.2",
                 "sort-keys-length": "1.0.1"
@@ -2073,7 +2073,7 @@
         "fs-minipass": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-            "integrity": "sha1-BsJ3IYRU7CiN93raVKA7hwKqy50=",
+            "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
             "requires": {
                 "minipass": "2.3.5"
             }
@@ -2654,7 +2654,7 @@
         "get-proxy": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
-            "integrity": "sha1-NJ8rTZHUTE1NTpy6KtkBQ/rF75M=",
+            "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
             "requires": {
                 "npm-conf": "1.1.3"
             }
@@ -2747,7 +2747,7 @@
         "global-modules": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-            "integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
+            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
             "dev": true,
             "requires": {
                 "global-prefix": "1.0.2",
@@ -2780,7 +2780,7 @@
         "got": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-            "integrity": "sha1-BUUP2ECU5rvqVvRRpDqcKJFmOFo=",
+            "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
             "requires": {
                 "decompress-response": "3.3.0",
                 "duplexer3": "0.1.4",
@@ -3161,7 +3161,7 @@
         "has-symbol-support-x": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-            "integrity": "sha1-FAn5i8ACR9pF2mfO4KNvKC/yZFU="
+            "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
         },
         "has-symbols": {
             "version": "1.0.0",
@@ -3172,7 +3172,7 @@
         "has-to-string-tag-x": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-            "integrity": "sha1-oEWrOD17SyASoAFIqwql8pAETU0=",
+            "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
             "requires": {
                 "has-symbol-support-x": "1.4.2"
             }
@@ -3278,7 +3278,7 @@
         "ini": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "interpret": {
             "version": "1.1.0",
@@ -3300,7 +3300,7 @@
         "is-absolute": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-            "integrity": "sha1-OV4a6EsR8mrReV5zwXN45IowFXY=",
+            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
                 "is-relative": "1.0.0",
@@ -3478,7 +3478,7 @@
         "is-plain-object": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-            "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "requires": {
                 "isobject": "3.0.1"
             }
@@ -3491,7 +3491,7 @@
         "is-relative": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-            "integrity": "sha1-obtpNc6MXboei5dUubLcwCDiJg0=",
+            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
                 "is-unc-path": "1.0.0"
@@ -3520,7 +3520,7 @@
         "is-unc-path": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-            "integrity": "sha1-1zHoiY7QkKEsNSrS6u1Qla0yLJ0=",
+            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
                 "unc-path-regex": "0.1.2"
@@ -3572,7 +3572,7 @@
         "isurl": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-            "integrity": "sha1-sn9PSfPNqj6kSgpbfzRi5u3DnWc=",
+            "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
             "requires": {
                 "has-to-string-tag-x": "1.4.1",
                 "is-object": "1.0.1"
@@ -3812,7 +3812,7 @@
         "lowercase-keys": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-            "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
+            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
         },
         "lru-cache": {
             "version": "4.1.5",
@@ -3897,7 +3897,7 @@
         "mime": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
         },
         "mime-db": {
             "version": "1.37.0",
@@ -4129,7 +4129,7 @@
         "node-yaml-parser": {
             "version": "0.0.9",
             "resolved": "https://registry.npmjs.org/node-yaml-parser/-/node-yaml-parser-0.0.9.tgz",
-            "integrity": "sha1-H9X9H38qRxRHdpFClJ8uKCcoarg="
+            "integrity": "sha512-bFFmAdUs9sdD+TwF/A91b4ozU2KJSDuK7HiBV0QDhdG7Cunu/4PakBLn3wWWAJurAJd7GqAeEwYhu32bTHOvQg=="
         },
         "node.extend": {
             "version": "1.1.8",
@@ -4190,7 +4190,7 @@
         "npm-conf": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
-            "integrity": "sha1-JWzEe9DiGMJZxOlVC/QTvCGSr/k=",
+            "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
             "requires": {
                 "config-chain": "1.1.12",
                 "pify": "3.0.0"
@@ -4379,7 +4379,7 @@
         "p-cancelable": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-            "integrity": "sha1-ueEjgAvOu3rBOkeb4ZW1B7mNMPo="
+            "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
         },
         "p-event": {
             "version": "1.3.0",
@@ -4526,7 +4526,7 @@
         "pidusage": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-1.2.0.tgz",
-            "integrity": "sha1-Ze6WrOTgikzT+SQJlshbNnFx7pI="
+            "integrity": "sha512-OGo+iSOk44HRJ8q15AyG570UYxcm5u+R99DI8Khu8P3tKGkVu5EZX4ywHglWSTMNNXQ274oeGpYrvFEhDIFGPg=="
         },
         "pify": {
             "version": "3.0.0",
@@ -4899,7 +4899,7 @@
         "restify-errors": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/restify-errors/-/restify-errors-5.0.0.tgz",
-            "integrity": "sha1-ZocX4QBoPuxs4NUV+J/x2+wlSo0=",
+            "integrity": "sha512-+vby9Kxf7qlzvbZSTIEGkIixkeHG+pVCl34dk6eKnL+ua4pCezpdLT/1/eabzPZb65ADrgoc04jeWrrF1E1pvQ==",
             "requires": {
                 "assert-plus": "1.0.0",
                 "lodash": "4.17.11",
@@ -4996,7 +4996,7 @@
         "set-value": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-            "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+            "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
                 "extend-shallow": "2.0.1",
@@ -5110,7 +5110,7 @@
         "snapdragon-node": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-            "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
                 "define-property": "1.0.0",
@@ -5161,7 +5161,7 @@
         "snapdragon-util": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-            "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
                 "kind-of": "3.2.2"
@@ -5291,7 +5291,7 @@
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -5334,7 +5334,7 @@
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-            "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
                 "extend-shallow": "3.0.2"
@@ -5513,7 +5513,7 @@
         "strip-dirs": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-            "integrity": "sha1-SYdzYmT8NEzyD2w0rKnRPR1O1sU=",
+            "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
             "requires": {
                 "is-natural-number": "4.0.1"
             }
@@ -5526,7 +5526,7 @@
         "strip-outer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-            "integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
+            "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
             "requires": {
                 "escape-string-regexp": "1.0.5"
             }
@@ -6164,7 +6164,7 @@
         },
         "vscode-debugadapter": {
             "version": "1.27.0",
-            "resolved": "http://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.27.0.tgz",
+            "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.27.0.tgz",
             "integrity": "sha512-JwE3fWmKnpjYnFqhff0umqIJi4c26gh/CXZ5LNb4gLIuPd5sEAEoEbGeCcAaajuTrVxFw6FlYEep9y+IQCf+ww==",
             "requires": {
                 "vscode-debugprotocol": "1.27.0"
@@ -6172,7 +6172,7 @@
         },
         "vscode-debugprotocol": {
             "version": "1.27.0",
-            "resolved": "http://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.27.0.tgz",
+            "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.27.0.tgz",
             "integrity": "sha512-cg3lKqVwxNpO2pLBxSwkBvE7w06+bHfbA/s14u8izSWyhJtPgRu1lQwi5tEyTRuwfEugfoPwerYL4vtY6teQDw=="
         },
         "vscode-extension-telemetry": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "preview": true,
     "publisher": "ms-kubernetes-tools",
     "engines": {
-        "vscode": "^1.23.0"
+        "vscode": "^1.31.0"
     },
     "license": "MIT",
     "categories": [
@@ -1231,7 +1231,7 @@
     },
     "devDependencies": {
         "@types/mocha": "^2.2.32",
-        "@types/node": "^6.0.40",
+        "@types/node": "^10.2.0",
         "@types/request": "^2.48.1",
         "gulp": "^4.0.0",
         "gulp-tslint": "^8.1.2",

--- a/src/components/installer/installer.ts
+++ b/src/components/installer/installer.ts
@@ -165,7 +165,7 @@ async function installFromTar(sourceUrl: string, destinationFolder: string, exec
     }
     await addPathToConfig(configKey, executableFullPath);
 
-    await fs.unlink(tarfile);
+    await fs.unlinkSync(tarfile);
 
     return { succeeded: true, result: null };
 }

--- a/src/components/installer/installer.ts
+++ b/src/components/installer/installer.ts
@@ -165,7 +165,7 @@ async function installFromTar(sourceUrl: string, destinationFolder: string, exec
     }
     await addPathToConfig(configKey, executableFullPath);
 
-    await fs.unlinkSync(tarfile);
+    fs.unlinkSync(tarfile);
 
     return { succeeded: true, result: null };
 }

--- a/src/draft/draftConfigurationProvider.ts
+++ b/src/draft/draftConfigurationProvider.ts
@@ -17,7 +17,7 @@ export class DraftConfigurationProvider implements DebugConfigurationProvider {
                 session.start(<NodeJS.ReadableStream>socket, socket);
             }).listen(0);
         }
-        config.debugServer = this.server.address().port;
+        config.debugServer = extractPort(this.server.address());
 
         return config;
     }
@@ -27,4 +27,8 @@ export class DraftConfigurationProvider implements DebugConfigurationProvider {
             this.server.close();
         }
     }
+}
+
+function extractPort(address: string | Net.AddressInfo): number {
+    return (address as Net.AddressInfo).port;  // always an AddressInfo unless listening on a pipe or Unix domain socket
 }

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -5,7 +5,7 @@ export interface FS {
     readFile(filename: string, encoding: string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
     readFileSync(filename: string, encoding: string): string;
     readFileToBufferSync(filename: string): Buffer;
-    writeFile(filename: string, data: any, callback?: (err: NodeJS.ErrnoException) => void): void;
+    writeFile(filename: string, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
     writeFileSync(filename: string, data: any): void;
     dirSync(path: string): string[];
     unlinkAsync(path: string): Promise<void>;

--- a/src/kuberesources.linkprovider.ts
+++ b/src/kuberesources.linkprovider.ts
@@ -171,7 +171,7 @@ function getLinkUriFromPVC(node: yl.YamlMappingItem): vscode.Uri | undefined {
 
 function k8sKind(document: vscode.TextDocument): string {
     const query = querystring.parse(document.uri.query);
-    const k8sid: string = query.value;
+    const k8sid = query.value as string;
     const kindSepIndex = k8sid.indexOf('/');
     return k8sid.substring(0, kindSepIndex);
 }

--- a/src/kuberesources.virtualfs.ts
+++ b/src/kuberesources.virtualfs.ts
@@ -65,8 +65,8 @@ export class KubernetesResourceVirtualFileSystemProvider implements FileSystemPr
         const query = querystring.parse(uri.query);
 
         const outputFormat = config.getOutputFormat();
-        const value = query.value;
-        const ns = query.ns;
+        const value = query.value as string;
+        const ns = query.ns as string | undefined;
         const resourceAuthority = uri.authority;
 
         const sr = await this.execLoadResource(resourceAuthority, ns, value, outputFormat);


### PR DESCRIPTION
The latest version of VS Code runs on Node 10.  This updates our Node type declarations to v10 to better check compatibility (though it looks like we were okay).

It looks like the CI was already using Node 10, so I don't think we need to update anything there.

Creating this PR now to allow CI to noodle on it.  @bnookala would you mind taking a look to see if you think I've overlooked anything please?  But let's not merge until the latest VS Code has been out there a little longer.  Thanks!