### PR TITLE
Cloud Explorer

### DIFF
--- a/docs/extending/README.md
+++ b/docs/extending/README.md
@@ -64,6 +64,13 @@ snippet. In terms of the TypeScript typings from the NPM package, `activate` ret
   extension commands and features
   * ID: `kubectl`
   * Versions: `v1`
-* [Cluster Explorer API](clusterexplorer.md) - used for working with the existing Clusters tree
+* [Helm API](helm.md) - used for invoking the `helm` CLI consistently with the core
+  extension commands and features
+  * ID: `kubectl`
+  * Versions: `v1`
+* [Cluster Explorer API](clusterexplorer.md) - used for working with the Clusters tree
   * ID: `clusterexplorer`
+  * Versions: `v1`
+* [Cloud Explorer API](cloudexplorer.md) - used for working with the Clouds tree
+  * ID: `cloudexplorer`
   * Versions: `v1`

--- a/docs/extending/cloudexplorer.md
+++ b/docs/extending/cloudexplorer.md
@@ -1,0 +1,168 @@
+# Adding Providers to the Cloud Explorer
+
+Cloud Explorer is a way for users to browse the Kubernetes clusters they have created
+in their cloud environments, regardless of whether those clusters appear in their
+kubeconfig.  Cloud Explorer provides access to _cloud-specific_ behaviour and features whereas
+Cluster Explorer provides access to Kubernetes cluster contents and features.
+
+Out of the box, the Cloud Explorer doesn't know about _any_ clouds.  As a cloud vendor, you
+can add your cloud to the Cloud Explorer using the Kubernetes extension's API, by writing
+and registering an object called a _cloud provider_.
+
+Note that as with cluster providers, a cloud provider is _not_ needed to use a Kubernetes
+cluster that runs in the cloud.  As long as the cluster is in kubeconfig, the extension will work with it.
+Cloud providers are used only to surface what is in the user's cloud and to provide
+integrated UI for adding clusters to kubeconfig or other tasks that require cloud-specific
+support.
+
+## Elements of a cloud provider
+
+An object that provides content for the Cloud Explorer is called a _cloud provider_.  Cloud
+providers must be hosted within a Visual Studio Code extension.  This table summarises what
+your cloud providers and their hosting extension need to do; the rest of this article goes into detail.
+
+| Component            | Responsibilities                                                     |
+|----------------------|----------------------------------------------------------------------|
+| Your extension       | Activate when Cloud Explorer is displayed                            |
+|                      | Register cloud providers with Kubernetes extension                   |
+| Cloud provider       | Implement the cloud provider interface                               |
+|                      | Provide metadata for the Cloud Explorer top level                    |
+|                      | Display cloud resources in tree format                               |
+|                      | Optionally, provide cluster kubeconfig when requested                |
+| Kubernetes extension | Display the Cloud Explorer tree                                      |
+|                      | Implement standard Merge Into Kubeconfig and Save Kubeconfig commands|
+
+## Implementing the cloud provider
+
+A cloud provider must implement the following interface.  (For documentation purposes
+the interface is written in TypeScript terms but any JavaScript object that provides
+the specified properties and methods will do.)
+
+```javascript
+interface CloudProvider {
+    readonly cloudName: string;
+    readonly treeDataProvider: vscode.TreeDataProvider<any>;
+    getKubeconfigYaml(cluster: any): Promise<string | undefined>;
+}
+```
+
+### Implementing the metadata
+
+The `cloudName` should be a user-friendly name for your cloud type, such as `Microsoft Azure` or
+`Contoso Compute Megafloof`.  It is displayed as a top level node in Cloud Explorer.
+
+### Implementing the tree provider
+
+Your provider completely controls the part of the tree under the top level node provided for it
+by the Kubernetes extension.  You define this by implementing the standard `vscode.TreeDataProvider`
+interface.  The Kubernetes extension will call into your TreeDataProvider to populate
+your branch of the tree; you do _not_ need to register it as associated with a view.
+
+Note that when `getChildren` is called for your first-level tree nodes, the parent `element`
+argument will be `undefined` as for a normal TreeDataProvider, _even though there is actually
+a parent node_ (provided by the Kubernetes extension).
+
+### Commands for your tree nodes
+
+The Kubernetes extension provides standard implementations for the `Merge into Kubeconfig` and
+`Save Kubeconfig` commands.  To opt into these, include the string `kubernetes.providesKubeconfig`
+in your tree item context (use the constant `SHOW_KUBECONFIG_COMMANDS_CONTEXT` from the NPM package).
+Here is an example from a Microsoft Azure sample provider, which uses a `nodeType` field to
+identify which tree nodes represent clusters:
+
+```javascript
+getTreeItem(element: AzureTreeNode): vscode.TreeItem | Thenable<vscode.TreeItem> {
+    if (element.nodeType === 'cluster') {
+        const treeItem = new vscode.TreeItem(element.name, vscode.TreeItemCollapsibleState.None);
+        treeItem.contextValue = `aks.cluster ${k8s.CloudExplorerV1.SHOW_KUBECONFIG_COMMANDS_CONTEXT}`;
+        return treeItem;
+    } else {
+        // handle other nodes types
+    }
+}
+```
+
+If you do this, then when the user invokes one of the standard commands for a cluster, the
+Kubernetes extension will call the cloud provider's `getKubeconfigYaml` method, passing the tree
+data item for which the command was invoked.  Your implementation should handle any user
+interaction or any error reporting, and return a string containing the cluster's kubeconfig
+in YAML format, or `undefined` to cancel the command (e.g. if there was an error or the user
+cancelled out of a prompt).  For example:
+
+```javascript
+async function getKubeconfigYaml(cluster: AzureClusterTreeNode): Promise<string | undefined> {
+    // Pull out of the tree node the data we need to talk to the cloud
+    const { resourceGroupName, name } = parseResource(cluster.armId);
+    if (!resourceGroupName || !name) {
+        vscode.window.showErrorMessage(`Invalid Azure resource ID ${target.armId}`);
+        return undefined;
+    }
+
+    try {
+        // Interact with the cloud to get the kubeconfig YAML - this is specific to the Azure sample
+        const client = new ContainerServiceClient(target.session.credentials, target.subscription.subscriptionId!);
+        const accessProfile = await client.managedClusters.getAccessProfile(resourceGroupName, name, 'clusterUser');
+        const kubeconfig = accessProfile.kubeConfig!.toString();
+        return kubeconfig;
+    } catch (e) {
+        vscode.window.showErrorMessage(`Can't get kubeconfig: ${e}`);
+        return undefined;
+    }
+}
+```
+
+_TODO: check and document behaviour if users define their own commands on their tree nodes (because we wrap them)_
+
+## Registering the cloud provider
+
+In order to be displayed in Cloud Explorer, a cloud
+provider must be _registered_ with the Kubernetes extension.  This is the responsibility
+of the VS Code extension that hosts the cluster provider.  To do this, the extension must:
+
+* Activate in response to the `kubernetes.cloudExplorer` view
+* Request the Kubernetes extension's Cloud Provider API
+* Call the `register` method for each cloud provider it wants to display
+
+### Activating the cloud provider extension
+
+Your extension needs to activate in response to the `kubernetes.cloudExplorer`
+commands, so that it can register its cloud provider(s) before the wizard is
+displayed.  To do this, your `package.json` must include the following activation event:
+
+```json
+    "activationEvents": [
+        "onView:kubernetes.cloudExplorer"
+    ],
+```
+
+Depending on your extension you may have other activation events as well.
+
+### Registering cloud providers with the Kubernetes extension
+
+In your extension's `activate` function, you must register your provider(s) using the
+Kubernetes extension API.  The following sample shows how to do this using the NPM
+helper package; if you don't use the helper then the process of requesting the API is
+more manual but the registration is the same.
+
+```javascript
+const MY_PROVIDER = {
+    cloudName: "Contoso Compute Megafloof",
+    treeDataProvider: new MegafloofTreeDataProvider(),
+    getKubeconfigYaml: (c: ClusterNode) => getClusterKubeconfig(c)
+};
+
+export async function activate(context: vscode.ExtensionContext) {
+    const cloudExplorer = await k8s.extension.cloudExplorer.v1;
+
+    if (!cloudExplorer.available) {
+        console.log("Unable to register provider: " + cp.reason);
+        return;
+    }
+
+    cloudExplorer.api.registerCloudProvider(MY_PROVIDER);
+}
+```
+
+Your cluster provider is now ready for testing!
+
+

--- a/docs/extending/cloudexplorer.md
+++ b/docs/extending/cloudexplorer.md
@@ -117,7 +117,7 @@ _TODO: check and document behaviour if users define their own commands on their 
 
 In order to be displayed in Cloud Explorer, a cloud
 provider must be _registered_ with the Kubernetes extension.  This is the responsibility
-of the VS Code extension that hosts the cluster provider.  To do this, the extension must:
+of the VS Code extension that hosts the cloud provider.  To do this, the extension must:
 
 * Activate in response to the `kubernetes.cloudExplorer` view
 * Request the Kubernetes extension's Cloud Provider API
@@ -126,7 +126,7 @@ of the VS Code extension that hosts the cluster provider.  To do this, the exten
 ### Activating the cloud provider extension
 
 Your extension needs to activate in response to the `kubernetes.cloudExplorer`
-commands, so that it can register its cloud provider(s) before the wizard is
+commands, so that it can register its cloud provider(s) before the tree is
 displayed.  To do this, your `package.json` must include the following activation event:
 
 ```json

