### PR TITLE
Fix error if kubectl path contains spaces

### DIFF
--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -285,13 +285,21 @@ function kubectlDone(context: Context): ShellHandler {
     };
 }
 
-async function baseKubectlPath(context: Context): Promise<string> {
+async function unquotedBaseKubectlPath(context: Context): Promise<string> {
     if (context.pathfinder) {
         return await context.pathfinder();
     }
     let bin = getToolPath(context.host, context.shell, 'kubectl');
     if (!bin) {
         bin = 'kubectl';
+    }
+    return bin;
+}
+
+async function baseKubectlPath(context: Context): Promise<string> {
+    let bin = await unquotedBaseKubectlPath(context);
+    if (bin && bin.includes(' ')) {
+        bin = `"${bin}"`;
     }
     return bin;
 }

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -80,8 +80,15 @@ function platform(): Platform {
     }
 }
 
-function concatIfBoth(s1: string | undefined, s2: string | undefined): string | undefined {
-    return s1 && s2 ? s1.concat(s2) : undefined;
+function concatIfSafe(homeDrive: string | undefined, homePath: string | undefined): string | undefined {
+    if (homeDrive && homePath) {
+        const safe = !homePath.toLowerCase().startsWith('\\windows\\system32');
+        if (safe) {
+            return homeDrive.concat(homePath);
+        }
+    }
+
+    return undefined;
 }
 
 function home(): string {
@@ -89,7 +96,7 @@ function home(): string {
         return shelljs.exec('wsl.exe echo ${HOME}').stdout.trim();
     }
     return process.env['HOME'] ||
-        concatIfBoth(process.env['HOMEDRIVE'], process.env['HOMEPATH']) ||
+        concatIfSafe(process.env['HOMEDRIVE'], process.env['HOMEPATH']) ||
         process.env['USERPROFILE'] ||
         '';
 }


### PR DESCRIPTION
If the path to `kubectl` contained spaces, we were throwing an error because we did not quote the path before composing the command string and passing it to the shell.

Fixes #637.