### PR TITLE
Added a basic Helm API

### DIFF
--- a/docs/extending/helm.md
+++ b/docs/extending/helm.md
@@ -1,0 +1,41 @@
+# Invoking `helm`
+
+The Kubernetes extension provides an API to invoke the Helm command line.
+As with `kubectl`, you can of course invoke `helm` directly using a library
+such as `shelljs`, but using the API gives your users a consistent user
+experience, for example in terms of error handling or offering to install
+it if missing.
+
+To invoke `helm` through the extension API:
+
+* Request the Kubernetes extension's Helm API
+* Call the `invokeCommand` method passing the desired `helm` command and arguments
+
+`invokeCommand` returns a promise, which resolves to either:
+
+* An object containing the exit code, standard output and standard error of `helm`
+* `undefined`, if the Kubernetes extension was unable to invoke `helm` at all
+
+The following example uses the Helm API to install Weave Scope:
+
+```javascript
+import * as k8s from 'vscode-kubernetes-tools-api';
+
+async function installScope() {
+    const helm = await k8s.extension.helm.v1;
+    if (!helm.available) {
+        return;
+    }
+    const result = await helm.api.invokeCommand(`install stable/weave-scope`);
+
+    if (!result || result.code !== 0) {
+        const errorMessage = result ? result.stderr : 'Unable to invoke helm';
+        await vscode.window.showErrorMessage(`Installing Scope failed: ${errorMessage}`);
+        return;
+    }
+
+    await vscode.window.showInformationMessage('Scope has been installed');
+}
+```
+
+

--- a/docs/extending/kubectl.md
+++ b/docs/extending/kubectl.md
@@ -28,7 +28,10 @@ import * as k8s from 'vscode-kubernetes-tools-api';
 
 async function cordonNode(nodeId: string) {
     const kubectl = await k8s.extension.kubectl.v1;
-    const result = await kubectl.invokeCommand(`cordon ${nodeId}`);
+    if (!kubectl.available) {
+        return;
+    }
+    const result = await kubectl.api.invokeCommand(`cordon ${nodeId}`);
 
     if (!result || result.code !== 0) {
         const errorMessage = result ? result.stderr : 'Unable to invoke kubectl';

--- a/src/api/contract/helm/v1.ts
+++ b/src/api/contract/helm/v1.ts
@@ -1,0 +1,15 @@
+// This module is contractual and should not be changed after release.
+// It should be in sync with vscode-kubernetes-tools-api/ts/helm/v1.ts
+// at all times.
+
+export interface HelmV1 {
+    invokeCommand(command: string): Promise<HelmV1.ShellResult | undefined>;
+}
+
+export namespace HelmV1 {
+    export interface ShellResult {
+        readonly code: number;
+        readonly stdout: string;
+        readonly stderr: string;
+    }
+}

--- a/src/api/implementation/apibroker.ts
+++ b/src/api/implementation/apibroker.ts
@@ -2,6 +2,7 @@ import { APIBroker, API } from "../contract/api";
 import { versionUnknown } from "./apiutils";
 import * as clusterprovider from "./clusterprovider/versions";
 import * as kubectl from "./kubectl/versions";
+import * as helm from "./helm/versions";
 import * as clusterExplorer from "./cluster-explorer/versions";
 import { ClusterProviderRegistry } from "../../components/clusterprovider/clusterproviderregistry";
 import { Kubectl } from "../../kubectl";
@@ -13,6 +14,7 @@ export function apiBroker(clusterProviderRegistry: ClusterProviderRegistry, kube
             switch (component) {
                 case "clusterprovider": return clusterprovider.apiVersion(clusterProviderRegistry, version);
                 case "kubectl": return kubectl.apiVersion(kubectlImpl, version);
+                case "helm": return helm.apiVersion(version);
                 case "clusterexplorer": return clusterExplorer.apiVersion(explorer, version);
                 default: return versionUnknown;
             }

--- a/src/api/implementation/helm/v1.ts
+++ b/src/api/implementation/helm/v1.ts
@@ -1,0 +1,12 @@
+import { HelmV1 } from "../../contract/helm/v1";
+import { helmExecAsync } from "../../../helm.exec";
+
+export function impl(): HelmV1 {
+    return new HelmV1Impl();
+}
+
+class HelmV1Impl implements HelmV1 {
+    invokeCommand(command: string): Promise<HelmV1.ShellResult | undefined> {
+        return helmExecAsync(command);
+    }
+}

--- a/src/api/implementation/helm/versions.ts
+++ b/src/api/implementation/helm/versions.ts
@@ -1,0 +1,10 @@
+import * as v1 from "./v1";
+import { API } from "../../contract/api";
+import { versionUnknown, available } from "../apiutils";
+
+export function apiVersion(version: string): API<any> {
+    switch (version) {
+        case "v1": return available(v1.impl());
+        default: return versionUnknown;
+    }
+}


### PR DESCRIPTION
The primary purpose is to support extensions that want to install tools via Helm charts.  But it may as well be a general-purpose invocation API.