--- a/docs/extending/cloudexplorer.md
+++ b/docs/extending/cloudexplorer.md
@@ -116,7 +116,14 @@ async function getKubeconfigYaml(cluster: AzureClusterTreeNode): Promise<string 
 Your TreeDataProvider can define contexts on its tree items, enabling you to contribute your
 own commands to those items.  For the most part this works in the normal way, using the
 `contributes.menus.view/item/context` section of `package.json`, and with the command target
-passed to the command handler.  However, the Kubernetes extension encapsulates command targets
+passed to the command handler.  Your tree data provider defines your viewItem contexts in
+its `getTreeItem` implementation, just as in a normal tree view.
+
+You can also attach commands to the top-level cloud entries, using a `when` clause with
+the viewItem context matching `/kubernetes\.cloudExplorer\.cloud\.`_cloudName_`/i`.  Remember to escape the
+backslashes in `package.json`, e.g. `"when": "viewItem =~ /kubernetes\\.cloudExplorer\\.cloud\\.contoso/i`.
+
+To distinguish the built-in and contributed nodes, the Kubernetes extension encapsulates command targets
 in Cloud Explorer, and your command handlers must resolve these to determine what resource
 the command was invoked on.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "0.1.19+preview3",
+    "version": "0.1.19+preview4",
     "preview": true,
     "publisher": "ms-kubernetes-tools",
     "engines": {
@@ -82,6 +82,7 @@
         "onCommand:extension.draftUp",
         "onView:extension.vsKubernetesExplorer",
         "onView:extension.vsKubernetesHelmRepoExplorer",
+        "onView:kubernetes.cloudExplorer",
         "onLanguage:helm",
         "onLanguage:yaml",
         "onFileSystem:k8smsx",
@@ -255,7 +256,12 @@
                 {
                     "id": "extension.vsKubernetesHelmRepoExplorer",
                     "name": "Helm Repos"
+                },
+                {
+                    "id": "kubernetes.cloudExplorer",
+                    "name": "Clouds"
                 }
+
             ]
         },
         "viewsContainers": {
@@ -334,6 +340,11 @@
                 {
                     "command": "extension.vsKubernetesRefreshHelmRepoExplorer",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer",
+                    "group": "navigation"
+                },
+                {
+                    "command": "extension.vsKubernetesRefreshCloudExplorer",
+                    "when": "view == kubernetes.cloudExplorer",
                     "group": "navigation"
                 }
             ],
