### PR TITLE
vscode.env.openExternal takes a Uri

### DIFF
--- a/src/components/platform/browser.ts
+++ b/src/components/platform/browser.ts
@@ -2,6 +2,10 @@ import * as vscode from 'vscode';
 import opn = require('opn');
 
 export function open(url: string) {
-    const openExternal: any = (<any>vscode.env).openExternal ? (<any>vscode.env).openExternal : opn;
-    openExternal(url);
+    // This check may be redundant now?
+    if ((<any>vscode.env).openExternal) {
+        vscode.env.openExternal(vscode.Uri.parse(url));
+    } else {
+        opn(url);
+    }
 }


### PR DESCRIPTION
I hit a problem where external browser windows weren't opening.  Looking at the docs, it seems like if the `openExternal` API is present then it's failing because we're passing it a string when it wants a `vscode.Uri`.  This PR fixes that.