### PR TITLE
Use CRD schemas if available

### DIFF
--- a/schema/schema_enums.json
+++ b/schema/schema_enums.json
@@ -1,0 +1,165 @@
+{
+  "io.k8s.api.core.v1.AzureDiskVolumeSource": {
+    "cachingMode": [
+      "None",
+      "ReadOnly",
+      "ReadWrite"
+    ],
+    "kind": [
+      "Shared",
+      "Dedicated"
+    ]
+  },
+  "io.k8s.api.core.v1.ComponentCondition": {
+    "status": [
+      "True",
+      "False"
+    ]
+  },
+  "io.k8s.api.core.v1.Container": {
+    "imagePullPolicy": [
+      "Always",
+      "Never"
+    ],
+    "terminationMessagePolicy": [
+      "File"
+    ]
+  },
+  "io.k8s.api.core.v1.ContainerPort": {
+    "protocol": [
+      "TCP",
+      "UDP"
+    ]
+  },
+  "io.k8s.api.core.v1.EndpointPort": {
+    "protocol": [
+      "TCP",
+      "UDP"
+    ]
+  },
+  "io.k8s.api.core.v1.LimitRangeItem": {
+    "type": [
+      "Pod",
+      "Container"
+    ]
+  },
+  "io.k8s.api.core.v1.NodeAddress": {
+    "type": [
+      "Hostname",
+      "ExternalIP",
+      "InternalIP",
+      "ExternalDNS"
+    ]
+  },
+  "io.k8s.api.core.v1.NodeCondition": {
+    "status": [
+      "True",
+      "False"
+    ],
+    "type": [
+      "Ready",
+      "MemoryPressure",
+      "DiskPressure",
+      "PIDPressure"
+    ]
+  },
+  "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
+    "type": [
+      "Resizing"
+    ]
+  },
+  "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+    "volumeMode": [
+      "Block"
+    ]
+  },
+  "io.k8s.api.core.v1.PodCondition": {
+    "status": [
+      "True",
+      "False"
+    ],
+    "type": [
+      "ContainersReady",
+      "Initialized",
+      "Ready"
+    ]
+  },
+  "io.k8s.api.core.v1.PodReadinessGate": {
+    "conditionType": [
+      "ContainersReady",
+      "Initialized",
+      "Ready"
+    ]
+  },
+  "io.k8s.api.core.v1.PodSpec": {
+    "dnsPolicy": [
+      "ClusterFirstWithHostNet",
+      "ClusterFirst",
+      "Default"
+    ],
+    "restartPolicy": [
+      "Always",
+      "OnFailure"
+    ]
+  },
+  "io.k8s.api.core.v1.PodStatus": {
+    "phase": [
+      "Pending",
+      "Running",
+      "Succeeded",
+      "Failed"
+    ],
+    "qosClass": [
+      "Guaranteed",
+      "Burstable"
+    ]
+  },
+  "io.k8s.api.core.v1.ReplicationControllerCondition": {
+    "status": [
+      "True",
+      "False"
+    ]
+  },
+  "io.k8s.api.core.v1.ResourceQuotaSpec": {
+    "scopes": [
+      "Terminating",
+      "NotTerminating",
+      "BestEffort",
+      "NotBestEffort"
+    ]
+  },
+  "io.k8s.api.core.v1.ScopedResourceSelectorRequirement": {
+    "scopeName": [
+      "Terminating",
+      "NotTerminating",
+      "BestEffort",
+      "NotBestEffort"
+    ]
+  },
+  "io.k8s.api.core.v1.ServicePort": {
+    "protocol": [
+      "TCP",
+      "UDP"
+    ]
+  },
+  "io.k8s.api.core.v1.ServiceSpec": {
+    "externalTrafficPolicy": [
+      "Local"
+    ],
+    "sessionAffinity": [
+      "ClientIP"
+    ],
+    "type": [
+      "ClusterIP",
+      "NodePort",
+      "LoadBalancer"
+    ]
+  },
+  "io.k8s.api.core.v1.Toleration": {
+    "effect": [
+      "NoSchedule",
+      "PreferNoSchedule",
+      "NoScheduleNoAdmit"
+    ]
+  }
+}

--- a/src/components/contextmanager/active-context-tracker.ts
+++ b/src/components/contextmanager/active-context-tracker.ts
@@ -1,0 +1,18 @@
+import { Kubectl } from "../../kubectl";
+import * as activeValueTracker from "./active-value-tracker";
+import { ActiveValueTracker } from "./active-value-tracker";
+import { getCurrentContext } from "../../kubectlUtils";
+
+const ACTIVE_CONTEXT_POLL_INTERVAL_MS = 60000;  // Hopefully people in the extension will mostly change contexts through the extension, and if not they may have to make do with a delay
+
+export function create(kubectl: Kubectl): ActiveValueTracker<string | null> {
+    return activeValueTracker.create(() => getActiveContextName(kubectl), ACTIVE_CONTEXT_POLL_INTERVAL_MS);
+}
+
+async function getActiveContextName(kubectl: Kubectl): Promise<string | null> {
+    const currentContext = await getCurrentContext(kubectl);
+    if (!currentContext) {
+        return null;
+    }
+    return currentContext.contextName;
+}

--- a/src/components/contextmanager/active-value-tracker.ts
+++ b/src/components/contextmanager/active-value-tracker.ts
@@ -1,0 +1,51 @@
+import { Event, EventEmitter } from "vscode";
+import { sleep } from "../../sleep";
+
+export interface ActiveValueTracker<T> {
+    readonly activeChanged: Event<T>;
+    setActive(switchedTo: T): void;
+    activeAsync(): Promise<T>;
+    active(): T | null;
+}
+
+export function create<T>(getActiveValue: () => Promise<T>, pollIntervalMS: number) {
+    return new ActiveValueTrackerImpl<T>(getActiveValue, pollIntervalMS);
+}
+
+class ActiveValueTrackerImpl<T> implements ActiveValueTracker<T> {
+    private activeValue: T | null = null;
+    private readonly activeChangedEmitter: EventEmitter<T> = new EventEmitter<T>();
+
+    constructor(private readonly getActiveValue: () => Promise<T>, private readonly pollIntervalMS: number) {
+        this.pollActive();
+    }
+
+    public get activeChanged(): Event<T> {
+        return this.activeChangedEmitter.event;
+    }
+
+    public setActive(switchedTo: T): void {
+        if (switchedTo !== this.activeValue) {
+            this.activeValue = switchedTo;
+            this.activeChangedEmitter.fire(this.activeValue);
+        }
+    }
+
+    public async activeAsync(): Promise<T> {
+        const value = await this.getActiveValue();
+        this.setActive(value);
+        return value;
+    }
+
+    public active(): T | null {
+        return this.activeValue;
+    }
+
+    private async pollActive(): Promise<never> {
+        while (true) {
+            const activeContext = await this.getActiveValue();
+            this.setActive(activeContext);
+            await sleep(this.pollIntervalMS);
+        }
+    }
+}

