### PR TITLE
Add port forwarding to the API

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "0.1.19+preview1",
+    "version": "0.1.19+preview2",
     "preview": true,
     "publisher": "ms-kubernetes-tools",
     "engines": {

--- a/src/api/contract/kubectl/v1.ts
+++ b/src/api/contract/kubectl/v1.ts
@@ -2,8 +2,11 @@
 // It should be in sync with vscode-kubernetes-tools-api/ts/kubectl/v1.ts
 // at all times.
 
+import * as vscode from 'vscode';
+
 export interface KubectlV1 {
     invokeCommand(command: string): Promise<KubectlV1.ShellResult | undefined>;
+    portForward(podName: string, podNamespace: string | undefined, localPort: number, remotePort: number): Promise<vscode.Disposable | undefined>;
 }
 
 export namespace KubectlV1 {

--- a/src/api/implementation/kubectl/v1.ts
+++ b/src/api/implementation/kubectl/v1.ts
@@ -1,5 +1,8 @@
+import * as vscode from 'vscode';
+
 import { KubectlV1 } from "../../contract/kubectl/v1";
 import { Kubectl } from "../../../kubectl";
+import { ChildProcess } from 'child_process';
 
 export function impl(kubectl: Kubectl): KubectlV1 {
     return new KubectlV1Impl(kubectl);
@@ -11,4 +14,49 @@ class KubectlV1Impl implements KubectlV1 {
     invokeCommand(command: string): Promise<KubectlV1.ShellResult | undefined> {
         return this.kubectl.invokeAsync(command);
     }
+
+    // TODO: move into core kubectl module
+    // And/or convert to invokeBackground API and make portForward a wrapper over that
+    async portForward(podName: string, podNamespace: string | undefined, localPort: number, remotePort: number): Promise<vscode.Disposable | undefined> {
+        const nsarg = podNamespace ? ['--namespace', podNamespace] : [];
+        const cmd = ['port-forward', podName, `${localPort}:${remotePort}`, ...nsarg];
+        const pfProcess = await this.kubectl.spawnAsChild(cmd);
+        if (!pfProcess) {
+            return undefined;
+        }
+
+        const forwarding = await waitForOutput(pfProcess, /Forwarding\s+from\s+127\.0\.0\.1:/);
+
+        if (forwarding === WaitForOutputResult.Success) {
+            const onDispose = () => { pfProcess.kill(); };
+            return vscode.Disposable.from({ dispose: onDispose });
+        }
+
+        return undefined;
+    }
+}
+
+enum WaitForOutputResult {
+    Success = 1,
+    ProcessExited = 2
+}
+
+function waitForOutput(process: ChildProcess, pattern: RegExp): Promise<WaitForOutputResult> {
+    return new Promise<WaitForOutputResult>((resolve) => {
+        let didOutput = false;
+
+        process.stdout.on('data', async (data) => {
+            const message = `${data}`;
+            if (pattern.test(message)) {
+                didOutput = true;
+                resolve(WaitForOutputResult.Success);
+            }
+        });
+
+        process.on('close', async (_code) => {
+            if (!didOutput) {
+                resolve(WaitForOutputResult.ProcessExited);
+            }
+        });
+    });
 }


### PR DESCRIPTION
Port forwarding is a bit fiddly, and is not readily supported by the simple `invokeCommand` abstraction which waits for command completion.  So it would be useful to facilitate it in the API.  (More generally, we should consider adding an 'invoke background' facility on top of which port forwarding could be built.)