### PR TITLE
Explorer link to cloud providers on marketplace

### DIFF
--- a/docs/extending/cloudexplorer.md
+++ b/docs/extending/cloudexplorer.md
@@ -25,6 +25,7 @@ your cloud providers and their hosting extension need to do; the rest of this ar
 |----------------------|----------------------------------------------------------------------|
 | Your extension       | Activate when Cloud Explorer is displayed                            |
 |                      | Register cloud providers with Kubernetes extension                   |
+|                      | Tag itself as a cloud provider in the Visual Studio Marketplace      |
 | Cloud provider       | Implement the cloud provider interface                               |
 |                      | Provide metadata for the Cloud Explorer top level                    |
 |                      | Display cloud resources in tree format                               |
@@ -229,6 +230,22 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 ```
 
-Your cluster provider is now ready for testing!
+Your cloud provider is now ready for testing!
 
+## Tagging your cloud provider extension
 
+The Cloud Explorer has a link for users to find cloud providers on the Visual Studio
+Marketplace.  If you'd like to appear in this link, please tag your extension
+with the keyword `kubernetes-extension-cloud-provider` in `package.json`.
+For example:
+
+```json
+{
+    "keywords": [
+        "kubernetes",
+        "contoso",
+        "megafloof",
+        "kubernetes-extension-cloud-provider"
+    ]
+}
+```

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
         "onView:kubernetes.cloudExplorer",
         "onCommand:kubernetes.cloudExplorer.mergeIntoKubeconfig",
         "onCommand:kubernetes.cloudExplorer.saveKubeconfig",
+        "onCommand:kubernetes.cloudExplorer.findProviders",
         "onLanguage:helm",
         "onLanguage:yaml",
         "onFileSystem:k8smsx",
@@ -348,6 +349,11 @@
                     "command": "extension.vsKubernetesRefreshCloudExplorer",
                     "when": "view == kubernetes.cloudExplorer",
                     "group": "navigation"
+                },
+                {
+                    "command": "kubernetes.cloudExplorer.findProviders",
+                    "when": "view == kubernetes.cloudExplorer",
+                    "group": "1"
                 }
             ],
             "view/item/context": [
@@ -525,6 +531,11 @@
                     "command": "kubernetes.cloudExplorer.saveKubeconfig",
                     "group": "7",
                     "when": "view == kubernetes.cloudExplorer && viewItem =~ /kubernetes\\.providesKubeconfig/i"
+                },
+                {
+                    "command": "kubernetes.cloudExplorer.findProviders",
+                    "when": "view == kubernetes.cloudExplorer && viewItem == kubernetes.noProviders",
+                    "group": "1"
                 }
             ],
             "commandPalette": [
@@ -982,6 +993,11 @@
                 "command": "kubernetes.cloudExplorer.saveKubeconfig",
                 "title": "Save Kubeconfig",
                 "description": "Save the cluster's kubeconfig as a kubeconfig file"
+            },
+            {
+                "command": "kubernetes.cloudExplorer.findProviders",
+                "title": "Find Cloud Providers on Marketplace",
+                "description": "Find extensions that add clouds to the Cloud Explorer"
             }
         ],
         "keybindings": [

--- a/src/components/cloudexplorer/cloudexplorer.ts
+++ b/src/components/cloudexplorer/cloudexplorer.ts
@@ -17,7 +17,11 @@ export class CloudExplorer implements vscode.TreeDataProvider<CloudExplorerTreeN
             return treeItem;
         }
         if (element.nodeType === 'message') {
-            return new vscode.TreeItem(element.text, vscode.TreeItemCollapsibleState.None);
+            const treeItem = new vscode.TreeItem(element.text, vscode.TreeItemCollapsibleState.None);
+            if (element.reason === 'no-providers') {
+                treeItem.command = { title: 'Find Cloud Providers on Marketplace', command: 'kubernetes.cloudExplorer.findProviders' };
+            }
+            return treeItem;
         }
         return element.provider.treeDataProvider.getTreeItem(element.value);
     }
@@ -25,7 +29,7 @@ export class CloudExplorer implements vscode.TreeDataProvider<CloudExplorerTreeN
     getChildren(element?: CloudExplorerTreeNode | undefined): vscode.ProviderResult<CloudExplorerTreeNode[]> {
         if (!element) {
             if (this.providers.length === 0) {
-                return [ { nodeType: 'message', text: 'Install a cloud provider from the marketplace to get started' } ];
+                return [ { nodeType: 'message', reason: 'no-providers', text: 'No clouds registered. Click here to install a cloud provider from the marketplace' } ];
             }
             return this.providers.map(asCloudNode);
         }
@@ -64,6 +68,7 @@ export interface CloudExplorerContributedNode {
 export interface CloudExplorerMessageNode {
     readonly nodeType: 'message';
     readonly text: string;
+    readonly reason: 'no-providers';
 }
 
 export type CloudExplorerTreeNode = CloudExplorerCloudNode | CloudExplorerContributedNode | CloudExplorerMessageNode;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,6 +53,7 @@ import { DebugSession } from './debug/debugSession';
 import { suggestedShellForContainer } from './utils/container-shell';
 import { getDebugProviderOfType, getSupportedDebuggerTypes } from './debug/providerRegistry';
 import * as config from './components/config/config';
+import * as browser from './components/platform/browser';
 
 import { registerYamlSchemaSupport } from './yaml-support/yaml-schema';
 import * as clusterproviderregistry from './components/clusterprovider/clusterproviderregistry';
@@ -233,6 +234,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         // Commands - API
         registerCommand('kubernetes.cloudExplorer.mergeIntoKubeconfig', kubernetesMergeIntoKubeconfig),
         registerCommand('kubernetes.cloudExplorer.saveKubeconfig', kubernetesSaveKubeconfig),
+        registerCommand('kubernetes.cloudExplorer.findProviders', kubernetesFindCloudProviders),
 
         // Commands - special no-op command for debouncing concurrent activations
         vscode.commands.registerCommand('extension.vsKubernetesDebounceActivation', () => {}),
@@ -2150,4 +2152,9 @@ async function kubeconfigFromTreeNode(target?: CloudExplorerTreeNode): Promise<s
     }
     const kubeconfigYaml = await target.provider.getKubeconfigYaml(target.value);
     return kubeconfigYaml;
+}
+
+function kubernetesFindCloudProviders() {
+    const searchUrl = 'https://marketplace.visualstudio.com/search?term=kubernetes-extension-cloud-provider&target=VSCode&category=All%20categories&sortBy=Relevance';
+    browser.open(searchUrl);
 }


### PR DESCRIPTION
Fixes #524.

Added a command which users can get to by:

* Clicking the 'no clouds registered' message
* Dropping down the `...` thingy on the Cloud Explorer title bar
* Command palette as usual

This will launch a search for the keyword `kubernetes-extension-cloud-provider` which is specified in the documentation for writing a cloud provider.