### PR TITLE
Run CronJob immediately

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4060,10 +4060,9 @@
             }
         },
         "moment": {
-            "version": "2.22.2",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-            "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
-            "optional": true
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
         },
         "ms": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "onCommand:extension.vsKubernetesUseNamespace",
         "onCommand:extension.vsKubernetesShowEvents",
         "onCommand:extension.vsKubernetesFollowEvents",
+        "onCommand:extension.vsKubernetesCronJobRunNow",
         "onCommand:extension.helmTemplate",
         "onCommand:extension.helmTemplatePreview",
         "onCommand:extension.helmLint",
@@ -437,6 +438,11 @@
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
                 },
                 {
+                    "command": "extension.vsKubernetesCronJobRunNow",
+                    "group": "3",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.cronjob"
+                },
+                {
                     "command": "extension.vsKubernetesAddFile",
                     "group": "3",
                     "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.configmap"
@@ -733,6 +739,11 @@
             {
                 "command": "extension.vsKubernetesDeleteFile",
                 "title": "Delete File",
+                "category": "Kubernetes"
+            },
+            {
+                "command": "extension.vsKubernetesCronJobRunNow",
+                "title": "Run CronJob Now",
                 "category": "Kubernetes"
             },
             {

--- a/package.json
+++ b/package.json
@@ -1060,6 +1060,7 @@
         "lodash": "^4.17.10",
         "mixin-deep": "^1.3.1",
         "mkdirp": "^0.5.1",
+        "moment": "^2.24.0",
         "natives": "^1.1.3",
         "node-yaml-parser": "^0.0.9",
         "opn": "^5.2.0",

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -251,6 +251,14 @@ export async function currentNamespace(kubectl: Kubectl): Promise<string> {
     return currentContext.context.namespace || "default";
 }
 
+export async function currentNamespaceArg(kubectl: Kubectl): Promise<string> {
+    const ns = await currentNamespace(kubectl);
+    if (ns.length === 0) {
+        return '';
+    }
+    return `--namespace ${ns}`;
+}
+
 export async function switchNamespace(kubectl: Kubectl, namespace: string): Promise<boolean> {
     const shellResult = await kubectl.invokeAsync("config current-context");
     if (!shellResult || shellResult.code !== 0) {

--- a/src/utils/naming.ts
+++ b/src/utils/naming.ts
@@ -1,0 +1,5 @@
+import * as moment from 'moment';
+
+export function timestampText(): string {
+    return moment().format('YYYYMMDD-HHmmss');  // Not caring much about UTC vs local for naming purposes
+}


### PR DESCRIPTION
This adds the functionality to run a CronJob immediately (that is, to create a 'normal' job from a CronJob).

Fixes #469.

~~(ETA: in order to avoid having to duplicate menu contributions for a new `vsKubernetes.resource.cronjob` tree node context, I switched over the menu contributions in `package.json` to use regular expressions on the context when clause.  This is orthogonal to the functional changes.  I can unpick it into a separate PR if it makes this one hard to read.)~~  This PR depends on #473 which separates out the refactoring of the explorer command contributions.  Once #473 is merged I can rebase this and it will reduce the noise.