### PR TITLE
Option to display logs in the terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Visual Studio Code Kubernetes Tools
 [![Build Status](https://travis-ci.org/Azure/vscode-kubernetes-tools.svg?branch=master)](https://travis-ci.org/Azure/vscode-kubernetes-tools)
 
-The extension for developers building applications to run in Kubernetes clusters 
+The extension for developers building applications to run in Kubernetes clusters
 and for DevOps staff troubleshooting Kubernetes applications.
 
 Works with any Kubernetes anywhere (Azure, Minikube, AWS, GCP and more!).
@@ -205,6 +205,7 @@ Minikube tools to be installed and available on your PATH.
        * `vs-kubernetes.knownKubeconfigs` - An array of file paths of kubeconfig files that you want to be able to quickly switch between using the Set Kubeconfig command.
        * `vs-kubernetes.autoCleanupOnDebugTerminate` - The flag to control whether to auto cleanup the created deployment and associated pod by the command "Kubernetes: Debug (Launch)". The cleanup action occurs when it failed to start debug session or debug session terminated. If not specified, the extension will prompt for whether to clean up or not. You might choose not to clean up if you wanted to view pod logs, etc.
        * `vs-kubernetes.outputFormat` - The output format that you prefer to view Kubernetes manifests in. One of "yaml" or "json". Defaults to "yaml".
+       * `logsDisplay` - Where and how to display Kubernetes logs.  One of `webview` (display in a filterable HTML view) and `terminal` (run the command in the VS Code terminal)
    * `vsdocker.imageUser` - Image prefix for the container images e.g. 'docker.io/brendanburns'
    * `checkForMinikubeUpgrade` - On extension startup, notify if a minikube upgrade is available. Defaults to true.
    * `disable-lint` - Disable all linting of Kubernetes files

--- a/package.json
+++ b/package.json
@@ -236,6 +236,14 @@
                             ],
                             "description": "Container image build tool. By default, Docker."
                         },
+                        "logsDisplay": {
+                            "type": "string",
+                            "enum": [
+                                "terminal",
+                                "webview"
+                            ],
+                            "description": "Where to display Kubernetes pod logs. Default is webview"
+                        },
                         "vs-kubernetes.python-autodetect-remote-root": {
                             "type": "boolean",
                             "description": "If true will try to automatically get the root location of the source code in the container (Python)."
@@ -264,6 +272,7 @@
                         "vs-kubernetes.nodejs-remote-root": "",
                         "vs-kubernetes.nodejs-debug-port": 9229,
                         "checkForMinikubeUpgrade": true,
+                        "logsDisplay": "webview",
                         "imageBuildTool": "Docker"
                     }
                 },

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -12,6 +12,11 @@ export enum KubectlVersioning {
     Infer = 2,
 }
 
+export enum LogsDisplay {
+    Webview = 1,
+    Terminal = 2,
+}
+
 export async function addPathToConfig(configKey: string, value: string): Promise<void> {
     await setConfigValue(configKey, value);
 }
@@ -176,6 +181,11 @@ export function getDisableLint(): boolean {
 export function getDisabledLinters(): string[] {
     const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY);
     return config['disable-linters'] as string[] || [];
+}
+
+export function logsDisplay(): LogsDisplay {
+    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY);
+    return (config['logsDisplay'] === 'terminal') ? LogsDisplay.Terminal : LogsDisplay.Webview;
 }
 
 // nodejs debugger attach  options

--- a/src/components/kubectl/logs.ts
+++ b/src/components/kubectl/logs.ts
@@ -9,6 +9,7 @@ import { LogsPanel } from '../../components/logs/logsWebview';
 import { ContainerContainer } from '../../utils/containercontainer';
 import { ChildProcess } from 'child_process';
 import { ClusterExplorerResourceNode } from '../clusterexplorer/node';
+import { logsDisplay, LogsDisplay } from '../config/config';
 
 export enum LogsDisplayMode {
     Show,
@@ -92,6 +93,20 @@ async function getLogsForContainer(
 
     if (containerName) {
         cmd = `${cmd} --container=${containerName}`;
+    }
+
+    if (displayMode === LogsDisplayMode.Follow) {
+        cmd = `${cmd} -f`;
+    }
+
+    if (logsDisplay() === LogsDisplay.Terminal) {
+        if (displayMode === LogsDisplayMode.Follow) {
+            const title = `Logs: ${containerResource.kindName}${containerName ? ('/' + containerName) : ''}`;
+            kubectl.invokeInNewTerminal(cmd, title);
+        } else {
+            kubectl.invokeInSharedTerminal(cmd);
+        }
+        return;
     }
 
     const resource = `${containerResource.namespace}/${containerResource.kindName}`;

--- a/src/components/logs/logsWebview.ts
+++ b/src/components/logs/logsWebview.ts
@@ -22,10 +22,12 @@ export class LogsPanel extends WebPanel {
 
     public addContent(content: string) {
         this.content += content;
-        this.panel.webview.postMessage({
-            command: 'content',
-            text: content,
-        });
+        if (this.canProcessMessages) {
+            this.panel.webview.postMessage({
+                command: 'content',
+                text: content,
+            });
+        }
     }
 
     protected update() {

--- a/src/components/webpanel/webpanel.ts
+++ b/src/components/webpanel/webpanel.ts
@@ -4,6 +4,7 @@ export abstract class WebPanel {
     private disposables: vscode.Disposable[] = [];
     protected content: string;
     protected resource: string;
+    private hasLivePanel = true;
 
     protected static createOrShowInternal<T extends WebPanel>(content: string, resource: string, viewType: string, title: string, currentPanels: Map<string, T>, fn: (p: vscode.WebviewPanel, content: string, resource: string) => T): T {
         const column = vscode.window.activeTextEditor ? vscode.window.activeTextEditor.viewColumn : undefined;
@@ -57,6 +58,8 @@ export abstract class WebPanel {
     protected dispose<T extends WebPanel>(currentPanels: Map<string, T>) {
         currentPanels.delete(this.resource);
 
+        this.hasLivePanel = false;
+
         this.panel.dispose();
 
         while (this.disposables.length) {
@@ -65,6 +68,10 @@ export abstract class WebPanel {
                 x.dispose();
             }
         }
+    }
+
+    public get canProcessMessages(): boolean {
+        return this.hasLivePanel;
     }
 
     protected abstract update(): void;


### PR DESCRIPTION
We've had some usability complaints and bug reports relating to displaying logs in a web view.  Ideally we'd like to address these issues to make the web view maximally useful for all our users, but this is a non-trivial piece of work.  It looks like the people who have raised issues were happy with the terminal-based display.  So as an interim measure this PR provides a settings option to revert to the old terminal-based display.  The web view remains the default, and we can and should continue working on it to address the issues our users have raised.