### PR TITLE
Upgrade telemetry package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
         "@types/minimatch": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+            "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0="
         },
         "@types/mkdirp": {
             "version": "0.5.2",
@@ -212,7 +212,7 @@
         "@types/spdy": {
             "version": "3.4.4",
             "resolved": "https://registry.npmjs.org/@types/spdy/-/spdy-3.4.4.tgz",
-            "integrity": "sha512-N9LBlbVRRYq6HgYpPkqQc3a9HJ/iEtVZToW6xlTtJiMhmRJ7jJdV7TaZQJw/Ve/1ePUsQiCTDc4JMuzzag94GA==",
+            "integrity": "sha1-MoL9StjEYDqkn3AX3VIKCKNFsrw=",
             "requires": {
                 "@types/node": "*"
             },
@@ -358,9 +358,14 @@
             }
         },
         "applicationinsights": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-0.18.0.tgz",
-            "integrity": "sha1-Fi67SKODQIvE3kTbMrQXMH9Fu8E="
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.8.tgz",
+            "integrity": "sha512-KzOOGdphOS/lXWMFZe5440LUdFbrLpMvh2SaRxn7BmiI550KAoSb2gIhiq6kJZ9Ir3AxRRztjhzif+e5P5IXIg==",
+            "requires": {
+                "diagnostic-channel": "0.2.0",
+                "diagnostic-channel-publishers": "0.2.1",
+                "zone.js": "0.7.6"
+            }
         },
         "arch": {
             "version": "2.1.1",
@@ -399,7 +404,7 @@
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
             "dev": true
         },
         "arr-map": {
@@ -664,7 +669,7 @@
         "base": {
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
             "dev": true,
             "requires": {
                 "cache-base": "^1.0.1",
@@ -742,7 +747,7 @@
         },
         "bl": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+            "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
             "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
             "requires": {
                 "readable-stream": "^2.3.5",
@@ -884,7 +889,7 @@
         "cache-base": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
             "dev": true,
             "requires": {
                 "collection-visit": "^1.0.0",
@@ -912,7 +917,7 @@
         "caw": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
-            "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
+            "integrity": "sha1-bDygcfwZRyCIPC3F2psHS/x+npU=",
             "requires": {
                 "get-proxy": "^2.0.0",
                 "isurl": "^1.0.0-alpha5",
@@ -972,7 +977,7 @@
         "class-utils": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
             "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
@@ -995,7 +1000,7 @@
         "clipboardy": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
-            "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
+            "integrity": "sha1-BSY2G/eHJMHyC+JI1CjjZUM8B+8=",
             "requires": {
                 "arch": "^2.1.0",
                 "execa": "^0.8.0"
@@ -1232,7 +1237,7 @@
         },
         "d": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
@@ -1307,7 +1312,7 @@
         "decompress-tar": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-            "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+            "integrity": "sha1-cYy9P8sWIJcW5womuE57pFkuWvE=",
             "requires": {
                 "file-type": "^5.2.0",
                 "is-stream": "^1.1.0",
@@ -1317,7 +1322,7 @@
         "decompress-tarbz2": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-            "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+            "integrity": "sha1-MIKluIDqQEOBY0nzeLVsUWvho5s=",
             "requires": {
                 "decompress-tar": "^4.1.0",
                 "file-type": "^6.1.0",
@@ -1329,14 +1334,14 @@
                 "file-type": {
                     "version": "6.2.0",
                     "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-                    "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
+                    "integrity": "sha1-5QzXXTVv/tTjBtxPW89Sp5kDqRk="
                 }
             }
         },
         "decompress-targz": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-            "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+            "integrity": "sha1-wJvDXE0R894J8tLaU+neI+fOHu4=",
             "requires": {
                 "decompress-tar": "^4.1.1",
                 "file-type": "^5.2.0",
@@ -1478,6 +1483,19 @@
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
             "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
         },
+        "diagnostic-channel": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
+            "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
+            "requires": {
+                "semver": "^5.3.0"
+            }
+        },
+        "diagnostic-channel-publishers": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.2.1.tgz",
+            "integrity": "sha1-ji1geottef6IC1SLxYzGvrKIxPM="
+        },
         "diff": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
@@ -1497,7 +1515,7 @@
         "download": {
             "version": "6.2.5",
             "resolved": "https://registry.npmjs.org/download/-/download-6.2.5.tgz",
-            "integrity": "sha512-DpO9K1sXAST8Cpzb7kmEhogJxymyVUd5qz/vCOSyvwtp2Klj2XcDt5YUuasgxka44SxF0q5RriKIwJmQHG2AuA==",
+            "integrity": "sha1-rNalQuTNC7Qspwz8mMnkOwcDlxQ=",
             "requires": {
                 "caw": "^2.0.0",
                 "content-disposition": "^0.5.2",
@@ -1697,7 +1715,7 @@
         "ewma": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/ewma/-/ewma-2.0.1.tgz",
-            "integrity": "sha512-MYYK17A76cuuyvkR7MnqLW4iFYPEi5Isl2qb8rXiWpLiwFS9dxW/rncuNnjjgSENuVqZQkIuR4+DChVL4g1lnw==",
+            "integrity": "sha1-mHbBxJGsVzPIZmABo5YaBMl88eg=",
             "requires": {
                 "assert-plus": "^1.0.0"
             }
@@ -1778,7 +1796,7 @@
         "ext-list": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
-            "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+            "integrity": "sha1-C5jmTtgvWs8PKTG6v2khLvUt3Tc=",
             "requires": {
                 "mime-db": "^1.28.0"
             }
@@ -1786,7 +1804,7 @@
         "ext-name": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
-            "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+            "integrity": "sha1-cHgZgdGD7hXROZPIgiBFxQbI8KY=",
             "requires": {
                 "ext-list": "^2.0.0",
                 "sort-keys-length": "^1.0.0"
@@ -2080,7 +2098,7 @@
         "fs-minipass": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-            "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+            "integrity": "sha1-BsJ3IYRU7CiN93raVKA7hwKqy50=",
             "requires": {
                 "minipass": "^2.2.1"
             }
@@ -2675,7 +2693,7 @@
         "get-proxy": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
-            "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
+            "integrity": "sha1-NJ8rTZHUTE1NTpy6KtkBQ/rF75M=",
             "requires": {
                 "npm-conf": "^1.1.0"
             }
@@ -2768,7 +2786,7 @@
         "global-modules": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+            "integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
             "dev": true,
             "requires": {
                 "global-prefix": "^1.0.1",
@@ -2801,7 +2819,7 @@
         "got": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-            "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+            "integrity": "sha1-BUUP2ECU5rvqVvRRpDqcKJFmOFo=",
             "requires": {
                 "decompress-response": "^3.2.0",
                 "duplexer3": "^0.1.4",
@@ -3196,7 +3214,7 @@
         "has-symbol-support-x": {
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-            "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+            "integrity": "sha1-FAn5i8ACR9pF2mfO4KNvKC/yZFU="
         },
         "has-symbols": {
             "version": "1.0.0",
@@ -3207,7 +3225,7 @@
         "has-to-string-tag-x": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-            "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+            "integrity": "sha1-oEWrOD17SyASoAFIqwql8pAETU0=",
             "requires": {
                 "has-symbol-support-x": "^1.4.1"
             }
@@ -3313,7 +3331,7 @@
         "ini": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+            "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
         },
         "interpret": {
             "version": "1.1.0",
@@ -3335,7 +3353,7 @@
         "is-absolute": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+            "integrity": "sha1-OV4a6EsR8mrReV5zwXN45IowFXY=",
             "dev": true,
             "requires": {
                 "is-relative": "^1.0.0",
@@ -3504,7 +3522,7 @@
         "is-plain-object": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
             "requires": {
                 "isobject": "^3.0.1"
             }
@@ -3517,7 +3535,7 @@
         "is-relative": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+            "integrity": "sha1-obtpNc6MXboei5dUubLcwCDiJg0=",
             "dev": true,
             "requires": {
                 "is-unc-path": "^1.0.0"
@@ -3546,7 +3564,7 @@
         "is-unc-path": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+            "integrity": "sha1-1zHoiY7QkKEsNSrS6u1Qla0yLJ0=",
             "dev": true,
             "requires": {
                 "unc-path-regex": "^0.1.2"
@@ -3598,7 +3616,7 @@
         "isurl": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-            "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+            "integrity": "sha1-sn9PSfPNqj6kSgpbfzRi5u3DnWc=",
             "requires": {
                 "has-to-string-tag-x": "^1.2.0",
                 "is-object": "^1.0.1"
@@ -3800,7 +3818,7 @@
         },
         "load-json-file": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
@@ -3813,7 +3831,7 @@
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 }
@@ -3832,7 +3850,7 @@
         "lowercase-keys": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-            "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+            "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
         },
         "lru-cache": {
             "version": "4.1.5",
@@ -3940,7 +3958,7 @@
         "mime": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+            "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
         },
         "mime-db": {
             "version": "1.37.0",
@@ -4164,14 +4182,14 @@
         },
         "next-tick": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
             "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
             "dev": true
         },
         "node-yaml-parser": {
             "version": "0.0.9",
             "resolved": "https://registry.npmjs.org/node-yaml-parser/-/node-yaml-parser-0.0.9.tgz",
-            "integrity": "sha512-bFFmAdUs9sdD+TwF/A91b4ozU2KJSDuK7HiBV0QDhdG7Cunu/4PakBLn3wWWAJurAJd7GqAeEwYhu32bTHOvQg=="
+            "integrity": "sha1-H9X9H38qRxRHdpFClJ8uKCcoarg="
         },
         "node.extend": {
             "version": "1.1.8",
@@ -4243,7 +4261,7 @@
         "npm-conf": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
-            "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+            "integrity": "sha1-JWzEe9DiGMJZxOlVC/QTvCGSr/k=",
             "requires": {
                 "config-chain": "^1.1.11",
                 "pify": "^3.0.0"
@@ -4417,7 +4435,7 @@
         },
         "os-locale": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
@@ -4432,7 +4450,7 @@
         "p-cancelable": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-            "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
+            "integrity": "sha1-ueEjgAvOu3rBOkeb4ZW1B7mNMPo="
         },
         "p-event": {
             "version": "1.3.0",
@@ -4551,7 +4569,7 @@
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 }
@@ -4579,7 +4597,7 @@
         "pidusage": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-1.2.0.tgz",
-            "integrity": "sha512-OGo+iSOk44HRJ8q15AyG570UYxcm5u+R99DI8Khu8P3tKGkVu5EZX4ywHglWSTMNNXQ274oeGpYrvFEhDIFGPg=="
+            "integrity": "sha1-Ze6WrOTgikzT+SQJlshbNnFx7pI="
         },
         "pify": {
             "version": "3.0.0",
@@ -4952,7 +4970,7 @@
         "restify-errors": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/restify-errors/-/restify-errors-5.0.0.tgz",
-            "integrity": "sha512-+vby9Kxf7qlzvbZSTIEGkIixkeHG+pVCl34dk6eKnL+ua4pCezpdLT/1/eabzPZb65ADrgoc04jeWrrF1E1pvQ==",
+            "integrity": "sha1-ZocX4QBoPuxs4NUV+J/x2+wlSo0=",
             "requires": {
                 "assert-plus": "^1.0.0",
                 "lodash": "^4.2.1",
@@ -5049,7 +5067,7 @@
         "set-value": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-            "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
             "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
@@ -5163,7 +5181,7 @@
         "snapdragon-node": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
             "dev": true,
             "requires": {
                 "define-property": "^1.0.0",
@@ -5214,7 +5232,7 @@
         "snapdragon-util": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
             "dev": true,
             "requires": {
                 "kind-of": "^3.2.0"
@@ -5344,7 +5362,7 @@
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -5387,7 +5405,7 @@
         "split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
             "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.0"
@@ -5566,7 +5584,7 @@
         "strip-dirs": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-            "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+            "integrity": "sha1-SYdzYmT8NEzyD2w0rKnRPR1O1sU=",
             "requires": {
                 "is-natural-number": "^4.0.1"
             }
@@ -5579,7 +5597,7 @@
         "strip-outer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-            "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+            "integrity": "sha1-sv0qv2YEudHmATBXGV34Nrip1jE=",
             "requires": {
                 "escape-string-regexp": "^1.0.2"
             }
@@ -6217,7 +6235,7 @@
         },
         "vscode-debugadapter": {
             "version": "1.27.0",
-            "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.27.0.tgz",
+            "resolved": "http://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.27.0.tgz",
             "integrity": "sha512-JwE3fWmKnpjYnFqhff0umqIJi4c26gh/CXZ5LNb4gLIuPd5sEAEoEbGeCcAaajuTrVxFw6FlYEep9y+IQCf+ww==",
             "requires": {
                 "vscode-debugprotocol": "1.27.0"
@@ -6225,16 +6243,15 @@
         },
         "vscode-debugprotocol": {
             "version": "1.27.0",
-            "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.27.0.tgz",
+            "resolved": "http://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.27.0.tgz",
             "integrity": "sha512-cg3lKqVwxNpO2pLBxSwkBvE7w06+bHfbA/s14u8izSWyhJtPgRu1lQwi5tEyTRuwfEugfoPwerYL4vtY6teQDw=="
         },
         "vscode-extension-telemetry": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.6.tgz",
-            "integrity": "sha1-X0CO+QYMBSNxpcBJOsHfu+FEgjE=",
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.1.tgz",
+            "integrity": "sha512-TkKKG/B/J94DP5qf6xWB4YaqlhWDg6zbbqVx7Bz//stLQNnfE9XS1xm3f6fl24c5+bnEK0/wHgMgZYKIKxPeUA==",
             "requires": {
-                "applicationinsights": "0.18.0",
-                "winreg": "1.2.3"
+                "applicationinsights": "1.0.8"
             }
         },
         "vscode-uri": {
@@ -6285,11 +6302,6 @@
             "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
             "dev": true
         },
-        "winreg": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.3.tgz",
-            "integrity": "sha1-k60RayaW2ofVj3JlqPzqUlSpZdU="
-        },
         "wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -6297,7 +6309,7 @@
         },
         "wrap-ansi": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
@@ -6392,6 +6404,11 @@
             "requires": {
                 "buffer-crc32": "~0.2.3"
             }
+        },
+        "zone.js": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.7.6.tgz",
+            "integrity": "sha1-+7w50+AmHQmG8boGMG6zrrDSIAk="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1243,7 +1243,7 @@
         "uuid": "^3.1.0",
         "vscode-debugadapter": "1.27.0",
         "vscode-debugprotocol": "1.27.0",
-        "vscode-extension-telemetry": "^0.0.6",
+        "vscode-extension-telemetry": "^0.1.1",
         "vscode-uri": "^1.0.1",
         "yaml-ast-parser": "^0.0.40",
         "yamljs": "0.2.10"


### PR DESCRIPTION
Because it pulls in a very old version of Application Insights, and AI has been implicated in an issue with HTTP requests from other extensions; so if we are going to need support with that then we want to be on the latest version.