### PR TITLE
Languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1042,6 +1042,12 @@
                     "**/templates/**/*.tpl"
                 ],
                 "configuration": "./language-configuration.json"
+            },
+            {
+                "id": "ignore",
+                "filenames": [
+                    ".helmignore"
+                ]
             }
         ],
         "grammars": [

--- a/package.json
+++ b/package.json
@@ -1048,6 +1048,12 @@
                 "filenames": [
                     ".helmignore"
                 ]
+            },
+            {
+                "id": "yaml",
+                "filenames": [
+                    "requirements.lock"
+                ]
             }
         ],
         "grammars": [


### PR DESCRIPTION
The `ignore` language id is also used for many other ignore files.

Requirements is written in YAML format.