### PR TITLE
Fix for contributed cluster types not appearing first time if extension activated by wizard command

### DIFF
--- a/package.json
+++ b/package.json
@@ -506,6 +506,10 @@
             ],
             "commandPalette": [
                 {
+                    "command": "extension.vsKubernetesDebounceActivation",
+                    "when": "context == thiscontextdoesnotexist7603253285"
+                },
+                {
                     "command": "extension.vsKubernetesApplyFile",
                     "when": "filesExplorerFocus"
                 },
@@ -572,6 +576,11 @@
             ]
         },
         "commands": [
+            {
+                "command": "extension.vsKubernetesDebounceActivation",
+                "title": "Debounce Activation",
+                "category": "Kubernetes"
+            },
             {
                 "command": "extension.vsKubernetesDescribe.Refresh",
                 "title": "Refresh",


### PR DESCRIPTION
A cluster provider normally activates in response to one of the wizard commands.  If the _core_ Kubernetes extension was not already active at that point - that is, it is the wizard command that's activating the core extension - then the core extension activates and sometimes the wizard command would start to run _before_ the cluster provider could activate and add its entry to the cluster types list.  This would require the user to cancel and restart the wizard, so that it would include the now-registered cluster type.

This PR works around this by forcing VS Code to await the execution of a dummy, no-op command before starting the wizard.  This seems to give extension-extensions the chance to complete their activation before the first page of the wizard is displayed and the cluster provider registry is read.

Don't judge me, people.

Fixes #504.

Raised underlying issue as https://github.com/Microsoft/vscode/issues/71471.