### PR TITLE
Bump version for API preview consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "0.1.18",
+    "version": "0.1.19+preview1",
     "preview": true,
     "publisher": "ms-kubernetes-tools",
     "engines": {


### PR DESCRIPTION
Creating a preview version so that users wanting to try out the new API don't need to build the extension themselves.  This will be distributed only as a VSIX via a GitHub release page; it will not go to the marketplace.