### PR TITLE
Kubectl per cluster version

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Minikube tools to be installed and available on your PATH.
        * `vs-kubernetes.helm-path` - File path to the helm binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
        * `vs-kubernetes.draft-path` - File path to the draft binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
        * `vs-kubernetes.minikube-path` - File path to the minikube binary. Note this is the binary file itself, not just the directory containing the file. On Windows, this must contain the `.exe` extension.
+       * `vs-kubernetes.kubectlVersioning` - By default, the extension uses the `kubectl` binary you provide on the system PATH or in the `vs-kubernetes.kubectl-path` configuration setting. If you set this setting to `infer`, then for each cluster the extension will attempt to identify the cluster version and download a compatible `kubectl` binary.  This improves compatibility if you have multiple Kubernetes versions in play, but may be slower.  **IMPORTANT:** Even if this setting is `infer`, you need a 'bootstrap' copy of `kubectl` on your PATH or at the `vs-kubernetes.kubectl-path` location - we need this to find out the server version so we know which version of `kubectl` to download!  Also note that this setting is checked only when the extension loads; if you change it, you must reload the extension.
        * `vs-kubernetes.kubeconfig` - File path to the kubeconfig file you want to use. This overrides both the default kubeconfig and the KUBECONFIG environment variable.
        * `vs-kubernetes.knownKubeconfigs` - An array of file paths of kubeconfig files that you want to be able to quickly switch between using the Set Kubeconfig command.
        * `vs-kubernetes.autoCleanupOnDebugTerminate` - The flag to control whether to auto cleanup the created deployment and associated pod by the command "Kubernetes: Debug (Launch)". The cleanup action occurs when it failed to start debug session or debug session terminated. If not specified, the extension will prompt for whether to clean up or not. You might choose not to clean up if you wanted to view pod logs, etc.
@@ -288,3 +289,6 @@ For technical information about contributing, see [CONTRIBUTING.md](CONTRIBUTING
 
 This extension was born from the `vs-kubernetes` extension by @brendandburns and
 the `vs-helm` extension by @technosophos.
+
+The 'infer `kubectl` version' feature was inspired by @jakepearson's `k` utility
+(https://github.com/jakepearson/k), and some parts of the design were based on his implementation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1897,6 +1897,11 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
         },
+        "fast-sha256": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.1.0.tgz",
+            "integrity": "sha1-tkAYlAPH/w15bRJRocH2lUxA57Q="
+        },
         "fd-slicer": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1054,6 +1054,7 @@
         "docker-file-parser": "^1.0.3",
         "dockerfile-parse": "^0.2.0",
         "download": "^6.2.5",
+        "fast-sha256": "^1.1.0",
         "fuzzysearch": "^1.0.3",
         "graceful-fs": "^4.1.11",
         "js-yaml": "^3.8.2",

--- a/package.json
+++ b/package.json
@@ -164,6 +164,11 @@
                             "type": "string",
                             "description": "File path to a minikube binary."
                         },
+                        "vs-kubernetes.kubectlVersioning": {
+                            "type": "string",
+                            "enum": ["user-provided", "infer"],
+                            "description": "Whether to use the kubectl binary you provide ('user-provided'), or to automatically download the right version of kubectl for each cluster ('infer')."
+                        },
                         "vs-kubernetes.kubeconfig": {
                             "type": "string",
                             "description": "File path to the kubeconfig file."
@@ -215,6 +220,7 @@
                         "vs-kubernetes.helm-path": "",
                         "vs-kubernetes.draft-path": "",
                         "vs-kubernetes.minikube-path": "",
+                        "vs-kubernetes.kubectlVersioning": "user-provided",
                         "vs-kubernetes.outputFormat": "yaml",
                         "vs-kubernetes.kubeconfig": "",
                         "vs-kubernetes.knownKubeconfigs": [],

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -5,6 +5,12 @@ import { Shell, Platform } from '../../shell';
 const EXTENSION_CONFIG_KEY = "vs-kubernetes";
 const KUBECONFIG_PATH_KEY = "vs-kubernetes.kubeconfig";
 const KNOWN_KUBECONFIGS_KEY = "vs-kubernetes.knownKubeconfigs";
+const KUBECTL_VERSIONING_KEY = "vs-kubernetes.kubectlVersioning";
+
+export enum KubectlVersioning {
+    UserProvided = 1,
+    Infer = 2,
+}
 
 export async function addPathToConfig(configKey: string, value: string): Promise<void> {
     await setConfigValue(configKey, value);
@@ -112,6 +118,14 @@ function osKeyString(os: Platform): string | null {
         case Platform.Linux: return 'linux';
         default: return null;
     }
+}
+
+export function getKubectlVersioning(): KubectlVersioning {
+    const configValue = vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)[KUBECTL_VERSIONING_KEY];
+    if (configValue === "infer") {
+        return KubectlVersioning.Infer;
+    }
+    return KubectlVersioning.UserProvided;
 }
 
 // Auto cleanup on debug terminate

