### PR TITLE
Fix annoying double autocomplete bug

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -16,7 +16,6 @@
     // symbols that are auto closed when typing
     "autoClosingPairs": [
         ["{{", "}}"],
-        ["{{-", "-}}"],
         ["{", "}"],
         ["[", "]"],
         ["(", ")"],


### PR DESCRIPTION
Removed `{{-` `autoClosingPairs`
Closes #571