### PR TITLE
Arrays of enums need the enum on the item schema

### DIFF
--- a/src/yaml-support/schema-holder.ts
+++ b/src/yaml-support/schema-holder.ts
@@ -149,7 +149,11 @@ export class KubernetesClusterSchemaHolder {
         if (node.properties && this.schemaEnums[node.name]) {
             _.each(node.properties, (propSchema, propKey) => {
                 if (this.schemaEnums[node.name][propKey]) {
-                    propSchema.enum = this.schemaEnums[node.name][propKey];
+                    if (propSchema.type === "array" && propSchema.items) {
+                        propSchema.items.enum = this.schemaEnums[node.name][propKey];
+                    } else {
+                        propSchema.enum = this.schemaEnums[node.name][propKey];
+                    }
                 }
             });
         }


### PR DESCRIPTION
The Kubernetes Swagger does not include enum values.  To provide better code completion, we try to identify enum-ish types in the Kubernetes Go source code, create a file of those, and apply them to the relevant properties in the Swagger at run time.

However, we had a bug where if the schema specified an _array_ of the enumerated type, we were incorrectly applying the enum constraint to the _array itself_ rather than to the _items of the array_.  This led to a very confusing wiggly along the lines of `Value is not accepted. Valid values: "<the very thing that was in the YAML>".` because we were looking at the array and going "well, this array object is clearly _not_ a member of this set of strings."

Fortunately, this only affects two places, `NamespaceSpec.finalizers` and `ResourceQuotaSpec.scopes`; unfortunately, the first of those bit one of our customers and contributors.

The fix is simply to detect if the property being munged is of type `array` and if so apply the `enum` constraint to its `items` attribute.

Fixes #641  