### PR TITLE
Fix node pods not displayed with kubectl 1.12+

### DIFF
--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -10,7 +10,7 @@ import * as compatibility from './components/kubectl/compatibility';
 import { getToolPath, affectsUs, getUseWsl, KubectlVersioning } from './components/config/config';
 import { ensureSuitableKubectl } from './components/kubectl/autoversion';
 
-const KUBECTL_OUTPUT_COLUMN_SEPARATOR = /\s+/g;
+const KUBECTL_OUTPUT_COLUMN_SEPARATOR = /\s\s+/g;
 
 export interface Kubectl {
     checkPresent(errorMessageMode: CheckPresentMessageMode): Promise<boolean>;


### PR DESCRIPTION
Fixes #565.

The underlying issue is that someone forgot that `kubectl` table output is meant to be parseable by tools such as `awk`, and that multi-word column headers should therefore be hyphenated instead of spaced.  This person added a pod column called `NOMINATED NODE`.  Because we parse based on space-separation, we interpreted this as two columns, `NOMINATED` and `NODE`.  And the spurious `NODE` column duplicated and overwrite the real `NODE` column which we needed to relate pods to nodes.

Fortunately it seems that we can - for now at least - rely on at least three spaces between columns, per the TabWriter implementation and the settings in the k8s `tabwriter.go` file.  So there is a simple fix to set the column separator regex to at least two spaces.  It would be good to get this fixed upstream for the benefit of other tools though.  But we should also implement robustness improvements in our own parser, e.g. to deal with spaces in data fields.

NOTE: Unfortunately we can't use structured-text solutions such as `-o json`, or solutions where we control the output such as `-o custom-columns`, to work around this, because we need the `STATUS` field.  This does not map to a single server field, but is instead synthesised by the `kubectl` table formatter.  To my mind it is a bug in `kubectl` that we can't access this value without surrendering to an unpredictable output format.  But there it is.

![](https://i.imgflip.com/33fjl4.jpg)