### PR TITLE
Fix [object Object] if kubeconfig merging from Cloud Explorer exists

### DIFF
--- a/src/components/kubectl/kubeconfig.ts
+++ b/src/components/kubectl/kubeconfig.ts
@@ -50,7 +50,7 @@ async function mergeInto(existing: Named[], toMerge: Named[]): Promise<void> {
     for (const toMergeEntry of toMerge) {
         if (existing.some((e) => e.name === toMergeEntry.name)) {
             // we have CONFLICT and CONFLICT BUILDS CHARACTER
-            await vscode.window.showWarningMessage(`${toMergeEntry} already exists - skipping`);
+            await vscode.window.showWarningMessage(`${toMergeEntry.name} already exists - skipping`);
             continue;  // TODO: build character
         }
         existing.push(toMergeEntry);


### PR DESCRIPTION
When you merge a kubeconfig from Cloud Explorer, it checks if an entry name already exists and if so skips that entry.  The message currently says `[object Object] already exists - skipping`.  This displays the name instead.

Fixes #540.