### PR TITLE
Use full HTML documents for Web views

### DIFF
--- a/src/components/wizard/wizard.ts
+++ b/src/components/wizard/wizard.ts
@@ -51,7 +51,7 @@ export function createWizard(tabTitle: string, formId: string, s: Subscriber): W
     }
     </script>`;
 
-    const html = `<div id='wvcontent__' />${nextScript}`;
+    const html = `<html><body><div id='wvcontent__' />${nextScript}</body></html>`;
 
     const w = vscode.window.createWebviewPanel('vsk8s-dialog', tabTitle, vscode.ViewColumn.Active, {
         retainContextWhenHidden: true,


### PR DESCRIPTION
In the course of reporting/resolving the "spurious 'null' at the top of Web views" issue (https://github.com/Microsoft/vscode/issues/68953), we've been advised to use full HTML documents for Webviews rather than fragments.  (This doesn't work around the spurious text - they've fixed that upstream - but it's just a sensible idea anyway.)