### PR TITLE
Cluster explorer convenience API

### DIFF
--- a/docs/extending/clusterexplorernodes.md
+++ b/docs/extending/clusterexplorernodes.md
@@ -175,6 +175,42 @@ class LoadBalancerAddressNode implements Node {
 }
 ```
 
+### Built-in node contributors
+
+In some cases you do not need completely custom behaviour - you just want something that works
+like the built-in tree nodes.  You can use the API to create your own _resource folders_
+and _grouping folders_ using the `nodeSources` property.
+
+A _resource folder_ is a folder which displays a single Kubernetes resource type, such as
+a Services or Pods folder.
+
+A _grouping folder_ is a folder which contains other folders, such as the Storage folder
+which contains resource folders for Persistent Volumes, Persistent Volume Claims and
+Storage Classes.
+
+To use a built-in node contributor, call the appropriate `nodeSources` method to create
+a `NodeSource`, then use its `at` method to specify where to attach to the tree.
+For example, to display network policies under the Network folder:
+
+```
+clusterExplorer.api.registerNodeContributor(
+    clusterExplorer.api.nodeSources.resourceFolder("Network Policy", "Network Policies", "NetworkPolicy", "netpol").at("Network")
+);
+```
+
+Or to display a Security grouping folder directly under the context, and display folders for roles and so on under it:
+
+```
+clusterExplorer.api.registerNodeContributor(
+    clusterExplorer.api.nodeSources.groupingFolder("Security", undefined,
+        clusterExplorer.api.nodeSources.resourceFolder("Role", "Roles", "Role", "roles"),
+        clusterExplorer.api.nodeSources.resourceFolder("Role Binding", "Role Bindings", "RoleBinding", "rolebindings"),
+        clusterExplorer.api.nodeSources.resourceFolder("Cluster Role", "Cluster Roles", "ClusterRole", "clusterroles"),
+        clusterExplorer.api.nodeSources.resourceFolder("Cluster Role Binding", "Cluster Role Bindings", "ClusterRoleBinding", "clusterrolebindings"),
+    ).at(undefined);
+);
+```
+
 ## Registering the node contributor
 
 In order to have nodes displayed in the cluster explorer, a node contributor must be _registered_

--- a/docs/extending/clusterexplorernodes.md
+++ b/docs/extending/clusterexplorernodes.md
@@ -195,7 +195,7 @@ The `at` method may specify an existing grouping folder (specified by display na
 
 For example, to display network policies under the Network folder:
 
-```
+```javascript
 clusterExplorer.api.registerNodeContributor(
     clusterExplorer.api.nodeSources.resourceFolder("Network Policy", "Network Policies", "NetworkPolicy", "netpol").at("Network")
 );
@@ -203,7 +203,7 @@ clusterExplorer.api.registerNodeContributor(
 
 Or to display a Security grouping folder directly under the context, and display folders for roles and so on under it:
 
-```
+```javascript
 clusterExplorer.api.registerNodeContributor(
     clusterExplorer.api.nodeSources.groupingFolder("Security", undefined,
         clusterExplorer.api.nodeSources.resourceFolder("Role", "Roles", "Role", "roles"),
@@ -211,6 +211,24 @@ clusterExplorer.api.registerNodeContributor(
         clusterExplorer.api.nodeSources.resourceFolder("Cluster Role", "Cluster Roles", "ClusterRole", "clusterroles"),
         clusterExplorer.api.nodeSources.resourceFolder("Cluster Role Binding", "Cluster Role Bindings", "ClusterRoleBinding", "clusterrolebindings")
 ).at(undefined));
+```
+
+You can also use the `if` method to conditionally display nodes:
+
+```javascript
+clusterExplorer.api.registerNodeContributor(
+    clusterExplorer.api.nodeSources.resourceFolder("Contoso Backup", "Contoso Backups", "ContosoBackup", "contosobackups")
+        .if(isContosoBackupOperatorInstalled)
+        .at("Storage")
+);
+
+async function isContosoBackupOperatorInstalled(): Promise<boolean> {
+    const sr = await kubectl.api.invokeCommand('get crd');
+    if (!sr || sr.code !== 0) {
+        return false;
+    }
+    return sr.stdout.includes("backup.k8soperators.contoso.com");  // Naive check to keep example simple!
+}
 ```
 
 ## Registering the node contributor

