### PR TITLE
Job logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -864,10 +864,10 @@
             "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
             "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
             "requires": {
-                "dtrace-provider": "~0.8",
-                "moment": "^2.10.6",
-                "mv": "~2",
-                "safe-json-stringify": "~1"
+                "dtrace-provider": "0.8.7",
+                "moment": "2.24.0",
+                "mv": "2.1.1",
+                "safe-json-stringify": "1.2.0"
             }
         },
         "byline": {

--- a/package.json
+++ b/package.json
@@ -430,12 +430,12 @@
                 {
                     "command": "extension.vsKubernetesShowLogs",
                     "group": "3",
-                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
+                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /^vsKubernetes\\.resource\\.(pod|job)$/"
                 },
                 {
                     "command": "extension.vsKubernetesFollowLogs",
                     "group": "3",
-                    "when": "view == extension.vsKubernetesExplorer && viewItem == vsKubernetes.resource.pod"
+                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /^vsKubernetes\\.resource\\.(pod|job)$/"
                 },
                 {
                     "command": "extension.vsKubernetesCronJobRunNow",

--- a/src/utils/containercontainer.ts
+++ b/src/utils/containercontainer.ts
@@ -1,0 +1,44 @@
+import { Container } from "../kuberesources.objectmodel";
+import * as explorer from "../explorer";
+import { PodSummary } from "../extension";
+
+// Represents a Kubernetes resource that contains a collection of (Docker) containers -
+// specifically a pod or a job.
+//
+// Yes, I would like a better name for it!
+export interface ContainerContainer {
+    readonly kindName: string;
+    readonly namespace: string | undefined;
+    readonly containers?: Container[];
+    readonly containersQueryPath: string;
+}
+
+export module ContainerContainer {
+
+    export function fromNode(explorerNode: explorer.ResourceNode): ContainerContainer | undefined {
+        const queryPath = containersQueryPath(explorerNode);
+        if (!queryPath) {
+            return undefined;
+        }
+        return { kindName: explorerNode.resourceId, namespace: explorerNode.namespace || undefined, containersQueryPath: queryPath };
+    }
+
+    export function fromPod(pod: PodSummary): ContainerContainer {
+        return {
+            kindName: `pod/${pod.name}`,
+            namespace: pod.namespace || undefined,
+            containers: pod.spec ? pod.spec.containers : undefined,
+            containersQueryPath: '.spec'
+        };
+    }
+
+    function containersQueryPath(explorerNode: explorer.ResourceNode): string | undefined {
+        const kind = explorerNode.resourceId.substring(0, explorerNode.resourceId.indexOf('/'));
+        switch (kind) {
+            case 'pod': return '.spec';
+            case 'job': return '.spec.template.spec';
+            default: return undefined;
+        }
+    }
+
+}


### PR DESCRIPTION
Adds the Logs right-click commands on Kubernetes job resources.

(NOTE: This sits over the "explorer command refactoring" and "cron job" PRs.  Once those are merged it collapses to a single, more specific commit.)