### PR TITLE
Format minikube status dependent on its version

### DIFF
--- a/src/components/clusterprovider/minikube/minikube.ts
+++ b/src/components/clusterprovider/minikube/minikube.ts
@@ -121,7 +121,14 @@ async function minikubeUpgradeAvailable(context: Context): Promise<void> {
         return;
     }
 
-    const versionInfo = await getVersionInfo(context);
+    let versionInfo: MinikubeVersionInfo;
+
+    try {
+        versionInfo = await getVersionInfo(context);
+    } catch (err) {
+        vscode.window.showErrorMessage(`Failed to determine minikube version: ${err}`);
+        return;
+    }
 
     if (versionInfo.currentVersion !== versionInfo.availableVersion) {
         const value = await vscode.window.showInformationMessage(`Minikube upgrade available to ${versionInfo.availableVersion}, currently on ${versionInfo.currentVersion}`, 'Install');


### PR DESCRIPTION
This fixes an error when querying the status of minikube by choosing a `--format` string appropriate for its version.

Fixes issue: https://github.com/Azure/vscode-kubernetes-tools/issues/467