--- a/src/components/download/download.ts
+++ b/src/components/download/download.ts
@@ -3,12 +3,22 @@ import * as stream from 'stream';
 import * as tmp from 'tmp';
 
 import { succeeded, Errorable } from '../../errorable';
+import { Dictionary } from '../../utils/dictionary';
+import { sleep } from '../../sleep';
 
 type DownloadFunc =
     (url: string, destination?: string, options?: any)
          => Promise<Buffer> & stream.Duplex; // Stream has additional events - see https://www.npmjs.com/package/download
 
-let download: DownloadFunc;
+let download: DownloadFunc | undefined;
+
+const DOWNLOAD_ONCE_STATUS = Dictionary.of<DownloadOperationStatus>();
+
+enum DownloadOperationStatus {
+    Queued = 1,
+    Completed = 2,
+    Failed = 3,
+}
 
 function ensureDownloadFunc() {
     if (!download) {
@@ -35,9 +45,29 @@ export async function toTempFile(sourceUrl: string): Promise<Errorable<string>> 
 export async function to(sourceUrl: string, destinationFile: string): Promise<Errorable<null>> {
     ensureDownloadFunc();
     try {
-        await download(sourceUrl, path.dirname(destinationFile), { filename: path.basename(destinationFile) });
+        await download!(sourceUrl, path.dirname(destinationFile), { filename: path.basename(destinationFile) });  // safe because we ensured it
         return { succeeded: true, result: null };
     } catch (e) {
         return { succeeded: false, error: [e.message] };
+    }
+}
+
+export async function once(sourceUrl: string, destinationFile: string): Promise<Errorable<null>> {
+    const downloadStatus = DOWNLOAD_ONCE_STATUS[destinationFile];
+    if (!downloadStatus || downloadStatus === DownloadOperationStatus.Failed) {
+        DOWNLOAD_ONCE_STATUS[destinationFile] = DownloadOperationStatus.Queued;
+        const result = await to(sourceUrl, destinationFile);
+        DOWNLOAD_ONCE_STATUS[destinationFile] = succeeded(result) ? DownloadOperationStatus.Completed : DownloadOperationStatus.Failed;
+        return result;
+    } else {
+        while (true) {
+            await sleep(100);
+            if (DOWNLOAD_ONCE_STATUS[destinationFile] === DownloadOperationStatus.Completed) {
+                return { succeeded: true, result: null };
+            }
+            else {
+                return await once(sourceUrl, destinationFile);
+            }
+        }
     }
 }

--- a/src/components/installer/installationlayout.ts
+++ b/src/components/installer/installationlayout.ts
@@ -1,0 +1,25 @@
+import { Platform } from "../../shell";
+
+export function platformUrlString(platform: Platform, supported?: Platform[]): string | null {
+    if (supported && supported.indexOf(platform) < 0) {
+        return null;
+    }
+    switch (platform) {
+        case Platform.Windows: return 'windows';
+        case Platform.MacOS: return 'darwin';
+        case Platform.Linux: return 'linux';
+        default: return null;
+    }
+}
+
+export function formatBin(tool: string, platform: Platform): string | null {
+    const platformString = platformUrlString(platform);
+    if (!platformString) {
+        return null;
+    }
+    const toolPath = `${platformString}-amd64/${tool}`;
+    if (platform === Platform.Windows) {
+        return toolPath + '.exe';
+    }
+    return toolPath;
+}

--- a/src/components/installer/installer.ts
+++ b/src/components/installer/installer.ts
@@ -8,6 +8,7 @@ import * as tar from 'tar';
 import { Shell, Platform } from '../../shell';
 import { Errorable, failed } from '../../errorable';
 import { addPathToConfig, toolPathBaseKey, getUseWsl } from '../config/config';
+import { platformUrlString, formatBin } from './installationlayout';
 
 export async function installKubectl(shell: Shell): Promise<Errorable<null>> {
     const tool = 'kubectl';
@@ -116,30 +117,6 @@ async function installToolFromTar(tool: string, urlTemplate: string, shell: Shel
 
 function getInstallFolder(shell: Shell, tool: string): string {
     return path.join(shell.home(), `.vs-kubernetes/tools/${tool}`);
-}
-
-function platformUrlString(platform: Platform, supported?: Platform[]): string | null {
-    if (supported && supported.indexOf(platform) < 0) {
-        return null;
-    }
-    switch (platform) {
-        case Platform.Windows: return 'windows';
-        case Platform.MacOS: return 'darwin';
-        case Platform.Linux: return 'linux';
-        default: return null;
-    }
-}
-
-function formatBin(tool: string, platform: Platform): string | null {
-    const platformString = platformUrlString(platform);
-    if (!platformString) {
-        return null;
-    }
-    const toolPath = `${platformString}-amd64/${tool}`;
-    if (platform === Platform.Windows) {
-        return toolPath + '.exe';
-    }
-    return toolPath;
 }
 
 async function installFromTar(sourceUrl: string, destinationFolder: string, executablePath: string, configKey: string, shell: Shell): Promise<Errorable<null>> {

--- a/src/components/kubectl/autoversion.ts
+++ b/src/components/kubectl/autoversion.ts
@@ -67,8 +67,10 @@ async function downloadKubectlVersion(shell: Shell, host: Host, serverVersion: s
     const os = platformUrlString(shell.platform())!;
     const binFile = (shell.isUnix()) ? 'kubectl' : 'kubectl.exe';
     const kubectlUrl = `https://storage.googleapis.com/kubernetes-release/release/${serverVersion}/bin/${os}/amd64/${binFile}`;
-    const downloadResult = await host.longRunning(`Downloading kubectl ${serverVersion}`, () =>
-        download.to(kubectlUrl, binPath)
+    // TODO: this feels a bit ugly and over-complicated - should perhaps be up to download.once to manage
+    // showing the progress UI so we don't need all the operationKey mess
+    const downloadResult = await host.longRunning({ title: `Downloading kubectl ${serverVersion}`, operationKey: binPath }, () =>
+        download.once(kubectlUrl, binPath)
     );
     return succeeded(downloadResult);
 }

--- a/src/components/kubectl/autoversion.ts
+++ b/src/components/kubectl/autoversion.ts
@@ -4,7 +4,7 @@ import * as sha256 from 'fast-sha256';
 import * as download from '../download/download';
 import { shell, Shell, Platform } from "../../shell";
 import { Dictionary } from '../../utils/dictionary';
-import { fs } from '../../fs';
+import { fs, FS } from '../../fs';
 import { Kubectl } from '../../kubectl';
 import { getCurrentContext } from '../../kubectlUtils';
 import { succeeded } from '../../errorable';
@@ -15,6 +15,8 @@ interface ClusterVersionCache {
     readonly derivedFromKubeconfig: string | undefined;
     readonly versions: Dictionary<string>;
 }
+
+let AUTO_VERSION_CACHE: ClusterVersionCache | undefined;
 
 export async function ensureSuitableKubectl(kubectl: Kubectl /* TODO: chicken my eggs */, shell: Shell): Promise<string | undefined> {
     const context = await getCurrentContext(kubectl);
@@ -73,6 +75,16 @@ function kubectlVersionPath(shell: Shell, serverVersion: string): string | undef
 }
 
 async function readCache(): Promise<ClusterVersionCache> {
+    if (!AUTO_VERSION_CACHE) {
+        AUTO_VERSION_CACHE = await readCacheFromFile();
+    }
+    if (!isCacheCurrent()) {
+        AUTO_VERSION_CACHE = { derivedFromKubeconfig: undefined, versions: {} };
+    }
+    return AUTO_VERSION_CACHE;
+}
+
+async function readCacheFromFile(): Promise<ClusterVersionCache> {
     if (fs.existsAsync(AUTO_VERSION_CACHE_FILE)) {
         return { derivedFromKubeconfig: undefined, versions: {} };
     }
@@ -80,9 +92,11 @@ async function readCache(): Promise<ClusterVersionCache> {
     return JSON.parse(cacheText);
 }
 
-async function writeCache(cache: ClusterVersionCache): Promise<void> {
-    const text = JSON.stringify(cache, undefined, 2);
-    await fs.writeTextFile(AUTO_VERSION_CACHE_FILE, text);
+async function writeCache(): Promise<void> {
+    if (AUTO_VERSION_CACHE) {
+        const text = JSON.stringify(AUTO_VERSION_CACHE, undefined, 2);
+        await fs.writeTextFile(AUTO_VERSION_CACHE_FILE, text);
+    }
 }
 
 async function isCacheCurrent(): Promise<boolean> {
@@ -92,8 +106,7 @@ async function isCacheCurrent(): Promise<boolean> {
     const kubeconfig = await fs.readFileAsync(KUBECONFIG_FILE);
     const kubeconfigHash = sha256.hash(kubeconfig);
     const kubeconfigHashText = hashToString(kubeconfigHash);
-    const cache = await readCache();
-    const cacheKubeconfigHashText = cache.derivedFromKubeconfig;
+    const cacheKubeconfigHashText = AUTO_VERSION_CACHE!.derivedFromKubeconfig;
     return kubeconfigHashText === cacheKubeconfigHashText;
 }
 
@@ -103,7 +116,7 @@ function hashToString(hash: Uint8Array): string {
 
 async function getServerVersion(kubectl: Kubectl, context: string): Promise<string | undefined> {
     const cachedVersions = await readCache();
-    if (cachedVersions.versions[context] && await isCacheCurrent()) {
+    if (cachedVersions.versions[context]) {
         return cachedVersions.versions[context];
     }
     const sr = await kubectl.invokeAsync('version -o json');
@@ -112,7 +125,7 @@ async function getServerVersion(kubectl: Kubectl, context: string): Promise<stri
         if (versionInfo && versionInfo.serverVersion) {
             const serverVersion: string = versionInfo.serverVersion.gitVersion;
             cachedVersions.versions[context] = serverVersion;
-            await writeCache(cachedVersions);
+            await writeCache();
             return serverVersion;
         }
     }
@@ -142,4 +155,33 @@ function formatBin(tool: string, platform: Platform): string | null {
         return toolPath + '.exe';
     }
     return toolPath;
+}
+
+class FileBacked<T> {
+    private value: T | undefined;
+
+    constructor(
+        private readonly fs: FS,
+        private readonly filename: string,
+        private readonly defaultValue: () => T)
+        {}
+
+    async read(): Promise<T> {
+        if (this.value) {
+            return this.value;
+        }
+        if (this.fs.existsAsync(this.filename)) {
+            const text = await this.fs.readTextFile(this.filename);
+            this.value = JSON.parse(text);
+            return this.value!;
+        }
+        await this.update(this.defaultValue());
+        return this.value!;
+    }
+
+    async update(value: T): Promise<void> {
+        this.value = value;
+        const text = JSON.stringify(this.value, undefined, 2);
+        await this.fs.writeTextFile(this.filename, text);
+    }
 }

--- a/src/components/kubectl/autoversion.ts
+++ b/src/components/kubectl/autoversion.ts
@@ -1,0 +1,137 @@
+import * as path from 'path';
+import * as sha256 from 'fast-sha256';
+
+import * as download from '../download/download';
+import { shell, Shell, Platform } from "../../shell";
+import { Dictionary } from '../../utils/dictionary';
+import { fs } from '../../fs';
+import { Kubectl } from '../../kubectl';
+import { getCurrentContext } from '../../kubectlUtils';
+import { succeeded } from '../../errorable';
+
+const AUTO_VERSION_CACHE_FILE = getCachePath();
+
+interface ClusterVersionCache {
+    readonly derivedFromKubeconfig: string | undefined;
+    readonly versions: Dictionary<string>;
+}
+
+export async function ensureSuitableKubectl(kubectl: Kubectl /* TODO: chicken my eggs */, shell: Shell): Promise<string | undefined> {
+    const context = await getCurrentContext(kubectl);
+    if (!context) {
+        return undefined;
+    }
+    const serverVersion = await getServerVersion(kubectl, context.contextName);
+    if (!serverVersion) {
+        return undefined;
+    }
+    if (!(await gotKubectlVersion(shell, serverVersion))) {
+        const downloaded = await downloadKubectlVersion(shell, serverVersion);
+        if (!downloaded) {
+            return undefined;
+        }
+    }
+    return kubectlVersionPath(shell, serverVersion);
+}
+
+function getBasePath(): string {
+    return path.join(shell.home(), `.vs-kubernetes/tools/kubectl/autoversion`);
+}
+
+function getCachePath(): string {
+    return path.join(getBasePath(), `cache.json`);
+}
+
+async function gotKubectlVersion(shell: Shell, serverVersion: string): Promise<boolean> {
+    const binPath = kubectlVersionPath(shell, serverVersion);
+    if (!binPath) {
+        return true;  // if we can't place the binary, there's no point downloading it
+    }
+    return await fs.existsAsync(binPath);
+}
+
+// TODO: deduplicate with installer.ts
+async function downloadKubectlVersion(shell: Shell, serverVersion: string): Promise<boolean> {
+    const binPath = kubectlVersionPath(shell, serverVersion);
+    if (!binPath) {
+        return false;
+    }
+    const os = platformUrlString(shell.platform())!;
+    const binFile = (shell.isUnix()) ? 'kubectl' : 'kubectl.exe';
+    const kubectlUrl = `https://storage.googleapis.com/kubernetes-release/release/${serverVersion}/bin/${os}/amd64/${binFile}`;
+    const downloadResult = await download.to(kubectlUrl, binPath);
+    return succeeded(downloadResult);
+}
+
+function kubectlVersionPath(shell: Shell, serverVersion: string): string | undefined {
+    const platform = shell.platform();
+    const binPath = formatBin('kubectl', platform);
+    if (!binPath) {
+        return undefined;  // should never happen
+    }
+    return path.join(getBasePath(), serverVersion, binPath);
+}
+
+async function readCache(): Promise<ClusterVersionCache> {
+    if (fs.existsAsync(AUTO_VERSION_CACHE_FILE)) {
+        return { derivedFromKubeconfig: undefined, versions: {} };
+    }
+    const cacheText = await fs.readTextFile(AUTO_VERSION_CACHE_FILE);
+    return JSON.parse(cacheText);
+}
+
+async function isCacheCurrent(): Promise<boolean> {
+    if (!await fs.existsAsync(KUBECONFIG_FILE)) {
+        return false;
+    }
+    const kubeconfig = await fs.readFileAsync(KUBECONFIG_FILE);
+    const kubeconfigHash = sha256.hash(kubeconfig);
+    const kubeconfigHashText = hashToString(kubeconfigHash);
+    const cache = await readCache();
+    const cacheKubeconfigHashText = cache.derivedFromKubeconfig;
+    return kubeconfigHashText === cacheKubeconfigHashText;
+}
+
+function hashToString(hash: Uint8Array): string {
+    return Buffer.from(hash).toString('hex');
+}
+
+async function getServerVersion(kubectl: Kubectl, context: string): Promise<string | undefined> {
+    const cachedVersions = await readCache();
+    if (cachedVersions.versions[context] && await isCacheCurrent()) {
+        return cachedVersions.versions[context];
+    }
+    const sr = await kubectl.invokeAsync('version -o json');
+    if (sr && sr.code === 0) {
+        const versionInfo = JSON.parse(sr.stdout);
+        const serverVersion: string = versionInfo.serverVersion.gitVersion;
+        // TODO: write it to the cache
+        return serverVersion;
+    }
+    return undefined;
+}
+
+// TODO: deduplicate from installer.ts
+function platformUrlString(platform: Platform, supported?: Platform[]): string | null {
+    if (supported && supported.indexOf(platform) < 0) {
+        return null;
+    }
+    switch (platform) {
+        case Platform.Windows: return 'windows';
+        case Platform.MacOS: return 'darwin';
+        case Platform.Linux: return 'linux';
+        default: return null;
+    }
+}
+
+function formatBin(tool: string, platform: Platform): string | null {
+    const platformString = platformUrlString(platform);
+    if (!platformString) {
+        return null;
+    }
+    const toolPath = `${platformString}-amd64/${tool}`;
+    if (platform === Platform.Windows) {
+        return toolPath + '.exe';
+    }
+    return toolPath;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ import { useNamespaceKubernetes } from './components/kubectl/namespace';
 import { EventDisplayMode, getEvents } from './components/kubectl/events';
 import * as docker from './docker';
 import { kubeChannel } from './kubeChannel';
-import { CheckPresentMessageMode, create as kubectlCreate } from './kubectl';
+import { CheckPresentMessageMode, createAutoVersioned as kubectlCreate } from './kubectl';
 import * as kubectlUtils from './kubectlUtils';
 import * as explorer from './explorer';
 import * as helmRepoExplorer from './helm.repoExplorer';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ import { useNamespaceKubernetes } from './components/kubectl/namespace';
 import { EventDisplayMode, getEvents } from './components/kubectl/events';
 import * as docker from './docker';
 import { kubeChannel } from './kubeChannel';
-import { CheckPresentMessageMode, createAutoVersioned as kubectlCreate } from './kubectl';
+import { CheckPresentMessageMode, create as kubectlCreate } from './kubectl';
 import * as kubectlUtils from './kubectlUtils';
 import * as explorer from './explorer';
 import * as helmRepoExplorer from './helm.repoExplorer';
@@ -81,7 +81,7 @@ let swaggerSpecPromise: Promise<explainer.SwaggerModel | undefined> | null = nul
 
 const kubernetesDiagnostics = vscode.languages.createDiagnosticCollection("Kubernetes");
 
-const kubectl = kubectlCreate(host, fs, shell, installDependencies);
+const kubectl = kubectlCreate(config.getKubectlVersioning(), host, fs, shell, installDependencies);
 const draft = draftCreate(host, fs, shell, installDependencies);
 const minikube = minikubeCreate(host, fs, shell, installDependencies);
 const clusterProviderRegistry = clusterproviderregistry.get();

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -9,6 +9,7 @@ export interface FS {
     readFileSync(filename: string, encoding: string): string;
     readFileToBufferSync(filename: string): Buffer;
     writeFile(filename: string, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
+    writeTextFile(filename: string, text: string): Promise<void>;
     writeFileSync(filename: string, data: any): void;
     dirSync(path: string): string[];
     unlinkAsync(path: string): Promise<void>;
@@ -29,6 +30,8 @@ export const fs: FS = {
     readFileSync: (filename, encoding) => sysfs.readFileSync(filename, encoding),
     readFileToBufferSync: (filename) => sysfs.readFileSync(filename),
     writeFile: (filename, data, callback) => sysfs.writeFile(filename, data, callback),
+    writeTextFile: promisify(
+        (filename: string, data: string, callback: (err: NodeJS.ErrnoException) => void) => sysfs.writeFile(filename, data, callback)),
     writeFileSync: (filename, data) => sysfs.writeFileSync(filename, data),
     dirSync: (path) => sysfs.readdirSync(path),
 

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -1,8 +1,11 @@
 import * as sysfs from 'fs';
+import { promisify } from 'util';
 
 export interface FS {
     existsSync(path: string | Buffer): boolean;
     readFile(filename: string, encoding: string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
+    readTextFile(path: string): Promise<string>;
+    readFileAsync(filename: string): Promise<Buffer>;
     readFileSync(filename: string, encoding: string): string;
     readFileToBufferSync(filename: string): Buffer;
     writeFile(filename: string, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
@@ -17,6 +20,12 @@ export interface FS {
 export const fs: FS = {
     existsSync: (path) => sysfs.existsSync(path),
     readFile: (filename, encoding, callback) => sysfs.readFile(filename, encoding, callback),
+    readTextFile: promisify(
+        (path: string, cb: (err: NodeJS.ErrnoException, data: string) => void) =>
+          sysfs.readFile(path, { encoding: 'utf8' }, cb)),
+    readFileAsync: promisify(
+        (path: string, cb: (err: NodeJS.ErrnoException, data: Buffer) => void) =>
+          sysfs.readFile(path, null, cb)),
     readFileSync: (filename, encoding) => sysfs.readFileSync(filename, encoding),
     readFileToBufferSync: (filename) => sysfs.readFileSync(filename),
     writeFile: (filename, data, callback) => sysfs.writeFile(filename, data, callback),

--- a/src/host.ts
+++ b/src/host.ts
@@ -18,6 +18,7 @@ export interface Host {
     showDocument(uri: vscode.Uri): Promise<vscode.TextDocument>;
     readDocument(uri: vscode.Uri): Promise<vscode.TextDocument>;
     selectRootFolder(): Promise<string | undefined>;
+    longRunning<T>(title: string, action: () => Promise<T>): Promise<T>;
 }
 
 export const host: Host = {
@@ -34,7 +35,8 @@ export const host: Host = {
     activeDocument : activeDocument,
     showDocument : showDocument,
     readDocument : readDocument,
-    selectRootFolder : selectRootFolder
+    selectRootFolder : selectRootFolder,
+    longRunning : longRunning
 };
 
 function showInputBox(options: vscode.InputBoxOptions, token?: vscode.CancellationToken): Thenable<string | undefined> {
@@ -134,4 +136,12 @@ async function selectRootFolder(): Promise<string | undefined> {
         return undefined;
     }
     return folder.uri.fsPath;
+}
+
+async function longRunning<T>(title: string, action: () => Promise<T>): Promise<T> {
+    const options = {
+        location: vscode.ProgressLocation.Notification,
+        title: title
+    };
+    return await vscode.window.withProgress(options, (_) => action());
 }

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -36,13 +36,22 @@ interface Context {
     readonly fs: FS;
     readonly shell: Shell;
     readonly installDependenciesCallback: () => void;
+    readonly pathfinder: (() => Promise<string>) | undefined;
     binFound: boolean;
     binPath: string;
 }
 
 class KubectlImpl implements Kubectl {
     constructor(host: Host, fs: FS, shell: Shell, installDependenciesCallback: () => void, kubectlFound: boolean) {
-        this.context = { host : host, fs : fs, shell : shell, installDependenciesCallback : installDependenciesCallback, binFound : kubectlFound, binPath : 'kubectl' };
+        this.context = {
+            host : host,
+            fs : fs,
+            shell : shell,
+            installDependenciesCallback : installDependenciesCallback,
+            pathfinder: undefined,
+            binFound : kubectlFound,
+            binPath : 'kubectl'
+        };
     }
 
     private readonly context: Context;
@@ -118,7 +127,7 @@ export enum CheckPresentMessageMode {
 }
 
 async function checkPresent(context: Context, errorMessageMode: CheckPresentMessageMode): Promise<boolean> {
-    if (context.binFound) {
+    if (context.binFound || context.pathfinder) {
         return true;
     }
 
@@ -163,7 +172,7 @@ async function invokeWithProgress(context: Context, command: string, progressMes
 
 async function invokeAsync(context: Context, command: string, stdin?: string): Promise<ShellResult | undefined> {
     if (await checkPresent(context, CheckPresentMessageMode.Command)) {
-        const bin = baseKubectlPath(context);
+        const bin = await baseKubectlPath(context);
         const cmd = `${bin} ${command}`;
         const sr = await context.shell.exec(cmd, stdin);
         if (sr && sr.code !== 0) {
@@ -199,7 +208,7 @@ async function invokeAsyncWithProgress(context: Context, command: string, progre
 
 async function spawnAsChild(context: Context, command: string[]): Promise<ChildProcess | undefined> {
     if (await checkPresent(context, CheckPresentMessageMode.Command)) {
-        return spawnChildProcess(path(context), command, context.shell.execOpts());
+        return spawnChildProcess(await path(context), command, context.shell.execOpts());
     }
     return undefined;
 }
@@ -219,7 +228,7 @@ async function invokeInTerminal(context: Context, command: string, pipeTo: strin
 
 async function runAsTerminal(context: Context, command: string[], terminalName: string): Promise<void> {
     if (await checkPresent(context, CheckPresentMessageMode.Command)) {
-        let execPath = path(context);
+        let execPath = await path(context);
         const cmd = command;
         if (getUseWsl()) {
             cmd.unshift(execPath);
@@ -233,7 +242,7 @@ async function runAsTerminal(context: Context, command: string[], terminalName: 
 
 async function kubectlInternal(context: Context, command: string, handler: ShellHandler): Promise<void> {
     if (await checkPresent(context, CheckPresentMessageMode.Command)) {
-        const bin = baseKubectlPath(context);
+        const bin = await baseKubectlPath(context);
         const cmd = `${bin} ${command}`;
         const sr = await context.shell.exec(cmd);
         if (sr) {
@@ -255,7 +264,10 @@ function kubectlDone(context: Context): ShellHandler {
     };
 }
 
-function baseKubectlPath(context: Context): string {
+async function baseKubectlPath(context: Context): Promise<string> {
+    if (context.pathfinder) {
+        return await context.pathfinder();
+    }
     let bin = getToolPath(context.host, context.shell, 'kubectl');
     if (!bin) {
         bin = 'kubectl';
@@ -307,7 +319,7 @@ async function asJson<T>(context: Context, command: string): Promise<Errorable<T
     return { succeeded: false, error: [ shellResult.stderr ] };
 }
 
-function path(context: Context): string {
-    const bin = baseKubectlPath(context);
+async function path(context: Context): Promise<string> {
+    const bin = await baseKubectlPath(context);
     return binutil.execPath(context.shell, bin);
 }

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -105,6 +105,11 @@ export async function getContexts(kubectl: Kubectl): Promise<KubectlContext[]> {
     });
 }
 
+export async function getCurrentContext(kubectl: Kubectl): Promise<KubectlContext | undefined> {
+    const contexts = await getContexts(kubectl);
+    return contexts.find((c) => c.active);
+}
+
 export async function deleteCluster(kubectl: Kubectl, context: KubectlContext): Promise<boolean> {
     const deleteClusterResult = await kubectl.invokeAsyncWithProgress(`config delete-cluster ${context.clusterName}`, "Deleting cluster...");
     if (!deleteClusterResult || deleteClusterResult.code !== 0) {

--- a/src/utils/filebacked.ts
+++ b/src/utils/filebacked.ts
@@ -13,7 +13,7 @@ export class FileBacked<T> {
         if (this.value) {
             return this.value;
         }
-        if (this.fs.existsAsync(this.filename)) {
+        if (await this.fs.existsAsync(this.filename)) {
             const text = await this.fs.readTextFile(this.filename);
             this.value = JSON.parse(text);
             return this.value!;
@@ -26,10 +26,5 @@ export class FileBacked<T> {
         this.value = value;
         const text = JSON.stringify(this.value, undefined, 2);
         await this.fs.writeTextFile(this.filename, text);
-    }
-
-    async invalidate(): Promise<void> {
-        const value = this.defaultValue();
-        await this.update(value);
     }
 }

--- a/src/utils/filebacked.ts
+++ b/src/utils/filebacked.ts
@@ -1,0 +1,35 @@
+import { FS } from "../fs";
+
+export class FileBacked<T> {
+    private value: T | undefined;
+
+    constructor(
+        private readonly fs: FS,
+        private readonly filename: string,
+        private readonly defaultValue: () => T)
+        {}
+
+    async get(): Promise<T> {
+        if (this.value) {
+            return this.value;
+        }
+        if (this.fs.existsAsync(this.filename)) {
+            const text = await this.fs.readTextFile(this.filename);
+            this.value = JSON.parse(text);
+            return this.value!;
+        }
+        await this.update(this.defaultValue());
+        return this.value!;
+    }
+
+    async update(value: T): Promise<void> {
+        this.value = value;
+        const text = JSON.stringify(this.value, undefined, 2);
+        await this.fs.writeTextFile(this.filename, text);
+    }
+
+    async invalidate(): Promise<void> {
+        const value = this.defaultValue();
+        await this.update(value);
+    }
+}

--- a/src/utils/mkdirp.ts
+++ b/src/utils/mkdirp.ts
@@ -1,0 +1,4 @@
+import { promisify } from "util";
+import mkdirp = require("mkdirp");
+
+export const mkdirpAsync = promisify(mkdirp);


### PR DESCRIPTION
Some customers - specifically the critical customer demographic known as _me_ - have clusters from multiple Kubernetes versions.  It is not always possible to find a version of `kubectl` that works with all clusters, because `kubectl` is only guaranteed to work up to 2 API versions away.  For example, if I use my 1.9 kubectl then I can't see pods in the 1.7 cluster, but if I use my 1.7 kubectl then I can't deploy CRDs into the 1.9 cluster.

This PR adds an _opt-in_ option by which, instead of users specifying a `kubectl` binary, we inspect the cluster, download the matching `kubectl` binary and use that.  This is opt-in because I'm worried about performance impact; later we could change it to opt-out so as to make it more transparent.  Cluster versions and kubectl binaries are cached and persisted to minimise delays when switching clusters.  However, we incur a `kubectl config` call on _every_ command, as we need to check the current context name, and this may be non-trivial.  In future perhaps we could cache that, invalidating if the user switches context through the VS Code UI, and re-evaluate if we get an error to handle the 'changing cluster behind our back' scenario.

At the moment, the user still needs to provide a `kubectl` binary to bootstrap the process (because you need a kubectl to call `kubectl version`).  It would be good to remove this requirement and quietly download the latest `kubectl` to act as bootstrapper if no other kubectl can be found.

Fixes #385.