### PR TITLE
Telemetrise more info about cluster type inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ This extension collects telemetry data to help us build a better experience for 
 * Which commands are executed, and whether they are executed against an Azure, Minikube or other type of cluster.
 * For the `Create Cluster` and `Add Existing Cluster` commands, the cluster type selected and the execution result (success/failure).
 
-We do not collect any information about image names, paths, etc. We collect cluster type information only if the cluster is Azure or Minikube. The extension respects the `telemetry.enableTelemetry` setting which you can learn more about in our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
+We do not collect any information about image names, paths, etc. We collect cluster type information only if the cluster is Azure or a local cluster such as Minikube. The extension respects the `telemetry.enableTelemetry` setting which you can learn more about in our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
 
 ## Running from source
 

--- a/src/telemetry-helper.ts
+++ b/src/telemetry-helper.ts
@@ -1,11 +1,12 @@
 import { reporter } from './telemetry';
 import { Kubectl } from './kubectl';
+import { ShellResult } from './shell';
 
 export function telemetrise(command: string, kubectl: Kubectl, callback: (...args: any[]) => any): (...args: any[]) => any {
     return (a) => {
-        clusterType(kubectl).then((ct) => {
+        clusterType(kubectl).then(([ct, ndr]) => {
             if (reporter) {
-                reporter.sendTelemetryEvent("command", { command: command, clusterType: ct });
+                reporter.sendTelemetryEvent("command", { command: command, clusterType: ct, nonDeterminationReason: ndr });
             }
         });
         return callback(a);
@@ -13,19 +14,38 @@ export function telemetrise(command: string, kubectl: Kubectl, callback: (...arg
 }
 
 export enum ClusterType {
-    Unknown = 0,
+    Unassigned = 0,  // This *should* be impossible to see, but tracking it for the case where something has been incorrectly 0-initialised
+    Indeterminate,
     Azure,
     Minikube,
+    Local,
+    FailedLocal,
     Other
 }
 
+export enum NonDeterminationReason {
+    Unassigned = 0,  // This *should* be impossible to see, but tracking it for the case where something has been incorrectly 0-initialised
+    None,
+    GetCurrentContextError,
+    GetClusterInfoFailed,
+    ConnectionRefused,
+    ConnectionTimeout,
+    ConnectionOtherError,
+    CredentialsExecError,
+    CredentialsOtherError,
+    GetClusterInfoOtherError,
+    NoMasterInClusterInfo,
+    NonAzureMasterURL
+}
+
 let latestContextName: string | null;
-let cachedClusterType: ClusterType = ClusterType.Unknown;
-const knownClusters: any = {};
+let cachedClusterType: ClusterType = ClusterType.Indeterminate;
+let cachedReason = NonDeterminationReason.None;
+const knownClusters: { [key: string]: [ClusterType, NonDeterminationReason] } = {};
 
 export function invalidateClusterType(newContext: string | undefined, kubectl?: Kubectl): void {
     latestContextName = newContext || null;
-    cachedClusterType = ClusterType.Unknown;
+    cachedClusterType = ClusterType.Indeterminate;
     if (kubectl) {
         setImmediate(() => {
             try {
@@ -37,73 +57,165 @@ export function invalidateClusterType(newContext: string | undefined, kubectl?: 
     }
 }
 
-async function clusterType(kubectl: Kubectl): Promise<string> {
-    if (cachedClusterType === ClusterType.Unknown) {
+async function clusterType(kubectl: Kubectl): Promise<[string, string]> {
+    if (cachedClusterType === ClusterType.Indeterminate || cachedClusterType === ClusterType.Unassigned) {
         await loadCachedClusterType(kubectl);
     }
 
-    switch (cachedClusterType) {
+    return [telemetryNameOf(cachedClusterType), telemetryReasonOf(cachedReason)];
+}
+
+function telemetryNameOf(clusterType: ClusterType): string {
+    switch (clusterType) {
         case ClusterType.Azure:
             return 'azure';
         case ClusterType.Minikube:
             return 'minikube';
+        case ClusterType.Local:
+            return 'local_non_minikube';
+        case ClusterType.FailedLocal:
+            return 'local_unreachable';
         case ClusterType.Other:
             return 'other';
-        default:
+        case ClusterType.Indeterminate:
             return 'indeterminate';
+        case ClusterType.Unassigned:
+            return 'internal_k8s_extension_error';
+    }
+}
+
+function telemetryReasonOf(reason: NonDeterminationReason): string {
+    switch (reason) {
+        case NonDeterminationReason.None:
+            return '';
+        case NonDeterminationReason.GetCurrentContextError:
+            return 'error_getting_current_context';
+        case NonDeterminationReason.GetClusterInfoFailed:
+            return 'error_calling_kubectl_cluster_info';
+        case NonDeterminationReason.ConnectionRefused:
+            return 'cluster_connection_refused';
+        case NonDeterminationReason.ConnectionTimeout:
+            return 'cluster_connection_timeout';
+        case NonDeterminationReason.ConnectionOtherError:
+            return 'cluster_connection_misc_error';
+        case NonDeterminationReason.CredentialsExecError:
+            return 'cluster_credentials_exec_error';
+        case NonDeterminationReason.CredentialsOtherError:
+            return 'cluster_credentials_misc_error';
+        case NonDeterminationReason.GetClusterInfoOtherError:
+            return 'kubectl_cluster_info_misc_error';
+        case NonDeterminationReason.NoMasterInClusterInfo:
+            return 'no_master_in_cluster_info';
+        case NonDeterminationReason.NonAzureMasterURL:
+            return 'master_url_not_recognised';
+        case NonDeterminationReason.Unassigned:
+            return 'internal_k8s_extension_error';
     }
 }
 
 async function loadCachedClusterType(kubectl: Kubectl) {
     if (latestContextName && knownClusters[latestContextName]) {
-        cachedClusterType = knownClusters[latestContextName];
+        [cachedClusterType, cachedReason] = knownClusters[latestContextName];
     }
     else {
-        cachedClusterType = await inferCurrentClusterType(kubectl);
+        [cachedClusterType, cachedReason] = await inferCurrentClusterType(kubectl);
         if (latestContextName) {
-            knownClusters[latestContextName] = cachedClusterType;
+            knownClusters[latestContextName] = [cachedClusterType, cachedReason];
         }
     }
 }
 
-async function inferCurrentClusterType(kubectl: Kubectl): Promise<ClusterType> {
+async function inferCurrentClusterType(kubectl: Kubectl): Promise<[ClusterType, NonDeterminationReason]> {
     if (!latestContextName) {
         const ctxsr = await kubectl.invokeAsync('config current-context');
         if (ctxsr && ctxsr.code === 0) {
             latestContextName = ctxsr.stdout.trim();
         } else {
-            return ClusterType.Other;  // something is terribly wrong; we don't want to retry
+            return [ClusterType.Other, NonDeterminationReason.GetCurrentContextError];  // something is terribly wrong; we don't want to retry
         }
     }
 
     if (latestContextName === 'minikube') {
-        return ClusterType.Minikube;
+        return [ClusterType.Minikube, NonDeterminationReason.None];
     }
 
     const cisr = await kubectl.invokeAsync('cluster-info');
     if (!cisr || cisr.code !== 0) {
-        return ClusterType.Unknown;
+        return [inferClusterTypeFromError(cisr), diagnoseKubectlClusterInfoError(cisr)];
     }
     const masterInfos = cisr.stdout.split('\n')
                                    .filter((s) => s.indexOf('master is running at') >= 0);
 
     if (masterInfos.length === 0) {
-        return ClusterType.Other;  // something is terribly wrong; we don't want to retry
+        return [ClusterType.Other, NonDeterminationReason.NoMasterInClusterInfo];  // something is terribly wrong; we don't want to retry
     }
 
     const masterInfo = masterInfos[0];
     if (masterInfo.indexOf('azmk8s.io') >= 0 || masterInfo.indexOf('azure.com') >= 0) {
-        return ClusterType.Azure;
+        return [ClusterType.Azure, NonDeterminationReason.None];
     }
 
     if (latestContextName) {
         const gcsr = await kubectl.invokeAsync(`config get-contexts ${latestContextName}`);
         if (gcsr && gcsr.code === 0) {
             if (gcsr.stdout.indexOf('minikube') >= 0) {
-                return ClusterType.Minikube;  // It's pretty heuristic, so don't spend time parsing the table
+                return [ClusterType.Minikube, NonDeterminationReason.None];  // It's pretty heuristic, so don't spend time parsing the table
             }
         }
     }
 
-    return ClusterType.Other;
+    // TODO: validate this
+    if (masterInfo.indexOf('localhost') >= 0 || masterInfo.indexOf('127.0.0.1') >= 0) {
+        return [ClusterType.Local, NonDeterminationReason.None];
+    }
+
+    return [ClusterType.Other, NonDeterminationReason.NonAzureMasterURL];
+}
+
+function inferClusterTypeFromError(sr: ShellResult | undefined): ClusterType {
+    if (!sr || sr.code === 0 || !sr.stderr) {
+        return ClusterType.Indeterminate;  // shouldn't be calling us in this case!
+    }
+
+    const errorText = sr.stderr.toLowerCase();
+    if (errorText.includes('dial tcp localhost') || errorText.includes('dial tcp 127.0.0.1')) {
+        return ClusterType.FailedLocal;
+    }
+
+    return ClusterType.Indeterminate;
+}
+
+function diagnoseKubectlClusterInfoError(sr: ShellResult | undefined): NonDeterminationReason {
+    if (!sr) {
+        return NonDeterminationReason.GetClusterInfoFailed;
+    }
+
+    if (sr.code === 0) {
+        return NonDeterminationReason.None;
+    }
+
+    if (!sr.stderr || sr.stderr.length === 0) {
+        return NonDeterminationReason.GetClusterInfoOtherError;
+    }
+
+    const error = sr.stderr.toLowerCase();
+
+    if (error.includes('connectex:')) {
+        if (error.includes('actively refused')) {
+            return NonDeterminationReason.ConnectionRefused;
+        }
+        if (error.includes('did not properly response after a period of time')) {
+            return NonDeterminationReason.ConnectionTimeout;
+        }
+        return NonDeterminationReason.ConnectionOtherError;
+    }
+
+    if (error.includes('getting credentials')) {
+        if (error.includes('exec')) {
+            return NonDeterminationReason.CredentialsExecError;
+        }
+        return NonDeterminationReason.CredentialsOtherError;
+    }
+
+    return NonDeterminationReason.GetClusterInfoOtherError;
 }


### PR DESCRIPTION
Our current telemetry is reporting a lot of 'indeterminate' cluster types.  This should happen only when there is an error - if the cluster is not Azure or Minikube, we should be reporting 'other', not 'indeterminate.'

This PR adds a 'non-determination reason' field to the telemetry, which distinguishes the cases of connection failure (refusal or timeout), credentials error, other `kubectl cluster-info` error and miscellaneous unknown errors.  This will help us to diagnose telemetry problems so that we can get a better sense of the environments in which the extension is being used.

As Minikube is being supplemented for local development by tools such as Kind and Microk8s, this PR also adds a new cluster type of 'local.'  Again, we are not trying to snoop into what people are using, but getting a sense for the extent to which they are using the extension against local (fast response, development only) environments or remote ones (slow response, shared, possibly production or staging) so that we can prioritise and optimise future work.