--- a/docs/extending/clusterexplorernodes.md
+++ b/docs/extending/clusterexplorernodes.md
@@ -179,7 +179,7 @@ class LoadBalancerAddressNode implements Node {
 
 In some cases you do not need completely custom behaviour - you just want something that works
 like the built-in tree nodes.  You can use the API to create your own _resource folders_
-and _grouping folders_ using the `nodeSources` property.
+and _grouping folders_ using the `nodeSources` property, and display them in the tree.
 
 A _resource folder_ is a folder which displays a single Kubernetes resource type, such as
 a Services or Pods folder.
@@ -190,6 +190,9 @@ Storage Classes.
 
 To use a built-in node contributor, call the appropriate `nodeSources` method to create
 a `NodeSource`, then use its `at` method to specify where to attach to the tree.
+The `at` method may specify an existing grouping folder (specified by display name), or
+`undefined` to appear directly under the context tree node.
+
 For example, to display network policies under the Network folder:
 
 ```
@@ -206,9 +209,8 @@ clusterExplorer.api.registerNodeContributor(
         clusterExplorer.api.nodeSources.resourceFolder("Role", "Roles", "Role", "roles"),
         clusterExplorer.api.nodeSources.resourceFolder("Role Binding", "Role Bindings", "RoleBinding", "rolebindings"),
         clusterExplorer.api.nodeSources.resourceFolder("Cluster Role", "Cluster Roles", "ClusterRole", "clusterroles"),
-        clusterExplorer.api.nodeSources.resourceFolder("Cluster Role Binding", "Cluster Role Bindings", "ClusterRoleBinding", "clusterrolebindings"),
-    ).at(undefined);
-);
+        clusterExplorer.api.nodeSources.resourceFolder("Cluster Role Binding", "Cluster Role Bindings", "ClusterRoleBinding", "clusterrolebindings")
+).at(undefined));
 ```
 
 ## Registering the node contributor

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "0.1.19+preview5",
+    "version": "0.1.19+preview6",
     "preview": true,
     "publisher": "ms-kubernetes-tools",
     "engines": {

--- a/src/api/contract/cluster-explorer/v1.ts
+++ b/src/api/contract/cluster-explorer/v1.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 export interface ClusterExplorerV1 {
     resolveCommandTarget(target?: any): ClusterExplorerV1.ClusterExplorerNode | undefined;
     registerNodeContributor(nodeContributor: ClusterExplorerV1.NodeContributor): void;
-    readonly nodeContributors: ClusterExplorerV1.NodeContributors;
+    readonly nodeSources: ClusterExplorerV1.NodeSources;
     registerNodeUICustomizer(nodeUICustomizer: ClusterExplorerV1.NodeUICustomizer): void;
     refresh(): void;
 }
@@ -94,13 +94,13 @@ export namespace ClusterExplorerV1 {
         readonly abbreviation: string;
     }
 
-    export interface NodeSet {
+    export interface NodeSource {
         at(parentFolder: string | undefined): NodeContributor;
         nodes(): Promise<Node[]>;
     }
 
-    export interface NodeContributors {
-        resourceFolder(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string): NodeSet;
-        groupingFolder(displayName: string, contextValue: string | undefined, ...children: NodeSet[]): NodeSet;
+    export interface NodeSources {
+        resourceFolder(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string): NodeSource;
+        groupingFolder(displayName: string, contextValue: string | undefined, ...children: NodeSource[]): NodeSource;
     }
 }

--- a/src/api/contract/cluster-explorer/v1.ts
+++ b/src/api/contract/cluster-explorer/v1.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 export interface ClusterExplorerV1 {
     resolveCommandTarget(target?: any): ClusterExplorerV1.ClusterExplorerNode | undefined;
     registerNodeContributor(nodeContributor: ClusterExplorerV1.NodeContributor): void;
+    readonly nodeContributors: ClusterExplorerV1.NodeContributors;
     registerNodeUICustomizer(nodeUICustomizer: ClusterExplorerV1.NodeUICustomizer): void;
     refresh(): void;
 }
@@ -91,5 +92,10 @@ export namespace ClusterExplorerV1 {
     export interface ResourceKind {
         readonly manifestKind: string;
         readonly abbreviation: string;
+    }
+
+    export interface NodeContributors {
+        resourceFolder(parentFolder: string | undefined, displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string): NodeContributor;
+        groupingFolder(parentFolder: string | undefined, displayName: string, contextValue: string | undefined, children: () => Promise<Node[]>): NodeContributor;
     }
 }

--- a/src/api/contract/cluster-explorer/v1.ts
+++ b/src/api/contract/cluster-explorer/v1.ts
@@ -96,6 +96,7 @@ export namespace ClusterExplorerV1 {
 
     export interface NodeSource {
         at(parentFolder: string | undefined): NodeContributor;
+        if(condition: () => boolean | Thenable<boolean>): NodeSource;
         nodes(): Promise<Node[]>;
     }
 

--- a/src/api/contract/cluster-explorer/v1.ts
+++ b/src/api/contract/cluster-explorer/v1.ts
@@ -94,8 +94,13 @@ export namespace ClusterExplorerV1 {
         readonly abbreviation: string;
     }
 
+    export interface NodeSet {
+        at(parentFolder: string | undefined): NodeContributor;
+        nodes(): Promise<Node[]>;
+    }
+
     export interface NodeContributors {
-        resourceFolder(parentFolder: string | undefined, displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string): NodeContributor;
-        groupingFolder(parentFolder: string | undefined, displayName: string, contextValue: string | undefined, children: () => Promise<Node[]>): NodeContributor;
+        resourceFolder(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string): NodeSet;
+        groupingFolder(displayName: string, contextValue: string | undefined, ...children: NodeSet[]): NodeSet;
     }
 }

--- a/src/api/implementation/cluster-explorer/v1.ts
+++ b/src/api/implementation/cluster-explorer/v1.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 
 import { ClusterExplorerV1 } from "../../contract/cluster-explorer/v1";
 import { ExplorerExtender, ExplorerUICustomizer } from "../../../explorer.extension";
-import { KUBERNETES_EXPLORER_NODE_CATEGORY, KubernetesObject, ResourceFolder, ResourceNode, KubernetesExplorer, CustomResourceFolderNodeSource, CustomGroupingFolderNodeSource, NodeSetImpl } from "../../../explorer";
+import { KUBERNETES_EXPLORER_NODE_CATEGORY, KubernetesObject, ResourceFolder, ResourceNode, KubernetesExplorer, CustomResourceFolderNodeSource, CustomGroupingFolderNodeSource, NodeSourceImpl } from "../../../explorer";
 import { Kubectl } from "../../../kubectl";
 import { Host } from "../../../host";
 import { KubectlContext } from '../../../kubectlUtils';
@@ -37,7 +37,7 @@ class ClusterExplorerV1Impl implements ClusterExplorerV1 {
         this.explorer.registerUICustomiser(adapted);
     }
 
-    get nodeContributors(): ClusterExplorerV1.NodeContributors {
+    get nodeSources(): ClusterExplorerV1.NodeSources {
         return {
             resourceFolder: resourceFolderContributor,
             groupingFolder: groupingFolderContributor
@@ -130,28 +130,28 @@ class ContributedNode implements KubernetesObject {
     }
 }
 
-function resourceFolderContributor(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string): ClusterExplorerV1.NodeSet {
+function resourceFolderContributor(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string): ClusterExplorerV1.NodeSource {
     const nodeSource = new CustomResourceFolderNodeSource(new ResourceKind(displayName, pluralDisplayName, manifestKind, abbreviation));
-    return apiNodeSetOf(nodeSource);
+    return apiNodeSourceOf(nodeSource);
 }
 
-function groupingFolderContributor(displayName: string, contextValue: string | undefined, ...children: ClusterExplorerV1.NodeSet[]): ClusterExplorerV1.NodeSet {
-    const nodeSource = new CustomGroupingFolderNodeSource(displayName, contextValue, children.map(internalNodeSetOf));
-    return apiNodeSetOf(nodeSource);
+function groupingFolderContributor(displayName: string, contextValue: string | undefined, ...children: ClusterExplorerV1.NodeSource[]): ClusterExplorerV1.NodeSource {
+    const nodeSource = new CustomGroupingFolderNodeSource(displayName, contextValue, children.map(internalNodeSourceOf));
+    return apiNodeSourceOf(nodeSource);
 }
 
 const BUILT_IN_CONTRIBUTOR_KIND_TAG = 'nativeextender-4a4bc473-a8c6-4b1e-973f-22327f99cea8';
 const BUILT_IN_NODE_KIND_TAG = 'nativek8sobject-5be3c876-3683-44cd-a400-7763d2c4302a';
-const BUILT_IN_NODE_SET_KIND_TAG = 'nativenodeset-aa0c30a9-bf1d-444a-a147-7823edcc7c04';
+const BUILT_IN_NODE_SOURCE_KIND_TAG = 'nativenodesource-aa0c30a9-bf1d-444a-a147-7823edcc7c04';
 
 interface BuiltInNodeContributor {
     readonly [BUILT_IN_CONTRIBUTOR_KIND_TAG]: true;
     readonly impl: ExplorerExtender<KubernetesObject>;
 }
 
-interface BuiltInNodeSet {
-    readonly [BUILT_IN_NODE_SET_KIND_TAG]: true;
-    readonly impl: NodeSetImpl;
+interface BuiltInNodeSource {
+    readonly [BUILT_IN_NODE_SOURCE_KIND_TAG]: true;
+    readonly impl: NodeSourceImpl;
 }
 
 interface BuiltInNode {
@@ -159,18 +159,18 @@ interface BuiltInNode {
     readonly impl: KubernetesObject;
 }
 
-function apiNodeSetOf(nodeSet: NodeSetImpl): ClusterExplorerV1.NodeSet & BuiltInNodeSet {
+function apiNodeSourceOf(nodeSet: NodeSourceImpl): ClusterExplorerV1.NodeSource & BuiltInNodeSource {
     return {
         at(parent: string | undefined) { const ee = nodeSet.at(parent); return apiNodeContributorOf(ee); },
         async nodes() { return (await nodeSet.nodes()).map(apiNodeOf); },
-        [BUILT_IN_NODE_SET_KIND_TAG]: true,
+        [BUILT_IN_NODE_SOURCE_KIND_TAG]: true,
         impl: nodeSet
     };
 }
 
-function internalNodeSetOf(nodeSet: ClusterExplorerV1.NodeSet): NodeSetImpl {
-    if ((<any>nodeSet)[BUILT_IN_NODE_SET_KIND_TAG]) {
-        return (nodeSet as unknown as BuiltInNodeSet).impl;
+function internalNodeSourceOf(nodeSet: ClusterExplorerV1.NodeSource): NodeSourceImpl {
+    if ((<any>nodeSet)[BUILT_IN_NODE_SOURCE_KIND_TAG]) {
+        return (nodeSet as unknown as BuiltInNodeSource).impl;
     }
     return {
         at(parent: string | undefined) { return internalNodeContributorOf(nodeSet.at(parent)); },

--- a/src/api/implementation/cluster-explorer/v1.ts
+++ b/src/api/implementation/cluster-explorer/v1.ts
@@ -162,6 +162,7 @@ interface BuiltInNode {
 function apiNodeSourceOf(nodeSet: NodeSourceImpl): ClusterExplorerV1.NodeSource & BuiltInNodeSource {
     return {
         at(parent: string | undefined) { const ee = nodeSet.at(parent); return apiNodeContributorOf(ee); },
+        if(condition: () => boolean | Thenable<boolean>) { return apiNodeSourceOf(nodeSet.if(condition)); },
         async nodes() { return (await nodeSet.nodes()).map(apiNodeOf); },
         [BUILT_IN_NODE_SOURCE_KIND_TAG]: true,
         impl: nodeSet
@@ -174,6 +175,7 @@ function internalNodeSourceOf(nodeSet: ClusterExplorerV1.NodeSource): NodeSource
     }
     return {
         at(parent: string | undefined) { return internalNodeContributorOf(nodeSet.at(parent)); },
+        if(condition: () => boolean | Thenable<boolean>) { return internalNodeSourceOf(nodeSet).if(condition); },
         async nodes() { return (await nodeSet.nodes()).map(internalNodeOf); }
     };
 }

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -679,9 +679,9 @@ export class ContributedNodeSourceExtender implements ExplorerExtender<Kubernete
             return false;
         }
         if (this.under) {
-            return parent.nodeType === 'folder.grouping' && parent.id === this.under;  // TODO: needs to be display name really
+            return parent.nodeType === 'folder.grouping' && (parent as KubernetesFolder).displayName === this.under;
         }
-        return parent.nodeType === 'context' /* && parent.isActive */;
+        return parent.nodeType === 'context' && (parent as KubernetesContextNode).metadata.active;
     }
 
     getChildren(_parent?: KubernetesObject | undefined): Promise<KubernetesObject[]> {


### PR DESCRIPTION
Per preview feedback, adds APIs to the ClusterExplorerV1 interface/namespace for defining resource folders and grouping folders without implementing the whole thing yourself.

Samples:

Adding Network Policies to the Network folder:

```
clusterExplorer.api.registerNodeContributor(
    clusterExplorer.api.nodeSources.resourceFolder("Network Policy", "Network Policies", "NetworkPolicy", "netpol").at("Network")
);
```

Adding a Security folder to the context node:

```
clusterExplorer.api.registerNodeContributor(
    clusterExplorer.api.nodeSources.groupingFolder("Security", undefined,
        clusterExplorer.api.nodeSources.resourceFolder("Role", "Roles", "Role", "roles"),
        clusterExplorer.api.nodeSources.resourceFolder("Role Binding", "Role Bindings", "RoleBinding", "rolebindings"),
        clusterExplorer.api.nodeSources.resourceFolder("Cluster Role", "Cluster Roles", "ClusterRole", "clusterroles"),
        clusterExplorer.api.nodeSources.resourceFolder("Cluster Role Binding", "Cluster Role Bindings", "ClusterRoleBinding", "clusterrolebindings")
).at(undefined));
```