### PR TITLE
Display active port forwards in the status bar

### DIFF
--- a/docs/extending/kubectl.md
+++ b/docs/extending/kubectl.md
@@ -72,3 +72,42 @@ try {
     session.dispose();
 }
 ```
+
+### Port forwarding status bar indicator
+
+By default, port forwarding occurs behind the scenes, and it is up to your extension
+to determine when to end the forwarding, either programmatically or by displaying its
+own UI.  If you would like to give the user an indication
+that port forwarding is happening, and allow them to end the forwarding (and thus
+end the `kubectl` process), you can ask for your port-forwarding session to be shown
+in the status bar by passing an options object to `portForward`.  The options object
+should look like this:
+
+```javascript
+{
+    showInUI: {
+        location: 'status-bar'
+    }
+}
+```
+
+You can also provide an optional `description`, which is displayed to help the user
+understand what the port-forward is used for and to distinguish it from other port
+forwarding sessions.  This is recommended as the user may otherwise have to guess
+which sessions they still need and which it is safe to terminate.
+
+Additionally, you can provide an `onCancel` property, which is a function to be
+called back if the user terminates the port forwarding via the UI.  You can
+use this to present UI, clear state associated with the port-forward, etc.
+
+A fully populated options object might look like this:
+
+```javascript
+{
+    showInUI: {
+        location: 'status-bar',
+        description: 'Connection to the linkerd dashboard',
+        onCancel: () => { linkerd.isDashboardPortFowarded(false); }
+    }
+}
+```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "0.1.19+preview6",
+    "version": "0.1.19+preview7",
     "preview": true,
     "publisher": "ms-kubernetes-tools",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
         "onCommand:kubernetes.cloudExplorer.mergeIntoKubeconfig",
         "onCommand:kubernetes.cloudExplorer.saveKubeconfig",
         "onCommand:kubernetes.cloudExplorer.findProviders",
+        "onCommand:kubernetes.portForwarding.showSessions",
         "onLanguage:helm",
         "onLanguage:yaml",
         "onFileSystem:k8smsx",
@@ -624,6 +625,10 @@
                 {
                     "command": "kubernetes.cloudExplorer.saveKubeconfig",
                     "when": ""
+                },
+                {
+                    "command": "kubernetes.portForwarding.showSessions",
+                    "when": ""
                 }
             ]
         },
@@ -1004,6 +1009,11 @@
                 "command": "kubernetes.cloudExplorer.findProviders",
                 "title": "Find Cloud Providers on Marketplace",
                 "description": "Find extensions that add clouds to the Cloud Explorer"
+            },
+            {
+                "command": "kubernetes.portForwarding.showSessions",
+                "title": "Show Port Forwarding Sessions",
+                "category": "Kubernetes"
             }
         ],
         "keybindings": [

--- a/src/api/contract/kubectl/v1.ts
+++ b/src/api/contract/kubectl/v1.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 
 export interface KubectlV1 {
     invokeCommand(command: string): Promise<KubectlV1.ShellResult | undefined>;
-    portForward(podName: string, podNamespace: string | undefined, localPort: number, remotePort: number): Promise<vscode.Disposable | undefined>;
+    portForward(podName: string, podNamespace: string | undefined, localPort: number, remotePort: number, options?: KubectlV1.PortForwardOptions): Promise<vscode.Disposable | undefined>;
 }
 
 export namespace KubectlV1 {
@@ -15,4 +15,20 @@ export namespace KubectlV1 {
         readonly stdout: string;
         readonly stderr: string;
     }
+
+    export interface PortForwardOptions {
+        readonly showInUI?: PortForwardUIOptions;
+    }
+
+    export interface PortForwardNoUIOptions {
+        readonly location: 'none';
+    }
+
+    export interface PortForwardStatusBarUIOptions {
+        readonly location: 'status-bar';
+        readonly description?: string;
+        readonly onCancel?: () => void;
+    }
+
+    export type PortForwardUIOptions = PortForwardNoUIOptions | PortForwardStatusBarUIOptions;
 }

--- a/src/api/implementation/apibroker.ts
+++ b/src/api/implementation/apibroker.ts
@@ -9,13 +9,14 @@ import { ClusterProviderRegistry } from "../../components/clusterprovider/cluste
 import { Kubectl } from "../../kubectl";
 import { KubernetesExplorer } from "../../explorer";
 import { CloudExplorer } from "../../components/cloudexplorer/cloudexplorer";
+import { PortForwardStatusBarManager } from "../../components/kubectl/port-forward-ui";
 
-export function apiBroker(clusterProviderRegistry: ClusterProviderRegistry, kubectlImpl: Kubectl, explorer: KubernetesExplorer, cloudExplorer: CloudExplorer): APIBroker {
+export function apiBroker(clusterProviderRegistry: ClusterProviderRegistry, kubectlImpl: Kubectl, portForwardStatusBarManager: PortForwardStatusBarManager, explorer: KubernetesExplorer, cloudExplorer: CloudExplorer): APIBroker {
     return {
         get(component: string, version: string): API<any> {
             switch (component) {
                 case "clusterprovider": return clusterprovider.apiVersion(clusterProviderRegistry, version);
-                case "kubectl": return kubectl.apiVersion(kubectlImpl, version);
+                case "kubectl": return kubectl.apiVersion(kubectlImpl, portForwardStatusBarManager, version);
                 case "helm": return helm.apiVersion(version);
                 case "clusterexplorer": return clusterexplorer.apiVersion(explorer, version);
                 case "cloudexplorer": return cloudexplorer.apiVersion(cloudExplorer, version);

--- a/src/api/implementation/kubectl/versions.ts
+++ b/src/api/implementation/kubectl/versions.ts
@@ -2,10 +2,11 @@ import * as v1 from "./v1";
 import { API } from "../../contract/api";
 import { versionUnknown, available } from "../apiutils";
 import { Kubectl } from "../../../kubectl";
+import { PortForwardStatusBarManager } from "../../../components/kubectl/port-forward-ui";
 
-export function apiVersion(kubectl: Kubectl, version: string): API<any> {
+export function apiVersion(kubectl: Kubectl, portForwardStatusBarManager: PortForwardStatusBarManager, version: string): API<any> {
     switch (version) {
-        case "v1": return available(v1.impl(kubectl));
+        case "v1": return available(v1.impl(kubectl, portForwardStatusBarManager));
         default: return versionUnknown;
     }
 }

--- a/src/components/kubectl/port-forward-ui.ts
+++ b/src/components/kubectl/port-forward-ui.ts
@@ -1,0 +1,55 @@
+import * as vscode from 'vscode';
+
+import { Dictionary } from "../../utils/dictionary";
+
+export interface PortForwardSession {
+    readonly podName: string;
+    readonly podNamespace: string | undefined;
+    readonly localPort: number;
+    readonly remotePort: number;
+    readonly description: string | undefined;
+    readonly onCancel?: () => void;
+}
+
+export class PortForwardStatusBarManager {
+    private readonly sessions = Dictionary.of<PortForwardSession>();
+    private constructor(private readonly statusBarItem: vscode.StatusBarItem) {}
+
+    static init(statusBarItem: vscode.StatusBarItem): PortForwardStatusBarManager {
+        const manager = new PortForwardStatusBarManager(statusBarItem);
+        manager.refreshPortForwardStatus();
+        return manager;
+    }
+
+    registerPortForward(session: PortForwardSession): string {
+        const lookupKey = keyOf(session);
+        this.sessions[lookupKey] = session;
+        this.refreshPortForwardStatus();
+        return lookupKey;
+    }
+
+    unregisterPortForward(cookie: string): void {
+        const session = this.sessions[cookie];
+        if (session.onCancel) {
+            session.onCancel();
+        }
+        delete this.sessions[cookie];
+        this.refreshPortForwardStatus();
+    }
+
+    private refreshPortForwardStatus() {
+        const sessionCount = Object.keys(this.sessions).length;
+        if (sessionCount > 0) {
+            this.statusBarItem.text = 'Kubectl Port Forwarding';
+            this.statusBarItem.tooltip = `kubectl is currently running ${sessionCount} port forwarding sessions in the background.  Click to view and terminate.`;
+            this.statusBarItem.command = 'kubernetes.portForwarding.showSessions';
+            this.statusBarItem.show();
+        } else {
+            this.statusBarItem.hide();
+        }
+    }
+}
+
+function keyOf(session: PortForwardSession): string {
+    return `PFSESSIONKEY/${session.podName}/${session.podNamespace || ''}/${session.localPort}`;
+}

--- a/src/components/kubectl/port-forward-ui.ts
+++ b/src/components/kubectl/port-forward-ui.ts
@@ -65,7 +65,7 @@ export class PortForwardStatusBarManager {
         const sessionCount = Object.keys(this.sessions).length;
         if (sessionCount > 0) {
             this.statusBarItem.text = 'Kubectl Port Forwarding';
-            this.statusBarItem.tooltip = `kubectl is currently running ${sessionCount} port forwarding sessions in the background.  Click to view and terminate.`;
+            this.statusBarItem.tooltip = `kubectl is currently running ${sessionCount} port forwarding session(s) in the background.  Click to view and terminate.`;
             this.statusBarItem.command = 'kubernetes.portForwarding.showSessions';
             this.statusBarItem.show();
         } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -211,7 +211,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         registerCommand('extension.vsKubernetesShowEvents', (explorerNode: explorer.ResourceNode) => { getEvents(kubectl, EventDisplayMode.Show, explorerNode); }),
         registerCommand('extension.vsKubernetesFollowEvents', (explorerNode: explorer.ResourceNode) => { getEvents(kubectl, EventDisplayMode.Follow, explorerNode); }),
         registerCommand('extension.vsKubernetesCronJobRunNow', cronJobRunNow),
-        registerCommand('kubernetes.portForwarding.showSessions', showPortForwardingSessions),
+        registerCommand('kubernetes.portForwarding.showSessions', () => portForwardStatusBarManager.showSessions()),
         // Commands - Helm
         registerCommand('extension.helmVersion', helmexec.helmVersion),
         registerCommand('extension.helmTemplate', helmexec.helmTemplate),
@@ -2165,8 +2165,4 @@ async function kubeconfigFromTreeNode(target?: CloudExplorerTreeNode): Promise<s
 function kubernetesFindCloudProviders() {
     const searchUrl = 'https://marketplace.visualstudio.com/search?term=kubernetes-extension-cloud-provider&target=VSCode&category=All%20categories&sortBy=Relevance';
     browser.open(searchUrl);
-}
-
-async function showPortForwardingSessions(): Promise<void> {
-    await vscode.window.showInformationMessage("SHOWING ALL THE SESSIONS WOO");
 }


### PR DESCRIPTION
Currently only for port forwards done via the API.  But eventually we should consolidate all behind-the-scenes port forwarding.

~~TODO: docs.~~ <-- Done