--- a/src/components/contextmanager/background-context-cache.ts
+++ b/src/components/contextmanager/background-context-cache.ts
@@ -1,0 +1,70 @@
+import { ActiveValueTracker } from "./active-value-tracker";
+
+// The use case here is when we have to work with an API that requires
+// information to be available synchronously, but for us to know the
+// current value is time-consuming and best performed asynchronously.
+export class BackgroundContextCache<T> {
+    private readonly cache = new Map<string, T>();
+
+    constructor(private readonly activeContextTracker: ActiveValueTracker<string | null>,
+        private readonly getActiveContextValue: () => Promise<T>,
+        private readonly fallbackValue: T)
+    {
+        this.activeContextTracker.activeChanged(this.onActiveContextChanged);
+
+        const activeContext = this.activeContextTracker.active();
+        if (activeContext) {
+            this.updateCache(activeContext);
+        }
+    }
+
+    private onActiveContextChanged(newContext: string | null): void {
+        if (newContext) {
+            this.updateCache(newContext);
+        }
+    }
+
+    public async activeAsync(): Promise<T> {
+        const contextName = await this.activeContextTracker.activeAsync();
+        if (!contextName) {
+            return this.fallbackValue;
+        }
+        const result = this.cache.get(contextName);
+        if (result) {
+            return result;
+        }
+        const value = await this.getActiveContextValue();
+        this.cache.set(contextName, value);
+        return value;
+    }
+
+    public changedActiveContextValue(): void {
+        const activeContext = this.activeContextTracker.active();
+        if (activeContext) {
+            this.updateCache(activeContext);
+        }
+    }
+
+    public active(): T {
+        const activeContext = this.activeContextTracker.active();
+        if (!activeContext) {
+            return this.fallbackValue;
+        }
+        const result = this.cache.get(activeContext);
+        if (result) {
+            return result;
+        }
+        this.updateCache(activeContext);
+        return this.fallbackValue;
+    }
+
+    private async updateCache(activeContextName: string): Promise<void> {
+        const value = await this.getActiveContextValue();
+        // Heuristic check that the active context didn't change while getActiveContextValue
+        // was doing it thing (because it it did then the retrieved value might not be for the
+        // context we thought it was!).
+        if (this.activeContextTracker.active() === activeContextName) {
+            this.cache.set(activeContextName, value);
+        }
+    }
+}

--- a/src/components/contextmanager/background-context-cache.ts
+++ b/src/components/contextmanager/background-context-cache.ts
@@ -67,4 +67,11 @@ export class BackgroundContextCache<T> {
             this.cache.set(activeContextName, value);
         }
     }
+
+    public invalidateActive(): void {
+        const activeContext = this.activeContextTracker.active();
+        if (activeContext) {
+            this.updateCache(activeContext);
+        }
+    }
 }