@@ -528,6 +539,10 @@
                 {
                     "command": "extension.vsKubernetesRefreshHelmRepoExplorer",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer"
+                },
+                {
+                    "command": "extension.vsKubernetesRefreshCloudExplorer",
+                    "when": "view == kubernetes.cloudExplorer"
                 },
                 {
                     "command": "extension.vsKubernetesUseContext",
@@ -928,6 +943,15 @@
                 "title": "Show Dependencies",
                 "description": "List the dependencies of a Helm chart",
                 "category": "Helm"
+            },
+            {
+                "command": "extension.vsKubernetesRefreshCloudExplorer",
+                "title": "Refresh",
+                "category": "Kubernetes",
+                "icon": {
+                    "light": "images/light/refresh.svg",
+                    "dark": "images/dark/refresh.svg"
+                }
             }
         ],
         "keybindings": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "0.1.19+preview4",
+    "version": "0.1.19+preview5",
     "preview": true,
     "publisher": "ms-kubernetes-tools",
     "engines": {
@@ -83,6 +83,8 @@
         "onView:extension.vsKubernetesExplorer",
         "onView:extension.vsKubernetesHelmRepoExplorer",
         "onView:kubernetes.cloudExplorer",
+        "onCommand:kubernetes.cloudExplorer.mergeIntoKubeconfig",
+        "onCommand:kubernetes.cloudExplorer.saveKubeconfig",
         "onLanguage:helm",
         "onLanguage:yaml",
         "onFileSystem:k8smsx",
@@ -513,6 +515,16 @@
                     "command": "extension.helmInspectValues",
                     "group": "0@2",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem =~ /^vsKubernetes\\.((chart)|(chartversion))$/i"
+                },
+                {
+                    "command": "kubernetes.cloudExplorer.mergeIntoKubeconfig",
+                    "group": "7",
+                    "when": "view == kubernetes.cloudExplorer && viewItem =~ /kubernetes\\.providesKubeconfig/i"
+                },
+                {
+                    "command": "kubernetes.cloudExplorer.saveKubeconfig",
+                    "group": "7",
+                    "when": "view == kubernetes.cloudExplorer && viewItem =~ /kubernetes\\.providesKubeconfig/i"
                 }
             ],
             "commandPalette": [
@@ -587,6 +599,14 @@
                 {
                     "command": "extension.helmInspectChart",
                     "when": "view === extension.vsKubernetesHelmRepoExplorer"
+                },
+                {
+                    "command": "kubernetes.cloudExplorer.mergeIntoKubeconfig",
+                    "when": ""
+                },
+                {
+                    "command": "kubernetes.cloudExplorer.saveKubeconfig",
+                    "when": ""
                 }
             ]
         },
@@ -952,6 +972,16 @@
                     "light": "images/light/refresh.svg",
                     "dark": "images/dark/refresh.svg"
                 }
+            },
+            {
+                "command": "kubernetes.cloudExplorer.mergeIntoKubeconfig",
+                "title": "Merge into Kubeconfig",
+                "description": "Merge the cluster's kubeconfig into your existing kubeconfig"
+            },
+            {
+                "command": "kubernetes.cloudExplorer.saveKubeconfig",
+                "title": "Save Kubeconfig",
+                "description": "Save the cluster's kubeconfig as a kubeconfig file"
             }
         ],
         "keybindings": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "0.1.19+preview5",
