### PR TITLE
Make "minikube status" version independent

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -199,8 +199,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         registerCommand('extension.vsMinikubeStatus', async () => {
             try {
                 const status = await minikube.status();
-                const isRunning = status.running ? "running" : "stopped";
-                vscode.window.showInformationMessage(`Minikube is ${isRunning}`);
+                kubeChannel.showOutput(status.message, "Minikube status");
             } catch (err) {
                 vscode.window.showErrorMessage(`Error getting status ${err}`);
             }


### PR DESCRIPTION
Like suggested in https://github.com/Azure/vscode-kubernetes-tools/pull/575 this will remove the version dependency of the `minikube status --format` output and do the following:
* Use the first line of the output (.Host/.MinikubeStatus) for determining the status of Minikube (running/stopped)
* Instead of the notification bar (`showInfoMessage`) the whole output of `minikube status` is shown in the `Output -> Kubernetes` channel; So now users can see the status of the apiserver and kubelet, and the configuration of the kubectl.

@brendandburns: Like @itowlson already mentioned in https://github.com/Azure/vscode-kubernetes-tools/pull/575#issuecomment-509927412 I am changing the the original behavior of your work, and want to include you in the discussion whether this is ok or not.