### PR TITLE
Prevent triple closing brackets

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -15,7 +15,6 @@
     ],
     // symbols that are auto closed when typing
     "autoClosingPairs": [
-        ["{{", "}}"],
         ["{", "}"],
         ["[", "]"],
         ["(", ")"],


### PR DESCRIPTION
Typing a `{` in a helm template would automatically add a closing bracket resulting in `{}`, if you try to type another `{` bracket, that would result in `{{}}}` instead of the expected `{{}}`.