+    "version": "0.1.19+preview4",
     "preview": true,
     "publisher": "ms-kubernetes-tools",
     "engines": {

--- a/src/api/contract/cloudexplorer/v1.ts
+++ b/src/api/contract/cloudexplorer/v1.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 
 export interface CloudExplorerV1 {
     registerCloudProvider(cloudProvider: CloudExplorerV1.CloudProvider): void;
+    resolveCommandTarget(target?: any): CloudExplorerV1.CloudExplorerNode | undefined;
     refresh(): void;
 }
 
@@ -15,4 +16,17 @@ export namespace CloudExplorerV1 {
         readonly treeDataProvider: vscode.TreeDataProvider<any>;
         getKubeconfigYaml(cluster: any): Promise<string | undefined>;
     }
+
+    export interface CloudExplorerCloudNode {
+        readonly nodeType: 'cloud';
+        readonly cloudName: string;
+    }
+
+    export interface CloudExplorerResourceNode {
+        readonly nodeType: 'resource';
+        readonly cloudName: string;
+        readonly cloudResource: any;
+    }
+
+    export type CloudExplorerNode = CloudExplorerCloudNode | CloudExplorerResourceNode;
 }

--- a/src/api/contract/cloudexplorer/v1.ts
+++ b/src/api/contract/cloudexplorer/v1.ts
@@ -13,5 +13,6 @@ export namespace CloudExplorerV1 {
     export interface CloudProvider {
         readonly cloudName: string;
         readonly treeDataProvider: vscode.TreeDataProvider<any>;
+        getKubeconfigYaml(cluster: any): Promise<string | undefined>;
     }
 }

--- a/src/api/contract/cloudexplorer/v1.ts
+++ b/src/api/contract/cloudexplorer/v1.ts
@@ -1,0 +1,17 @@
+// This module is contractual and should not be changed after release.
+// It should be in sync with vscode-kubernetes-tools-api/ts/explorer-tree/v1.ts
+// at all times.
+
+import * as vscode from 'vscode';
+
+export interface CloudExplorerV1 {
+    registerCloudProvider(cloudProvider: CloudExplorerV1.CloudProvider): void;
+    refresh(): void;
+}
+
+export namespace CloudExplorerV1 {
+    export interface CloudProvider {
+        readonly name: string;
+        readonly treeDataProvider: vscode.TreeDataProvider<any>;
+    }
+}