--- a/src/components/contextmanager/background-context-cache.ts
+++ b/src/components/contextmanager/background-context-cache.ts
@@ -10,7 +10,7 @@ export class BackgroundContextCache<T> {
         private readonly getActiveContextValue: () => Promise<T>,
         private readonly fallbackValue: T)
     {
-        this.activeContextTracker.activeChanged(this.onActiveContextChanged);
+        this.activeContextTracker.activeChanged(this.onActiveContextChanged, this);
 
         const activeContext = this.activeContextTracker.active();
         if (activeContext) {

--- a/src/components/kubectl/proxy.ts
+++ b/src/components/kubectl/proxy.ts
@@ -1,0 +1,71 @@
+import { Errorable } from "../../errorable";
+import { Kubectl } from "../../kubectl";
+import { ChildProcess } from "child_process";
+
+export async function proxy(kubectl: Kubectl, port: number | 'random'): Promise<Errorable<ProxySession>> {
+    const portNumber = (port === 'random') ? 0 : port;
+    const args = ['proxy', `--port=${portNumber}`];
+
+    // TODO: option to show a cancellable progress indicator while opening proxy?  We don't really need this for the Swagger scenario though
+    const proxyingProcess = await kubectl.spawnAsChild(args);
+    if (!proxyingProcess) {
+        return { succeeded: false, error: ['Failed to invoke kubectl'] };
+    }
+
+    const forwarding = await waitForOutput(proxyingProcess, /Starting to serve on \d+\.\d+\.\d+\.\d+:(\d+)/);
+
+    if (forwarding.waitResult === 'process-exited') {
+        return { succeeded: false, error: ['Failed to open proxy to cluster']};  // TODO: get the error moar betters
+    }
+
+    if (forwarding.matchedOutput.length < 2) {
+        return { succeeded: false, error: [`Failed to open proxy to cluster: unexpected kubectl output ${forwarding.matchedOutput[0]}`]};  // TODO: get the error moar betters
+    }
+
+    const actualPort = Number.parseInt(forwarding.matchedOutput[1]);
+    const dispose = () => { proxyingProcess.kill(); };
+
+    return {
+        succeeded: true,
+        result: { port: actualPort, dispose: dispose }
+    };
+}
+
+export interface ProxySession {
+    readonly port: number;
+    dispose(): void;
+}
+
+// TODO: expands on code from API port forward impl: deduplicate
+
+interface WaitForOutputSucceeded {
+    readonly waitResult: 'succeeded';
+    readonly matchedOutput: RegExpExecArray;
+}
+
+interface WaitForOutputProcessExited {
+    readonly waitResult: 'process-exited';
+}
+
+type WaitForOutputResult = WaitForOutputSucceeded | WaitForOutputProcessExited;
+
+function waitForOutput(process: ChildProcess, pattern: RegExp): Promise<WaitForOutputResult> {
+    return new Promise<WaitForOutputResult>((resolve) => {
+        let didOutput = false;
+
+        process.stdout.on('data', async (data) => {
+            const message = `${data}`;
+            const matchResult = pattern.exec(message);
+            if (matchResult && matchResult.length > 0) {
+                didOutput = true;
+                resolve({ waitResult: 'succeeded', matchedOutput: matchResult });
+            }
+        });
+
+        process.on('close', async (_code) => {
+            if (!didOutput) {
+                resolve({ waitResult: 'process-exited'});
+            }
+        });
+    });
+}

--- a/src/components/swagger/swagger.ts
+++ b/src/components/swagger/swagger.ts
@@ -1,0 +1,37 @@
+import * as download from '../../components/download/download';
+import { Errorable, failed } from "../../errorable";
+import { Kubectl } from "../../kubectl";
+import { proxy } from "../kubectl/proxy";
+import { fs } from '../../fs';
+
+export type Swagger = any;
+
+export async function getClusterSwagger(kubectl: Kubectl): Promise<Errorable<Swagger>> {
+    const proxyResult = await proxy(kubectl, 'random');
+    if (failed(proxyResult)) {
+        return proxyResult;
+    }
+
+    const proxySession = proxyResult.result;
+
+    try {
+        const uri = `http://localhost:${proxySession.port}/openapi/v2`;  // TODO: /swagger.json for server version <1.10
+        const swaggerDownload = await download.toTempFile(uri);
+        if (failed(swaggerDownload)) {
+            return swaggerDownload;
+        }
+
+        const swaggerTempFile = swaggerDownload.result;
+
+        try {
+            const swaggerText = await fs.readTextFile(swaggerTempFile);
+            const swagger = JSON.parse(swaggerText);
+            // TODO: Looks like we need to post-process out the enum definitions per https://github.com/Azure/vscode-kubernetes-tools/pull/243/files
+            return { succeeded: true, result: swagger };
+        } finally {
+            await fs.unlinkAsync(swaggerTempFile);
+        }
+    } finally {
+        proxySession.dispose();
+    }
+}

--- a/src/components/swagger/swagger.ts
+++ b/src/components/swagger/swagger.ts
@@ -26,7 +26,6 @@ export async function getClusterSwagger(kubectl: Kubectl): Promise<Errorable<Swa
         try {
             const swaggerText = await fs.readTextFile(swaggerTempFile);
             const swagger = JSON.parse(swaggerText);
-            // TODO: Looks like we need to post-process out the enum definitions per https://github.com/Azure/vscode-kubernetes-tools/pull/243/files
             return { succeeded: true, result: swagger };
         } finally {
             await fs.unlinkAsync(swaggerTempFile);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,7 +55,7 @@ import { getDebugProviderOfType, getSupportedDebuggerTypes } from './debug/provi
 import * as config from './components/config/config';
 import * as browser from './components/platform/browser';
 
-import { registerYamlSchemaSupport } from './yaml-support/yaml-schema';
+import { registerYamlSchemaSupport, updateYAMLSchema } from './yaml-support/yaml-schema';
 import * as clusterproviderregistry from './components/clusterprovider/clusterproviderregistry';
 import * as azureclusterprovider from './components/clusterprovider/azure/azureclusterprovider';
 import * as minikubeclusterprovider from './components/clusterprovider/minikube/minikubeclusterprovider';
@@ -581,6 +581,11 @@ function maybeRunKubernetesCommandForActiveWindow(command: string, progressMessa
     const resultHandler: ShellHandler | undefined = isKubernetesSyntax ? undefined /* default handling */ :
         (code, stdout, stderr) => {
             if (code === 0 ) {
+                if (command === 'create' || command === 'apply') {
+                    // This is a very crude test - it would be nice to check if we have modified a CRD.
+                    // But the current structure of the code does not support that.
+                    updateYAMLSchema();
+                }
                 vscode.window.showInformationMessage(stdout);
             } else {
                 vscode.window.showErrorMessage(`Kubectl command failed. The open document might not be a valid Kubernetes resource.  Details: ${stderr}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,6 +84,7 @@ import { PortForwardStatusBarManager } from './components/kubectl/port-forward-u
 import { getBuildCommand, getPushCommand } from './image/imageUtils';
 import { getImageBuildTool } from './components/config/config';
 import { ClusterExplorerNode, ClusterExplorerConfigurationValueNode, ClusterExplorerResourceNode, ClusterExplorerResourceFolderNode } from './components/clusterexplorer/node';
+import { create as activeContextTrackerCreate } from './components/contextmanager/active-context-tracker';
 
 let explainActive = false;
 let swaggerSpecPromise: Promise<explainer.SwaggerModel | undefined> | null = null;
@@ -96,6 +97,7 @@ const minikube = minikubeCreate(host, fs, shell, installDependencies);
 const clusterProviderRegistry = clusterproviderregistry.get();
 const configMapProvider = new configmaps.ConfigMapTextProvider(kubectl);
 const git = new Git(shell);
+const activeContextTracker = activeContextTrackerCreate(kubectl);
 
 export const overwriteMessageItems: vscode.MessageItem[] = [
     {
@@ -376,7 +378,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
     subscriptions.forEach((element) => {
         context.subscriptions.push(element);
     });
-    await registerYamlSchemaSupport();
+    await registerYamlSchemaSupport(activeContextTracker, kubectl);
 
     vscode.workspace.registerTextDocumentContentProvider(configmaps.uriScheme, configMapProvider);
     return apiBroker(clusterProviderRegistry, kubectl, portForwardStatusBarManager, treeProvider, cloudExplorer);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1858,6 +1858,7 @@ async function useContextKubernetes(explorerNode: ClusterExplorerNode) {
     const shellResult = await kubectl.invokeAsync(`config use-context ${targetContext}`);
     if (shellResult && shellResult.code === 0) {
         telemetry.invalidateClusterType(targetContext);
+        activeContextTracker.setActive(targetContext);
         refreshExplorer();
     } else {
         vscode.window.showErrorMessage(`Failed to set '${targetContext}' as current cluster: ${shellResult ? shellResult.stderr : "Unable to run kubectl"}`);

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -9,6 +9,7 @@ import { parseLineOutput } from './outputUtils';
 import * as compatibility from './components/kubectl/compatibility';
 import { getToolPath, affectsUs, getUseWsl, KubectlVersioning } from './components/config/config';
 import { ensureSuitableKubectl } from './components/kubectl/autoversion';
+import { updateYAMLSchema } from './yaml-support/yaml-schema';
 
 const KUBECTL_OUTPUT_COLUMN_SEPARATOR = /\s\s+/g;
 
@@ -279,6 +280,7 @@ function kubectlDone(context: Context): ShellHandler {
             return;
         }
 
+        updateYAMLSchema();  // TODO: I really do not like having this here. Massive separation of concerns red flag plus we lack context to decide whether it's needed. But hard to move without revamping the result handling system.
         context.host.showInformationMessage(stdout);
     };
 }

--- a/src/yaml-support/schema-holder.ts
+++ b/src/yaml-support/schema-holder.ts
@@ -1,0 +1,240 @@
+import * as _ from 'lodash';
+
+import { Kubectl } from "../kubectl";
+import { KUBERNETES_SCHEMA_ENUM_FILE, FALLBACK_SCHEMA_FILE, KUBERNETES_GROUP_VERSION_KIND } from "./yaml-constant";
+import { formatComplex, formatOne, formatType } from '../schema-formatting';
+import * as swagger from '../components/swagger/swagger';
+import { succeeded } from '../errorable';
+import * as util from "./yaml-util";
+
+interface KubernetesSchema {
+    readonly name: string;
+    readonly description?: string;
+    readonly id?: string;
+    readonly apiVersion?: string;
+    readonly kind?: string;
+    readonly 'x-kubernetes-group-version-kind'?: any[];
+    readonly properties?: { [key: string]: any; };
+}
+
+export class KubernetesClusterSchemaHolder {
+    private definitions: { [key: string]: KubernetesSchema; } = {};
+    private schemaEnums: { [key: string]: { [key: string]: [string[]] }; };
+
+    public static async fromActiveCluster(kubectl: Kubectl): Promise<KubernetesClusterSchemaHolder> {
+        const holder = new KubernetesClusterSchemaHolder();
+        await holder.loadSchemaFromActiveCluster(kubectl, KUBERNETES_SCHEMA_ENUM_FILE);
+        return holder;
+    }
+
+    public static fallback(): KubernetesClusterSchemaHolder {
+        const holder = new KubernetesClusterSchemaHolder();
+        const fallbackSchema = util.loadJson(FALLBACK_SCHEMA_FILE);
+        holder.loadSchemaFromRaw(fallbackSchema, KUBERNETES_SCHEMA_ENUM_FILE);
+        return holder;
+    }
+
+    private async loadSchemaFromActiveCluster(kubectl: Kubectl, schemaEnumFile?: string): Promise<void> {
+        const clusterSwagger = await swagger.getClusterSwagger(kubectl);
+        const schemaRaw = succeeded(clusterSwagger) ? this.definitionsObject(clusterSwagger.result) : util.loadJson(FALLBACK_SCHEMA_FILE);
+        this.loadSchemaFromRaw(schemaRaw, schemaEnumFile);
+    }
+
+    private definitionsObject(swagger: any): any {
+        return {
+            definitions: swagger.definitions
+        };
+    }
+
+    private loadSchemaFromRaw(schemaRaw: any, schemaEnumFile?: string): void {
+        this.schemaEnums = schemaEnumFile ? util.loadJson(schemaEnumFile) : {};
+        const definitions = schemaRaw.definitions;
+        for (const name of Object.keys(definitions)) {
+            this.saveSchemaWithManifestStyleKeys(name, definitions[name]);
+        }
+
+        for (const schema of _.values(this.definitions) ) {
+            if (schema.properties) {
+                // the swagger schema has very short description on properties, we need to get the actual type of
+                // the property and provide more description/properties details, just like `kubernetes explain` do.
+                _.each(schema.properties, (propVal, propKey) => {
+                    if (schema.kind && propKey === 'kind') {
+                        propVal.markdownDescription = this.getMarkdownDescription(schema.kind, undefined, schema, true);
+                        return;
+                    }
+
+                    const currentPropertyTypeRef = propVal.$ref || (propVal.items ? propVal.items.$ref : undefined);
+                    if (_.isString(currentPropertyTypeRef)) {
+                        const id = getNameInDefinitions(currentPropertyTypeRef);
+                        const propSchema = this.lookup(id);
+                        if (propSchema) {
+                            propVal.markdownDescription = this.getMarkdownDescription(propKey, propVal, propSchema);
+                        }
+                    } else {
+                        propVal.markdownDescription = this.getMarkdownDescription(propKey, propVal, undefined);
+                    }
+                });
+
+                // fix on each node in properties for $ref since it will directly reference '#/definitions/...'
+                // we need to convert it into schema like 'kubernetes://schema/...'
+                // we need also an array to collect them since we need to get schema from _definitions, at this point, we have
+                // not finished the process of add schemas to _definitions, call patchOnRef will fail for some cases.
+                this.replaceDefinitionRefsWithYamlSchemaUris(schema.properties);
+                this.loadEnumsForKubernetesSchema(schema);
+            }
+        }
+    }
+
+    // get kubernetes schema by the key
+    public lookup(key: string): KubernetesSchema | undefined {
+        return key ? this.definitions[key.toLowerCase()] : undefined;
+    }
+
+    /**
+     * Save the schema object in swagger json to schema map.
+     *
+     * @param {string} name the property name in definition node of swagger json
+     * @param originalSchema the origin schema object in swagger json
+     */
+    private saveSchemaWithManifestStyleKeys(name: string, originalSchema: any): void {
+        if (isGroupVersionKindStyle(originalSchema)) {
+            // if the schema contains 'x-kubernetes-group-version-kind'. then it is a direct kubernetes manifest,
+            getManifestStyleSchemas(originalSchema).forEach((schema: KubernetesSchema) =>  {
+                this.saveSchema({
+                    name,
+                    ...schema
+                });
+            });
+
+        } else {
+            // if x-kubernetes-group-version-kind cannot be found, then it is an in-direct schema refereed by
+            // direct kubernetes manifest, eg: io.k8s.kubernetes.pkg.api.v1.PodSpec
+            this.saveSchema({
+                name,
+                ...originalSchema
+            });
+        }
+    }
+
+    // replace schema $ref with values like 'kubernetes://schema/...'
+    private replaceDefinitionRefsWithYamlSchemaUris(node: any): void {
+        if (!node) {
+            return;
+        }
+        if (_.isArray(node)) {
+            for (const subItem of <any[]>node) {
+                this.replaceDefinitionRefsWithYamlSchemaUris(subItem);
+            }
+        }
+        if (!_.isObject(node)) {
+            return;
+        }
+        for (const key of Object.keys(node)) {
+            this.replaceDefinitionRefsWithYamlSchemaUris(node[key]);
+        }
+
+        if (_.isString(node.$ref)) {
+            const name = getNameInDefinitions(node.$ref);
+            const schema = this.lookup(name);
+            if (schema) {
+                // replacing $ref
+                node.$ref = util.makeKubernetesUri(schema.name);
+            }
+        }
+    }
+
+    // add enum field for pre-defined enums in schema-enums json file
+    private loadEnumsForKubernetesSchema(node: KubernetesSchema) {
+        if (node.properties && this.schemaEnums[node.name]) {
+            _.each(node.properties, (propSchema, propKey) => {
+                if (this.schemaEnums[node.name][propKey]) {
+                    propSchema.enum = this.schemaEnums[node.name][propKey];
+                }
+            });
+        }
+    }
+
+    // save the schema to the _definitions
+    private saveSchema(schema: KubernetesSchema): void {
+        if (schema.name) {
+            this.definitions[schema.name.toLowerCase()] = schema;
+        }
+        if (schema.id) {
+            this.definitions[schema.id.toLowerCase()] = schema;
+        }
+    }
+
+    // get the markdown format of document for the current property and the type of current property
+    private getMarkdownDescription(currentPropertyName: string, currentProperty: any, targetSchema: any, isKind = false): string {
+        if (isKind) {
+            return formatComplex(currentPropertyName, targetSchema.description, undefined, targetSchema.properties);
+        }
+        if (!targetSchema) {
+            return formatOne(currentPropertyName, formatType(currentProperty), currentProperty.description);
+        }
+        const properties = targetSchema.properties;
+        if (properties) {
+            return formatComplex(currentPropertyName, currentProperty ? currentProperty.description : "",
+                targetSchema.description, properties);
+        }
+        return currentProperty ? currentProperty.description : (targetSchema ? targetSchema.description : "");
+    }
+}
+
+/**
+ * Tell whether or not the swagger schema is a kubernetes manifest schema, a kubernetes manifest schema like Service
+ * should have `x-kubernetes-group-version-kind` node.
+ *
+ * @param originalSchema the origin schema object in swagger json
+ * @return whether or not the swagger schema is
+ */
+function isGroupVersionKindStyle(originalSchema: any): boolean {
+    return originalSchema[KUBERNETES_GROUP_VERSION_KIND] && originalSchema[KUBERNETES_GROUP_VERSION_KIND].length;
+}
+
+/**
+ * Process on kubernetes manifest schemas, for each selector in x-kubernetes-group-version-kind,
+ * extract apiVersion and kind and make a id composed by apiVersion and kind.
+ *
+ * @param originalSchema the origin schema object in swagger json
+ * @returns {KubernetesSchema[]} an array of schemas for the same manifest differentiated by id/apiVersion/kind;
+ */
+function getManifestStyleSchemas(originalSchema: any): KubernetesSchema[] {
+    const schemas = Array.of<KubernetesSchema>();
+    // eg: service, pod, deployment
+    const groupKindNode = originalSchema[KUBERNETES_GROUP_VERSION_KIND];
+
+    // delete 'x-kubernetes-group-version-kind' since it is not a schema standard, it is only a selector
+    delete originalSchema[KUBERNETES_GROUP_VERSION_KIND];
+
+    groupKindNode.forEach((groupKindNode: any) => {
+        const gvk = util.parseKubernetesGroupVersionKind(groupKindNode);
+        if (!gvk) {
+            return;
+        }
+
+        const { id, apiVersion, kind } = gvk;
+
+        // a direct kubernetes manifest has two reference keys: id && name
+        // id: apiVersion + kind
+        // name: the name in 'definitions' of schema
+        schemas.push({
+            id,
+            apiVersion,
+            kind,
+            ...originalSchema
+        });
+    });
+    return schemas;
+}
+
+// convert '#/definitions/com.github.openshift.origin.pkg.build.apis.build.v1.ImageLabel' to
+// 'com.github.openshift.origin.pkg.build.apis.build.v1.ImageLabel'
+function getNameInDefinitions ($ref: string): string {
+    const prefix = '#/definitions/';
+    if ($ref.startsWith(prefix)) {
+        return $ref.slice(prefix.length);
+    } else {
+        return prefix;
+    }
+}

--- a/src/yaml-support/yaml-constant.ts
+++ b/src/yaml-support/yaml-constant.ts
@@ -9,6 +9,7 @@ export const VSCODE_YAML_EXTENSION_ID = 'redhat.vscode-yaml';
 export const KUBERNETES_SCHEMA_VERSION = '1.12.2';
 
 export const KUBERNETES_SCHEMA_FILE = path.join(__dirname, `../../../schema/swagger-v${KUBERNETES_SCHEMA_VERSION}.json`);
+export const FALLBACK_SCHEMA_FILE = path.join(__dirname, `../../../schema/swagger-v${KUBERNETES_SCHEMA_VERSION}.json`);
 
 export const KUBERNETES_SCHEMA_ENUM_FILE = path.join(__dirname, `../../../schema/schema_enums-v${KUBERNETES_SCHEMA_VERSION}.json`);
 

--- a/src/yaml-support/yaml-schema.ts
+++ b/src/yaml-support/yaml-schema.ts
@@ -113,3 +113,12 @@ async function activateYamlExtension(): Promise<{registerContributor: YamlSchema
     }
     return yamlPlugin;
 }
+
+export function updateYAMLSchema() {
+    if (schemas) {
+        schemas.invalidateActive();
+        // There doesn't seem to be a way to get the YAML extension to pick up the update so
+        // for now users would need to close and reopen any affected open documents.  TODO: raise
+        // issue with the RH folks.
+    }
+}

--- a/src/yaml-support/yaml-schema.ts
+++ b/src/yaml-support/yaml-schema.ts
@@ -118,7 +118,7 @@ export function updateYAMLSchema() {
     if (schemas) {
         schemas.invalidateActive();
         // There doesn't seem to be a way to get the YAML extension to pick up the update so
-        // for now users would need to close and reopen any affected open documents.  TODO: raise
-        // issue with the RH folks.
+        // for now users would need to close and reopen any affected open documents.  Raised
+        // issue with RedHat: https://github.com/redhat-developer/vscode-yaml/issues/202
     }
 }

--- a/src/yaml-support/yaml-schema.ts
+++ b/src/yaml-support/yaml-schema.ts
@@ -3,27 +3,12 @@ import * as semver from 'semver';
 import Uri from 'vscode-uri';
 import * as vscode from 'vscode';
 import { yamlLocator, YamlMap } from "./yaml-locator";
-import {
-    VSCODE_YAML_EXTENSION_ID, KUBERNETES_SCHEMA, KUBERNETES_GROUP_VERSION_KIND, GROUP_VERSION_KIND_SEPARATOR,
-    KUBERNETES_SCHEMA_ENUM_FILE, FALLBACK_SCHEMA_FILE
-} from "./yaml-constant";
+import { VSCODE_YAML_EXTENSION_ID, KUBERNETES_SCHEMA, GROUP_VERSION_KIND_SEPARATOR } from "./yaml-constant";
 import * as util from "./yaml-util";
-import { formatComplex, formatOne, formatType } from '../schema-formatting';
-import * as swagger from '../components/swagger/swagger';
-import { succeeded } from '../errorable';
 import { Kubectl } from '../kubectl';
 import { ActiveValueTracker } from '../components/contextmanager/active-value-tracker';
 import { BackgroundContextCache } from '../components/contextmanager/background-context-cache';
-
-export interface KubernetesSchema {
-    readonly name: string;
-    readonly description?: string;
-    readonly id?: string;
-    readonly apiVersion?: string;
-    readonly kind?: string;
-    readonly 'x-kubernetes-group-version-kind'?: any[];
-    readonly properties?: { [key: string]: any; };
-}
+import { KubernetesClusterSchemaHolder } from './schema-holder';
 
 // The function signature exposed by vscode-yaml:
 // 1. the requestSchema api will be called by vscode-yaml extension to decide whether the schema can be handled by this
@@ -33,170 +18,6 @@ export interface KubernetesSchema {
 declare type YamlSchemaContributor = (schema: string,
                                        requestSchema: (resource: string) => string | undefined,
                                        requestSchemaContent: (uri: string) => string) => void;
-
-class KubernetesClusterSchemaHolder {
-    private definitions: { [key: string]: KubernetesSchema; } = {};
-    private schemaEnums: { [key: string]: { [key: string]: [string[]] }; };
-
-    public static async fromActiveCluster(kubectl: Kubectl): Promise<KubernetesClusterSchemaHolder> {
-        const holder = new KubernetesClusterSchemaHolder();
-        await holder.loadSchemaFromActiveCluster(kubectl, KUBERNETES_SCHEMA_ENUM_FILE);
-        return holder;
-    }
-
-    public static fallback(): KubernetesClusterSchemaHolder {
-        const holder = new KubernetesClusterSchemaHolder();
-        const fallbackSchema = util.loadJson(FALLBACK_SCHEMA_FILE);
-        holder.loadSchemaFromRaw(fallbackSchema, KUBERNETES_SCHEMA_ENUM_FILE);
-        return holder;
-    }
-
-    private async loadSchemaFromActiveCluster(kubectl: Kubectl, schemaEnumFile?: string): Promise<void> {
-        const clusterSwagger = await swagger.getClusterSwagger(kubectl);
-        const schemaRaw = succeeded(clusterSwagger) ? this.definitionsObject(clusterSwagger.result) : util.loadJson(FALLBACK_SCHEMA_FILE);
-        this.loadSchemaFromRaw(schemaRaw, schemaEnumFile);
-    }
-
-    private definitionsObject(swagger: any): any {
-        return {
-            definitions: swagger.definitions
-        };
-    }
-
-    private loadSchemaFromRaw(schemaRaw: any, schemaEnumFile?: string): void {
-        this.schemaEnums = schemaEnumFile ? util.loadJson(schemaEnumFile) : {};
-        const definitions = schemaRaw.definitions;
-        for (const name of Object.keys(definitions)) {
-            this.saveSchemaWithManifestStyleKeys(name, definitions[name]);
-        }
-
-        for (const schema of _.values(this.definitions) ) {
-            if (schema.properties) {
-                // the swagger schema has very short description on properties, we need to get the actual type of
-                // the property and provide more description/properties details, just like `kubernetes explain` do.
-                _.each(schema.properties, (propVal, propKey) => {
-                    if (schema.kind && propKey === 'kind') {
-                        propVal.markdownDescription = this.getMarkdownDescription(schema.kind, undefined, schema, true);
-                        return;
-                    }
-
-                    const currentPropertyTypeRef = propVal.$ref || (propVal.items ? propVal.items.$ref : undefined);
-                    if (_.isString(currentPropertyTypeRef)) {
-                        const id = getNameInDefinitions(currentPropertyTypeRef);
-                        const propSchema = this.lookup(id);
-                        if (propSchema) {
-                            propVal.markdownDescription = this.getMarkdownDescription(propKey, propVal, propSchema);
-                        }
-                    } else {
-                        propVal.markdownDescription = this.getMarkdownDescription(propKey, propVal, undefined);
-                    }
-                });
-
-                // fix on each node in properties for $ref since it will directly reference '#/definitions/...'
-                // we need to convert it into schema like 'kubernetes://schema/...'
-                // we need also an array to collect them since we need to get schema from _definitions, at this point, we have
-                // not finished the process of add schemas to _definitions, call patchOnRef will fail for some cases.
-                this.replaceDefinitionRefsWithYamlSchemaUris(schema.properties);
-                this.loadEnumsForKubernetesSchema(schema);
-            }
-        }
-    }
-
-    // get kubernetes schema by the key
-    public lookup(key: string): KubernetesSchema | undefined {
-        return key ? this.definitions[key.toLowerCase()] : undefined;
-    }
-
-    /**
-     * Save the schema object in swagger json to schema map.
-     *
-     * @param {string} name the property name in definition node of swagger json
-     * @param originalSchema the origin schema object in swagger json
-     */
-    private saveSchemaWithManifestStyleKeys(name: string, originalSchema: any): void {
-        if (isGroupVersionKindStyle(originalSchema)) {
-            // if the schema contains 'x-kubernetes-group-version-kind'. then it is a direct kubernetes manifest,
-            getManifestStyleSchemas(originalSchema).forEach((schema: KubernetesSchema) =>  {
-                this.saveSchema({
-                    name,
-                    ...schema
-                });
-            });
-
-        } else {
-            // if x-kubernetes-group-version-kind cannot be found, then it is an in-direct schema refereed by
-            // direct kubernetes manifest, eg: io.k8s.kubernetes.pkg.api.v1.PodSpec
-            this.saveSchema({
-                name,
-                ...originalSchema
-            });
-        }
-    }
-
-    // replace schema $ref with values like 'kubernetes://schema/...'
-    private replaceDefinitionRefsWithYamlSchemaUris(node: any): void {
-        if (!node) {
-            return;
-        }
-        if (_.isArray(node)) {
-            for (const subItem of <any[]>node) {
-                this.replaceDefinitionRefsWithYamlSchemaUris(subItem);
-            }
-        }
-        if (!_.isObject(node)) {
-            return;
-        }
-        for (const key of Object.keys(node)) {
-            this.replaceDefinitionRefsWithYamlSchemaUris(node[key]);
-        }
-
-        if (_.isString(node.$ref)) {
-            const name = getNameInDefinitions(node.$ref);
-            const schema = this.lookup(name);
-            if (schema) {
-                // replacing $ref
-                node.$ref = util.makeKubernetesUri(schema.name);
-            }
-        }
-    }
-
-    // add enum field for pre-defined enums in schema-enums json file
-    private loadEnumsForKubernetesSchema(node: KubernetesSchema) {
-        if (node.properties && this.schemaEnums[node.name]) {
-            _.each(node.properties, (propSchema, propKey) => {
-                if (this.schemaEnums[node.name][propKey]) {
-                    propSchema.enum = this.schemaEnums[node.name][propKey];
-                }
-            });
-        }
-    }
-
-    // save the schema to the _definitions
-    private saveSchema(schema: KubernetesSchema): void {
-        if (schema.name) {
-            this.definitions[schema.name.toLowerCase()] = schema;
-        }
-        if (schema.id) {
-            this.definitions[schema.id.toLowerCase()] = schema;
-        }
-    }
-
-    // get the markdown format of document for the current property and the type of current property
-    private getMarkdownDescription(currentPropertyName: string, currentProperty: any, targetSchema: any, isKind = false): string {
-        if (isKind) {
-            return formatComplex(currentPropertyName, targetSchema.description, undefined, targetSchema.properties);
-        }
-        if (!targetSchema) {
-            return formatOne(currentPropertyName, formatType(currentProperty), currentProperty.description);
-        }
-        const properties = targetSchema.properties;
-        if (properties) {
-            return formatComplex(currentPropertyName, currentProperty ? currentProperty.description : "",
-                targetSchema.description, properties);
-        }
-        return currentProperty ? currentProperty.description : (targetSchema ? targetSchema.description : "");
-    }
-}
 
 let schemas: BackgroundContextCache<KubernetesClusterSchemaHolder> | null = null;
 
@@ -271,64 +92,6 @@ function requestYamlSchemaContentCallback(uri: string): string | undefined {
     }
     return undefined;
 
-}
-
-/**
- * Tell whether or not the swagger schema is a kubernetes manifest schema, a kubernetes manifest schema like Service
- * should have `x-kubernetes-group-version-kind` node.
- *
- * @param originalSchema the origin schema object in swagger json
- * @return whether or not the swagger schema is
- */
-function isGroupVersionKindStyle(originalSchema: any): boolean {
-    return originalSchema[KUBERNETES_GROUP_VERSION_KIND] && originalSchema[KUBERNETES_GROUP_VERSION_KIND].length;
-}
-
-/**
- * Process on kubernetes manifest schemas, for each selector in x-kubernetes-group-version-kind,
- * extract apiVersion and kind and make a id composed by apiVersion and kind.
- *
- * @param originalSchema the origin schema object in swagger json
- * @returns {KubernetesSchema[]} an array of schemas for the same manifest differentiated by id/apiVersion/kind;
- */
-function getManifestStyleSchemas(originalSchema: any): KubernetesSchema[] {
-    const schemas = Array.of<KubernetesSchema>();
-    // eg: service, pod, deployment
-    const groupKindNode = originalSchema[KUBERNETES_GROUP_VERSION_KIND];
-
-    // delete 'x-kubernetes-group-version-kind' since it is not a schema standard, it is only a selector
-    delete originalSchema[KUBERNETES_GROUP_VERSION_KIND];
-
-    groupKindNode.forEach((groupKindNode: any) => {
-        const gvk = util.parseKubernetesGroupVersionKind(groupKindNode);
-        if (!gvk) {
-            return;
-        }
-
-        const { id, apiVersion, kind } = gvk;
-
-        // a direct kubernetes manifest has two reference keys: id && name
-        // id: apiVersion + kind
-        // name: the name in 'definitions' of schema
-        schemas.push({
-            id,
-            apiVersion,
-            kind,
-            ...originalSchema
-        });
-    });
-    return schemas;
-}
-
-// convert '#/definitions/com.github.openshift.origin.pkg.build.apis.build.v1.ImageLabel' to
-// 'com.github.openshift.origin.pkg.build.apis.build.v1.ImageLabel'
-function getNameInDefinitions ($ref: string): string {
-    const prefix = '#/definitions/';
-    if ($ref.startsWith(prefix)) {
-        return $ref.slice(prefix.length);
-    } else {
-        return prefix;
-    }
 }
 
 // find redhat.vscode-yaml extension and try to activate it to get the yaml contributor

--- a/tools/save-swagger-enums.js
+++ b/tools/save-swagger-enums.js
@@ -1,0 +1,308 @@
+const fs = require('fs');
+const download = require('download');
+const _ = require('lodash');
+
+const LATEST_SWAGGER_URL = 'https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json';  // TODO: master is not necessarily stable
+const LATEST_API_TYPES_GO_URL = 'https://raw.githubusercontent.com/kubernetes/kubernetes/master/staging/src/k8s.io/api/core/v1/types.go';
+
+const ENUMS_FILE = './schema/schema_enums.json';
+
+const GO_COMMENT_REGEX = /(\/\*([\s\S]*?)\*\/)|(\/\/(.*)$)/m;
+const GO_STRING_ALIAS_REGEX = /type\s+(\w+)\s+string/;
+const GO_STRUCT_DECL_REGEX = /type\s+(\w+)\s+struct\s{/;
+const GO_CONSTS_DECL_REGEX = /const\s+\(/;
+
+// goTypes[Full] is a Go source file ith declarations such as:
+//
+// type PersistentVolumeClaimVolumeSource struct {
+//     ClaimName string `json:"claimName" protobuf:"bytes,1,opt,name=claimName"`
+//     ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,2,opt,name=readOnly"`
+// }
+//
+// We are interested in constructs such as the following:
+//
+// type AzureDataDiskCachingMode string
+// type AzureDataDiskKind string
+
+// const (
+//     AzureDataDiskCachingNone      AzureDataDiskCachingMode = "None"
+//     AzureDataDiskCachingReadOnly  AzureDataDiskCachingMode = "ReadOnly"
+//     AzureDataDiskCachingReadWrite AzureDataDiskCachingMode = "ReadWrite"
+
+//     AzureSharedBlobDisk    AzureDataDiskKind = "Shared"
+//     AzureDedicatedBlobDisk AzureDataDiskKind = "Dedicated"
+//     AzureManagedDisk       AzureDataDiskKind = "Managed"
+// )
+
+// type AzureDiskVolumeSource struct {
+//     CachingMode *AzureDataDiskCachingMode `json:"cachingMode,omitempty" protobuf:"bytes,3,opt,name=cachingMode,casttype=AzureDataDiskCachingMode"`
+//     Kind *AzureDataDiskKind `json:"kind,omitempty" protobuf:"bytes,6,opt,name=kind,casttype=AzureDataDiskKind"`
+// }
+//
+// Note the `... protobuf:"...casttype=SOMETHING"` - this is our sign of an enum.  We can then
+// chase the SOMETHING to consts of the form VALUE_NAME SOMETHING = "VALUE".  For each of these,
+// VALUE is a legitimate value of the enum.
+
+function captureEnumValues(goTypesFull, swagger) {
+    const goTypes = goTypesFull.replace(GO_COMMENT_REGEX, '');
+    const goLines = goTypes.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+    return captureEnumValuesFrom(goLines, swagger);
+}
+
+function captureEnumValuesFrom(goLines, swaggerText) {
+    const possibleEnumTypes = [];
+    const enumValues = {};
+    const structEnumFields = {};
+
+    for (const cb of toCodeBlocks(goLines)) {
+        switch (cb.blockType) {
+            case 'possible-enum':
+                const aliasName = (GO_STRING_ALIAS_REGEX.exec(cb.content[0]))[1];
+                possibleEnumTypes.push(aliasName);
+                enumValues[aliasName] = [];
+                break;
+            case 'struct':
+                const structName = (GO_STRUCT_DECL_REGEX.exec(cb.content[0]))[1];
+                structEnumFields[structName] = parseEnumFields(cb.content, possibleEnumTypes);
+                break;
+            case 'consts':
+                parseEnumValues(cb.content, enumValues);
+                break;
+        }
+    }
+
+    const flattenedMap = keyByStructNameAndFieldSchemaName(structEnumFields, enumValues);
+
+    const enums = associateEnumValuesToSwaggerTypesAndProperties(swaggerText, flattenedMap);
+
+    return enums;
+}
+
+function keyByStructNameAndFieldSchemaName(structEnumFields, enumValues) {
+    const flattenedMap = {};
+
+    for (const structName of Object.keys(structEnumFields)) {
+        const enumFields = structEnumFields[structName];
+        for (const field of enumFields) {
+            if (isFieldOfEnumType(field, enumValues)) {
+                flattenedMap[flatKeyOf(structName, field.schemaName)] = {
+                    enums: enumValues[field.type]
+                };
+            }
+        }
+    }
+
+    return flattenedMap;
+}
+
+function flatKeyOf(structName, fieldSchemaName) {
+    return `${structName}!${fieldSchemaName}`;
+}
+
+function isFieldOfEnumType(field, enumValues) {
+    return enumValues[field.type] && enumValues[field.type].length > 0;
+}
+
+function associateEnumValuesToSwaggerTypesAndProperties(swaggerText, map) {
+    const swaggerObj = JSON.parse(swaggerText);
+
+    // The following map will eventually be of the form:
+    //
+    // {
+    //   "io.k8s.api.core.v1.Widget": {  // k8s schema type name
+    //     "foo": [                      // property name that should be enum but isn't in the Swagger
+    //       "None",                     // permitted values of the property
+    //       "ReadOnly",
+    //       "ReadWrite"
+    //     ],
+    //     "bar": [                      // another property within the same type
+    //       "Shared",
+    //       "Dedicated"
+    //     ]
+    //   },
+    //   "io.k8s.api.core.v1.Gadget": {  // and now another type
+    //     "status": [
+    //       "True",
+    //       "False"
+    //     ]
+    //   }...
+    //
+    // This is our destination JSON format which the YAML schematiser will munge with the cluster's
+    // Swagger document to produce an enumified Swagger document.
+
+    const enums = {};
+
+    _.each(swaggerObj.definitions, (definitions, qualifiedTypeName) => {
+        const shortTypeName = qualifiedTypeName.split('.').slice(-1)[0];
+        enums[qualifiedTypeName] = {};
+        _.each(definitions.properties, (propertySchema, propertyName) => {
+            propertyKey = flatKeyOf(shortTypeName, propertyName);
+            if (map[propertyKey]) {
+                if (!propertySchema.enum) {
+                    propertySchema.enum = map[propertyKey].enums;
+                    enums[qualifiedTypeName][propertyName] = propertySchema.enum;
+                }
+            }
+        });
+        if (Object.keys(enums[qualifiedTypeName]).length === 0) {
+            delete enums[qualifiedTypeName];
+        }
+    });
+
+    return enums;
+}
+
+function* toCodeBlocks(goLines) {
+    for (let i = 0; i < goLines.length; ++i) {
+        const line = goLines[i];
+
+        if (isPossibleEnumType(line)) {
+            yield { blockType: 'possible-enum', content: [line] };
+            continue;
+        }
+
+        if (isStructStart(line)) {
+            const { endIndex, content } = readToStructEnd(goLines, i);
+            i = endIndex;
+            yield { blockType: 'struct', content };
+            continue;
+        }
+
+        if (isConstBlockStart(line)) {
+            const { endIndex, content } = readToConstBlockEnd(goLines, i);
+            i = endIndex;
+            yield { blockType: 'consts', content };
+            continue;
+        }
+    }
+}
+
+function isPossibleEnumType(goLine) {
+    const m = GO_STRING_ALIAS_REGEX.exec(goLine.trim());
+    if (m && m.length > 1) {
+        return true;
+    }
+    return false;
+}
+
+function isStructStart(goLine) {
+    return GO_STRUCT_DECL_REGEX.test(goLine);
+}
+
+function isConstBlockStart(goLine) {
+    return GO_CONSTS_DECL_REGEX.test(goLine);
+}
+
+function readToStructEnd(goLines, startIndex) {
+    const content = [];
+    for (let i = startIndex; i < goLines.length; ++i) {
+        const line = goLines[i];
+        content.push(line);
+        if (line === '}') {
+            return { endIndex: i, content };
+        }
+    }
+    return { endIndex: 9999999, content };  // TODO: less ugly
+}
+
+// TODO: deduplicate
+function readToConstBlockEnd(goLines, startIndex) {
+    const content = [];
+    for (let i = startIndex; i < goLines.length; ++i) {
+        const line = goLines[i];
+        content.push(line);
+        if (line === ')') {
+            return { endIndex: i, content };
+        }
+    }
+    return { endIndex: 9999999, content };  // TODO: less ugly
+}
+
+function parseEnumFields(structLines, knownEnumTypes) {
+    const enumFields = [];
+    for (const line of structLines.slice(1, structLines.length - 1)) {
+        if (line.indexOf('metav1.TypeMeta') >= 0) {
+            continue;
+        }
+        const field = parseFieldInfo(line);
+        if (knownEnumTypes.indexOf(field.type) >= 0) {
+            enumFields.push(field);
+        }
+    }
+    return enumFields;
+}
+
+function parseFieldInfo(structLine) {
+    const bits = structLine.split(' ').filter((s) => s && s.length > 0);  // [ NAME, *TYPE, `ATTR1, ATTR2 ... ATTRn` ]
+    const firstAttrIndex = bits.findIndex((s) => s.startsWith('`'));
+    const fieldName = bits[0];
+    const fieldType = firstAttrIndex === 2 ? bits[1] : undefined;
+    const attrsQ = structLine.substring(structLine.indexOf('`')).trim();
+    const attrs = attrsQ.substr(1, attrsQ.length - 2);
+    const attrBits = attrs.split(' ');
+    const protobufAttr = attrBits.find((s) => s.startsWith('protobuf:'));
+    if (!protobufAttr) {
+        return { fieldName, schemaName: undefined, type: fieldType };
+    }
+    const protobufValueQ = protobufAttr.substring(protobufAttr.indexOf(':') + 1);  // of the form '"bytes,6,opt,name=kind,casttype=AzureDataDiskKind"' (note the double quotes!)
+    const protobufValue = protobufValueQ.substr(1, protobufValueQ.length - 2);
+    const pbBits = protobufValue.split(',');
+    const schemaName = getProtobufMetadata(pbBits, 'name');
+    const schemaType = getProtobufMetadata(pbBits, 'casttype');
+    return {
+        fieldName,
+        schemaName,
+        type: schemaType || fieldType
+    };
+}
+
+function getProtobufMetadata(pbBits, key) {
+    const prefix = `${key}=`;
+    const bit = pbBits.find((s) => s.startsWith(prefix));
+    if (!bit) {
+        return undefined;
+    }
+    const value = bit.substring(prefix.length);
+    return value;
+}
+
+const GO_ENUM_VALUE_CONST_REGEX = /(\w+)\s+(\w+)\s+=\s+"(\w+)"/;
+
+function parseEnumValues(constsLines, enumValues) {
+    for (const line of constsLines.slice(1, constsLines.length - 2)) {
+        // of the form 'AzureSharedBlobDisk    AzureDataDiskKind = "Shared"'
+        const bits = GO_ENUM_VALUE_CONST_REGEX.exec(line);
+        if (!bits || bits.length < 4) {
+            continue;
+        }
+        const typeName = bits[2];
+        const enumValue = bits[3];
+        if (typeName === 'string') {
+            continue;
+        }
+        enumValues[typeName].push(enumValue);
+    }
+}
+
+function downloadToMemory(url) {
+    return download(url).then(buf => buf.toString('utf-8'));
+}
+
+function saveSwaggerEnumsFrom(goTypes, swagger) {
+    const enumTypes = captureEnumValues(goTypes, swagger);
+    const enumTypesJSONText = JSON.stringify(enumTypes, null, 2);
+    fs.writeFileSync(ENUMS_FILE, enumTypesJSONText);
+}
+
+function saveSwaggerEnums() {
+    return downloadToMemory(LATEST_API_TYPES_GO_URL).then(
+        (goTypes) => downloadToMemory(LATEST_SWAGGER_URL).then(
+            (swagger) => saveSwaggerEnumsFrom(goTypes, swagger)
+        )
+    );
+}
+
+console.log('Saving all the things...');
+saveSwaggerEnums().then(() => {
+    console.log('Saved');
+});


### PR DESCRIPTION
From k8s 1.15, the cluster Swagger includes custom resource types and their schemas if provided (subject to a feature gate in 1.15).  To take advantage of this, however, we need to fetch the schema definitions from the active cluster instead of using a local JSON file.

This is conceptually simple, but in practice is drags in a whole bunch of complexity.  `vscode-yaml` requests schemas synchronously, so we need to fetch schemas in the background, and present our best effort when a document opens.  The user can change clusters, or deploy/update CRDs, both of which affect the schemas available, and both of which can happen behind our back.  And even just fetching the Swagger requires some `kubectl proxy` which needed some more componentising.

So this PR brings in a subsystem for tracking the active cluster, and for asynchronously caching per-cluster data while serving it synchronously.  (This may also be useful for other things such as cluster type telemetry which currently has an ad hoc solution.)  That is the bulk of the PR; there are also some follow-on changes for the YAML schema stuff to use this cache instead of the fixed local file, though a lot of this is moving the schema-holder code to a new file rather than making substantive changes.  Finally, there is also a tool for creating the schema enums file, based closely on Andy's gulp task but reworked to be hopefully more quickly understandable and easier to maintain.  (And an updated enums file which is not very interesting.)

Fixes #447.