### PR TITLE
Avoid polluting Array prototype

### DIFF
--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -12,8 +12,13 @@ declare global {
     }
 }
 
+function choose<T, U>(this: T[], fn: (t: T) => U | undefined): U[] {
+    return this.map(fn).filter((u) => u !== undefined).map((u) => u!);
+}
+
 if (!Array.prototype.choose) {
-    Array.prototype.choose = function<T, U>(this: T[], fn: (t: T) => U | undefined): U[] {
-        return this.map(fn).filter((u) => u !== undefined).map((u) => u!);
-    };
+    Object.defineProperty(Array.prototype, 'choose', {
+        enumerable: false,
+        value: choose
+    });
 }


### PR DESCRIPTION
Fixes #613 by making `choose` method non-enumerable.

cc @MikeRalphson in case you want to sanity check this!