--- a/src/api/contract/cloudexplorer/v1.ts
+++ b/src/api/contract/cloudexplorer/v1.ts
@@ -11,7 +11,7 @@ export interface CloudExplorerV1 {
 
 export namespace CloudExplorerV1 {
     export interface CloudProvider {
-        readonly name: string;
+        readonly cloudName: string;
         readonly treeDataProvider: vscode.TreeDataProvider<any>;
     }
 }

--- a/src/api/contract/cloudexplorer/v1.ts
+++ b/src/api/contract/cloudexplorer/v1.ts
@@ -1,5 +1,5 @@
 // This module is contractual and should not be changed after release.
-// It should be in sync with vscode-kubernetes-tools-api/ts/explorer-tree/v1.ts
+// It should be in sync with vscode-kubernetes-tools-api/ts/cloudexplorer/v1.ts
 // at all times.
 
 import * as vscode from 'vscode';

--- a/src/api/implementation/apibroker.ts
+++ b/src/api/implementation/apibroker.ts
@@ -3,19 +3,22 @@ import { versionUnknown } from "./apiutils";
 import * as clusterprovider from "./clusterprovider/versions";
 import * as kubectl from "./kubectl/versions";
 import * as helm from "./helm/versions";
-import * as clusterExplorer from "./cluster-explorer/versions";
+import * as clusterexplorer from "./cluster-explorer/versions";
+import * as cloudexplorer from "./cloudexplorer/versions";
 import { ClusterProviderRegistry } from "../../components/clusterprovider/clusterproviderregistry";
 import { Kubectl } from "../../kubectl";
 import { KubernetesExplorer } from "../../explorer";
+import { CloudExplorer } from "../../components/cloudexplorer/cloudexplorer";
 
-export function apiBroker(clusterProviderRegistry: ClusterProviderRegistry, kubectlImpl: Kubectl, explorer: KubernetesExplorer): APIBroker {
+export function apiBroker(clusterProviderRegistry: ClusterProviderRegistry, kubectlImpl: Kubectl, explorer: KubernetesExplorer, cloudExplorer: CloudExplorer): APIBroker {
     return {
         get(component: string, version: string): API<any> {
             switch (component) {
                 case "clusterprovider": return clusterprovider.apiVersion(clusterProviderRegistry, version);
                 case "kubectl": return kubectl.apiVersion(kubectlImpl, version);
                 case "helm": return helm.apiVersion(version);
-                case "clusterexplorer": return clusterExplorer.apiVersion(explorer, version);
+                case "clusterexplorer": return clusterexplorer.apiVersion(explorer, version);
+                case "cloudexplorer": return cloudexplorer.apiVersion(cloudExplorer, version);
                 default: return versionUnknown;
             }
         },

--- a/src/api/implementation/cloudexplorer/v1.ts
+++ b/src/api/implementation/cloudexplorer/v1.ts
@@ -1,5 +1,5 @@
 import { CloudExplorerV1 } from "../../contract/cloudexplorer/v1";
-import { CloudExplorer } from '../../../components/cloudexplorer/cloudexplorer';
+import { CloudExplorer, CloudExplorerTreeNode } from '../../../components/cloudexplorer/cloudexplorer';
 
 export function impl(explorer: CloudExplorer): CloudExplorerV1 {
     return new CloudExplorerV1Impl(explorer);
@@ -10,6 +10,28 @@ class CloudExplorerV1Impl implements CloudExplorerV1 {
 
     registerCloudProvider(cloudProvider: CloudExplorerV1.CloudProvider): void {
         this.explorer.register(cloudProvider);
+    }
+
+    resolveCommandTarget(target?: any): CloudExplorerV1.CloudExplorerNode | undefined {
+        if (!target) {
+            return undefined;
+        }
+
+        const node = target as CloudExplorerTreeNode;
+        if (node.nodeType === 'cloud') {
+            return {
+                nodeType: 'cloud',
+                cloudName: node.provider.cloudName
+            };
+        } else  if (node.nodeType === 'contributed') {
+            return {
+                nodeType: 'resource',
+                cloudName: node.provider.cloudName,
+                cloudResource: node.value
+            };
+        }
+
+        return undefined;
     }
 
     refresh(): void {

--- a/src/api/implementation/cloudexplorer/v1.ts
+++ b/src/api/implementation/cloudexplorer/v1.ts
@@ -1,0 +1,18 @@
+import { CloudExplorerV1 } from "../../contract/cloudexplorer/v1";
+import { CloudExplorer } from '../../../components/cloudexplorer/cloudexplorer';
+
+export function impl(explorer: CloudExplorer): CloudExplorerV1 {
+    return new CloudExplorerV1Impl(explorer);
+}
+
+class CloudExplorerV1Impl implements CloudExplorerV1 {
+    constructor(private readonly explorer: CloudExplorer) {}
+
+    registerCloudProvider(cloudProvider: CloudExplorerV1.CloudProvider): void {
+        this.explorer.register(cloudProvider);
+    }
+
+    refresh(): void {
+        this.explorer.refresh();
+    }
+}

--- a/src/api/implementation/cloudexplorer/versions.ts
+++ b/src/api/implementation/cloudexplorer/versions.ts
@@ -1,0 +1,11 @@
+import * as v1 from "./v1";
+import { API } from "../../contract/api";
+import { versionUnknown, available } from "../apiutils";
+import { CloudExplorer } from "../../../components/cloudexplorer/cloudexplorer";
+
+export function apiVersion(explorer: CloudExplorer, version: string): API<any> {
+    switch (version) {
+        case "v1": return available(v1.impl(explorer));
+        default: return versionUnknown;
+    }
+}

--- a/src/components/cloudexplorer/cloudexplorer.extension.ts
+++ b/src/components/cloudexplorer/cloudexplorer.extension.ts
@@ -3,4 +3,5 @@ import * as vscode from 'vscode';
 export interface CloudExplorerProvider {
     readonly cloudName: string;
     readonly treeDataProvider: vscode.TreeDataProvider<any>;
+    getKubeconfigYaml(cluster: any): Promise<string | undefined>;
 }

--- a/src/components/cloudexplorer/cloudexplorer.extension.ts
+++ b/src/components/cloudexplorer/cloudexplorer.extension.ts
@@ -1,0 +1,6 @@
+import * as vscode from 'vscode';
+
+export interface CloudExplorerProvider {
+    readonly cloudName: string;
+    readonly treeDataProvider: vscode.TreeDataProvider<any>;
+}

--- a/src/components/cloudexplorer/cloudexplorer.ts
+++ b/src/components/cloudexplorer/cloudexplorer.ts
@@ -12,6 +12,7 @@ export class CloudExplorer implements vscode.TreeDataProvider<CloudExplorerTreeN
 
     getTreeItem(element: CloudExplorerTreeNode): vscode.TreeItem | Thenable<vscode.TreeItem> {
         if (element.nodeType === 'cloud') {
+            // TODO: unique context so providers can add commands to them
             return new vscode.TreeItem(element.provider.cloudName, vscode.TreeItemCollapsibleState.Collapsed);
         }
         return element.provider.treeDataProvider.getTreeItem(element.value);
@@ -19,10 +20,11 @@ export class CloudExplorer implements vscode.TreeDataProvider<CloudExplorerTreeN
 
     getChildren(element?: CloudExplorerTreeNode | undefined): vscode.ProviderResult<CloudExplorerTreeNode[]> {
         if (!element) {
+            // TODO: if no providers registered, display a message
             return this.providers.map(asCloudNode);
         }
         if (element.nodeType === 'cloud') {
-            const children = element.provider.treeDataProvider.getChildren(element);
+            const children = element.provider.treeDataProvider.getChildren(undefined);
             return asContributed(children, element.provider);
         } else {
             const children = element.provider.treeDataProvider.getChildren(element.value);

--- a/src/components/cloudexplorer/cloudexplorer.ts
+++ b/src/components/cloudexplorer/cloudexplorer.ts
@@ -40,18 +40,18 @@ export class CloudExplorer implements vscode.TreeDataProvider<CloudExplorerTreeN
     }
 }
 
-interface CloudExplorerCloudNode {
+export interface CloudExplorerCloudNode {
     readonly nodeType: 'cloud';
     readonly provider: CloudExplorerProvider;
 }
 
-interface CloudExplorerContributedNode {
+export interface CloudExplorerContributedNode {
     readonly nodeType: 'contributed';
     readonly provider: CloudExplorerProvider;
     readonly value: any;
 }
 
-type CloudExplorerTreeNode = CloudExplorerCloudNode | CloudExplorerContributedNode;
+export type CloudExplorerTreeNode = CloudExplorerCloudNode | CloudExplorerContributedNode;
 
 function asCloudNode(provider: CloudExplorerProvider): CloudExplorerCloudNode {
     return { nodeType: 'cloud', provider: provider };

--- a/src/components/cloudexplorer/cloudexplorer.ts
+++ b/src/components/cloudexplorer/cloudexplorer.ts
@@ -19,7 +19,7 @@ export class CloudExplorer implements vscode.TreeDataProvider<CloudExplorerTreeN
 
     getChildren(element?: CloudExplorerTreeNode | undefined): vscode.ProviderResult<CloudExplorerTreeNode[]> {
         if (!element) {
-            return this.providers.map((p) => ({ nodeType: 'cloud', provider: p }));
+            return this.providers.map(asCloudNode);
         }
         if (element.nodeType === 'cloud') {
             const children = element.provider.treeDataProvider.getChildren(element);
@@ -53,6 +53,14 @@ interface CloudExplorerContributedNode {
 
 type CloudExplorerTreeNode = CloudExplorerCloudNode | CloudExplorerContributedNode;
 
+function asCloudNode(provider: CloudExplorerProvider): CloudExplorerCloudNode {
+    return { nodeType: 'cloud', provider: provider };
+}
+
 function asContributed(elements: vscode.ProviderResult<any[]>, provider: CloudExplorerProvider): vscode.ProviderResult<CloudExplorerContributedNode[]> {
-    return providerResult.map(elements, (e) => ({ nodeType: 'contributed', provider: provider, value: e }));
+    return providerResult.map(elements, (e) => asContributedNode(e, provider));
+}
+
+function asContributedNode(element: any, provider: CloudExplorerProvider): CloudExplorerContributedNode {
+    return { nodeType: 'contributed', provider: provider, value: element };
 }

--- a/src/components/cloudexplorer/cloudexplorer.ts
+++ b/src/components/cloudexplorer/cloudexplorer.ts
@@ -12,8 +12,9 @@ export class CloudExplorer implements vscode.TreeDataProvider<CloudExplorerTreeN
 
     getTreeItem(element: CloudExplorerTreeNode): vscode.TreeItem | Thenable<vscode.TreeItem> {
         if (element.nodeType === 'cloud') {
-            // TODO: unique context so providers can add commands to them
-            return new vscode.TreeItem(element.provider.cloudName, vscode.TreeItemCollapsibleState.Collapsed);
+            const treeItem = new vscode.TreeItem(element.provider.cloudName, vscode.TreeItemCollapsibleState.Collapsed);
+            treeItem.contextValue = `kubernetes.cloudExplorer.cloud.${element.provider.cloudName}`;
+            return treeItem;
         }
         if (element.nodeType === 'message') {
             return new vscode.TreeItem(element.text, vscode.TreeItemCollapsibleState.Collapsed);

--- a/src/components/cloudexplorer/cloudexplorer.ts
+++ b/src/components/cloudexplorer/cloudexplorer.ts
@@ -1,0 +1,58 @@
+import * as vscode from 'vscode';
+
+import { CloudExplorerProvider } from './cloudexplorer.extension';
+import * as providerResult from '../../utils/providerresult';
+import { sleep } from '../../sleep';
+
+export class CloudExplorer implements vscode.TreeDataProvider<CloudExplorerTreeNode> {
+    private readonly providers = Array.of<CloudExplorerProvider>();
+
+    private onDidChangeTreeDataEmitter: vscode.EventEmitter<CloudExplorerTreeNode | undefined> = new vscode.EventEmitter<CloudExplorerTreeNode | undefined>();
+    readonly onDidChangeTreeData: vscode.Event<CloudExplorerTreeNode | undefined> = this.onDidChangeTreeDataEmitter.event;
+
+    getTreeItem(element: CloudExplorerTreeNode): vscode.TreeItem | Thenable<vscode.TreeItem> {
+        if (element.nodeType === 'cloud') {
+            return new vscode.TreeItem(element.provider.cloudName, vscode.TreeItemCollapsibleState.Collapsed);
+        }
+        return element.provider.treeDataProvider.getTreeItem(element.value);
+    }
+
+    getChildren(element?: CloudExplorerTreeNode | undefined): vscode.ProviderResult<CloudExplorerTreeNode[]> {
+        if (!element) {
+            return this.providers.map((p) => ({ nodeType: 'cloud', provider: p }));
+        }
+        if (element.nodeType === 'cloud') {
+            const children = element.provider.treeDataProvider.getChildren(element);
+            return asContributed(children, element.provider);
+        } else {
+            const children = element.provider.treeDataProvider.getChildren(element.value);
+            return asContributed(children, element.provider);
+        }
+    }
+
+    refresh(): void {
+        this.onDidChangeTreeDataEmitter.fire();
+    }
+
+    register(provider: CloudExplorerProvider): void {
+        this.providers.push(provider);
+        sleep(50).then(() => vscode.commands.executeCommand('extension.vsKubernetesRefreshCloudExplorer'));
+    }
+}
+
+interface CloudExplorerCloudNode {
+    readonly nodeType: 'cloud';
+    readonly provider: CloudExplorerProvider;
+}
+
+interface CloudExplorerContributedNode {
+    readonly nodeType: 'contributed';
+    readonly provider: CloudExplorerProvider;
+    readonly value: any;
+}
+
+type CloudExplorerTreeNode = CloudExplorerCloudNode | CloudExplorerContributedNode;
+
+function asContributed(elements: vscode.ProviderResult<any[]>, provider: CloudExplorerProvider): vscode.ProviderResult<CloudExplorerContributedNode[]> {
+    return providerResult.map(elements, (e) => ({ nodeType: 'contributed', provider: provider, value: e }));
+}

--- a/src/components/cloudexplorer/cloudexplorer.ts
+++ b/src/components/cloudexplorer/cloudexplorer.ts
@@ -17,7 +17,7 @@ export class CloudExplorer implements vscode.TreeDataProvider<CloudExplorerTreeN
             return treeItem;
         }
         if (element.nodeType === 'message') {
-            return new vscode.TreeItem(element.text, vscode.TreeItemCollapsibleState.Collapsed);
+            return new vscode.TreeItem(element.text, vscode.TreeItemCollapsibleState.None);
         }
         return element.provider.treeDataProvider.getTreeItem(element.value);
     }

--- a/src/components/kubectl/kubeconfig.ts
+++ b/src/components/kubectl/kubeconfig.ts
@@ -1,0 +1,66 @@
+import * as vscode from 'vscode';
+import { fs } from '../../fs';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+import { refreshExplorer } from '../clusterprovider/common/explorer';
+import { getActiveKubeconfig } from '../config/config';
+
+interface Named {
+    readonly name: string;
+}
+
+export async function mergeToKubeconfig(newConfigText: string): Promise<void> {
+    const kcfile = kubeconfigPath();
+    if (!(await fs.existsAsync(kcfile))) {
+        vscode.window.showErrorMessage("Couldn't find kubeconfig file to merge into");
+        return;
+    }
+
+    const kubeconfigText = await fs.readTextFile(kcfile);
+    const kubeconfig = yaml.safeLoad(kubeconfigText);
+    const newConfig = yaml.safeLoad(newConfigText);
+
+    for (const section of ['clusters', 'contexts', 'users']) {
+        const existing: Named[] | undefined = kubeconfig[section];
+        const toMerge: Named[] | undefined = newConfig[section];
+        if (!toMerge) {
+            continue;
+        }
+        if (!existing) {
+            kubeconfig[section] = toMerge;
+            continue;
+        }
+        await mergeInto(existing, toMerge);
+    }
+
+    const merged = yaml.safeDump(kubeconfig, { lineWidth: 1000000, noArrayIndent: true });
+
+    const backupFile = kcfile + '.vscode-k8s-tools-backup';
+    if (await fs.existsAsync(backupFile)) {
+        await fs.unlinkAsync(backupFile);
+    }
+    await fs.renameAsync(kcfile, backupFile);
+    await fs.writeTextFile(kcfile, merged);
+
+    await refreshExplorer();
+    await vscode.window.showInformationMessage(`New configuration merged to ${kcfile}`);
+}
+
+async function mergeInto(existing: Named[], toMerge: Named[]): Promise<void> {
+    for (const toMergeEntry of toMerge) {
+        if (existing.some((e) => e.name === toMergeEntry.name)) {
+            // we have CONFLICT and CONFLICT BUILDS CHARACTER
+            await vscode.window.showWarningMessage(`${toMergeEntry} already exists - skipping`);
+            continue;  // TODO: build character
+        }
+        existing.push(toMergeEntry);
+    }
+}
+
+function kubeconfigPath(): string {
+    return getActiveKubeconfig() || getDefaultKubeconfig();
+}
+
+function getDefaultKubeconfig(): string {
+    return path.join((process.env['HOME'] || process.env['USERPROFILE'] || '.'), ".kube", "config");
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,6 +77,7 @@ import { ContainerContainer } from './utils/containercontainer';
 import { APIBroker } from './api/contract/api';
 import { apiBroker } from './api/implementation/apibroker';
 import { sleep } from './sleep';
+import { CloudExplorer } from './components/cloudexplorer/cloudexplorer';
 
 let explainActive = false;
 let swaggerSpecPromise: Promise<explainer.SwaggerModel | undefined> | null = null;
@@ -124,6 +125,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
 
     const treeProvider = explorer.create(kubectl, host);
     const helmRepoTreeProvider = helmRepoExplorer.create(host);
+    const cloudExplorer = new CloudExplorer();
     const resourceDocProvider = new KubernetesResourceVirtualFileSystemProvider(kubectl, host);
     const resourceLinkProvider = new KubernetesResourceLinkProvider();
     const previewProvider = new HelmTemplatePreviewDocumentProvider();
@@ -177,6 +179,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         registerCommand('extension.vsKubernetesCreateCluster', createClusterKubernetes),
         registerCommand('extension.vsKubernetesRefreshExplorer', () => treeProvider.refresh()),
         registerCommand('extension.vsKubernetesRefreshHelmRepoExplorer', () => helmRepoTreeProvider.refresh()),
+        registerCommand('extension.vsKubernetesRefreshCloudExplorer', () => cloudExplorer.refresh()),
         registerCommand('extension.vsKubernetesUseContext', useContextKubernetes),
         registerCommand('extension.vsKubernetesUseKubeconfig', useKubeconfigKubernetes),
         registerCommand('extension.vsKubernetesClusterInfo', clusterInfoKubernetes),
@@ -259,6 +262,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         // Tree data providers
         vscode.window.registerTreeDataProvider('extension.vsKubernetesExplorer', treeProvider),
         vscode.window.registerTreeDataProvider('extension.vsKubernetesHelmRepoExplorer', helmRepoTreeProvider),
+        vscode.window.registerTreeDataProvider('kubernetes.cloudExplorer', cloudExplorer),
 
         // Temporarily loaded resource providers
         vscode.workspace.registerFileSystemProvider(K8S_RESOURCE_SCHEME, resourceDocProvider, { /* TODO: case sensitive? */ }),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -362,7 +362,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
     await registerYamlSchemaSupport();
 
     vscode.workspace.registerTextDocumentContentProvider(configmaps.uriScheme, configMapProvider);
-    return apiBroker(clusterProviderRegistry, kubectl, treeProvider);
+    return apiBroker(clusterProviderRegistry, kubectl, treeProvider, cloudExplorer);
 }
 
 // this method is called when your extension is deactivated

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -7,6 +7,7 @@ export interface FS {
     readFile(filename: string, encoding: string, callback: (err: NodeJS.ErrnoException, data: string) => void): void;
     readTextFile(path: string): Promise<string>;
     readFileAsync(filename: string): Promise<Buffer>;
+    renameAsync(oldName: string, newName: string): Promise<void>;
     readFileSync(filename: string, encoding: string): string;
     readFileToBufferSync(filename: string): Buffer;
     writeFile(filename: string, data: any, callback: (err: NodeJS.ErrnoException) => void): void;
@@ -33,6 +34,9 @@ export const fs: FS = {
           sysfs.readFile(path, null, cb)),
     readFileSync: (filename, encoding) => sysfs.readFileSync(filename, encoding),
     readFileToBufferSync: (filename) => sysfs.readFileSync(filename),
+    renameAsync: promisify(
+        (oldName: string, newName: string, cb: (err: NodeJS.ErrnoException) => void) =>
+            sysfs.rename(oldName, newName, cb)),
     writeFile: (filename, data, callback) => sysfs.writeFile(filename, data, callback),
     writeTextFile: promisify(
         (filename: string, data: string, callback: (err: NodeJS.ErrnoException) => void) => sysfs.writeFile(filename, data, callback)),

--- a/src/utils/providerresult.ts
+++ b/src/utils/providerresult.ts
@@ -16,6 +16,16 @@ export function transform<T>(obj: T | Thenable<T>, f: (t: T) => void): T | Thena
     return obj;
 }
 
+export function map<T, U>(source: vscode.ProviderResult<T[]>, f: (t: T) => U): U[] | vscode.ProviderResult<U[]> {
+    if (isThenable(source)) {
+        return mapThenable(source, f);
+    }
+    if (!source) {
+        return source;
+    }
+    return source.map(f);
+}
+
 function isThenable<T>(r: vscode.ProviderResult<T>): r is Thenable<T | null | undefined> {
     return !!((r as Thenable<T>).then);
 }
@@ -37,4 +47,12 @@ async function appendSyncAsync<T>(first: T[] | null | undefined, ...rest: Thenab
 async function transformThenable<T>(obj: Thenable<T>, f: (t: T) => void): Promise<T> {
     f(await obj);
     return obj;
+}
+
+async function mapThenable<T, U>(obj: Thenable<T[] | null | undefined>, f: (t: T) => U): Promise<U[] | null | undefined> {
+    const sequence = await obj;
+    if (!sequence) {
+        return sequence;
+    }
+    return sequence.map(f);
 }


### PR DESCRIPTION
This provides a host for users to browse cloud resources.  It's pretty generic, though with specific support for adding kubeconfig entries when the resource being viewed is a Kubernetes cluster.

No clouds are built in; instead, the user can install cloud providers from the marketplace and they can register themselves to display content in the tree.