### PR TITLE
Fix starting multiple Swagger downloads

### DIFF
--- a/src/yaml-support/yaml-schema.ts
+++ b/src/yaml-support/yaml-schema.ts
@@ -42,6 +42,10 @@ function requestYamlSchemaUriCallback(resource: string): string | undefined {
     if (textEditor) {
         const yamlDocs = yamlLocator.getYamlDocuments(textEditor.document);
         const choices: string[] = [];
+        const activeSchema = schemas && schemas.active();
+        if (!activeSchema) {
+            return undefined;
+        }
         yamlDocs.forEach((doc) => {
             // if the yaml document contains apiVersion and kind node, it will report it is a kubernetes yaml
             // file
@@ -53,7 +57,7 @@ function requestYamlSchemaUriCallback(resource: string): string | undefined {
                 if (apiVersion && kind) {
                     const qualifiedKind = apiVersion + GROUP_VERSION_KIND_SEPARATOR + kind;
                     // Check we have a schema here - returning undefined from the schema content callback reports an error
-                    if (schemas && schemas.active().lookup(qualifiedKind)) {
+                    if (activeSchema.lookup(qualifiedKind)) {
                         choices.push(qualifiedKind);
                     }
                 }


### PR DESCRIPTION
We have a race condition in the per-cluster Swagger system.  Consider what happens when a document is loaded and triggers a series of requests for schemas.

* If the context name is not yet known, the bundled fallback Swagger is used.  This results in multiple lookups to the fallback Swagger (one per type in the document) which is fine.  Meanwhile, the context name is determined in the background, and when it arrives, we kick off a request to the cluster to get its Swagger.  The next time a document needs schema lookup it uses the now-available cached Swagger and all is well.

* But if the context name _is_ known (but the Swagger is not yet in the cache), then the cycle works a bit differently.  The first type name triggers a cache check for the context name.  The Swagger is not in the cache, so we start a background operation to download the cluster Swagger, and return the fallback Swagger as a placeholder (because the YAML extension needs the schema to be available synchronously).  This is fine.  But then we move onto the _second_ type name.  This also triggers a cache check for the context name.  Well, the Swagger is still not in the cache, so we start another background operation to download the cluster Swagger.  And so on until we have kicked off a download operation for every type in the document!

The fix has two parts.  The main thing is to track which contexts are already working on populating the cache (i.e. downloading their Swagger).  If we get another 'update cache' request for a context that's already doing it, we no-op it.  So there will be only one concurrent download request per context.  A second, though minor, thing is not to check the active schema on every YAML (sub)document in a text file - we run through the subdocs synchronously so it can't change within the loop - this reduces the number of calls that trigger a cache check.

Fixes #619.