### PR TITLE
Install latest version of Helm

### DIFF
--- a/src/components/installer/installer.ts
+++ b/src/components/installer/installer.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import * as https from 'https';
 import * as download from '../download/download';
 import * as fs from 'fs';
 import mkdirp = require('mkdirp');
@@ -7,9 +8,10 @@ import * as path from 'path';
 import * as unzipper from 'unzipper';
 import * as tar from 'tar';
 import { Shell, Platform } from '../../shell';
-import { Errorable, failed } from '../../errorable';
+import { Errorable, failed, succeeded } from '../../errorable';
 import { addPathToConfig, toolPathBaseKey, getUseWsl } from '../config/config';
 import { platformUrlString, formatBin } from './installationlayout';
+import { IncomingMessage } from 'http';
 
 enum ArchiveKind {
     Tar,
@@ -64,11 +66,39 @@ async function getStableKubectlVersion(): Promise<Errorable<string>> {
     return { succeeded: true, result: version };
 }
 
-export async function installHelm(shell: Shell): Promise<Errorable<null>> {
+async function getStableHelmVersion(): Promise<Errorable<string>> {
+    return new Promise<Errorable<string>>((resolve, _reject) => {
+        try {
+            const request = https.get('https://github.com/helm/helm/releases/latest', (r: IncomingMessage) => {
+                const location = r.headers.location;
+                if (location) {
+                    const locationBits = location.split('/');
+                    const version = locationBits[locationBits.length - 1];
+                    resolve({ succeeded: true, result: version });
+                } else {
+                    resolve({ succeeded: false, error: ['No location in response']});
+                }
+            });
+            request.on('error', (err) => resolve({ succeeded: false, error: [`${err}`]}));
+        }
+        catch (err) {
+            resolve({ succeeded: false, error: [`${err}`]});
+        }
+    });
+}
+
+const DEFAULT_HELM_VERSION = 'v3.0.0';
+
+export async function installHelm(shell: Shell, warn: (message: string) => void): Promise<Errorable<null>> {
     const tool = 'helm';
+    const latestVersionInfo = await getStableHelmVersion();
+    if (failed(latestVersionInfo)) {
+        warn(`Couldn't identify latest stable Helm: defaulting to ${DEFAULT_HELM_VERSION}. Error info: ${latestVersionInfo.error[0]}`);
+    }
+    const latestVersion = succeeded(latestVersionInfo) ? latestVersionInfo.result : DEFAULT_HELM_VERSION;
     const fileExtension = shell.isWindows() ? 'zip' : 'tar.gz';
     const archiveKind = shell.isWindows() ? ArchiveKind.Zip : ArchiveKind.Tar;
-    const urlTemplate = `https://get.helm.sh/helm-v3.0.0-{os_placeholder}-amd64.${fileExtension}`;
+    const urlTemplate = `https://get.helm.sh/helm-${latestVersion}-{os_placeholder}-amd64.${fileExtension}`;
     return await installToolFromArchive(tool, urlTemplate, shell, archiveKind);
 }
 

--- a/src/components/installer/installer.ts
+++ b/src/components/installer/installer.ts
@@ -68,7 +68,7 @@ export async function installHelm(shell: Shell): Promise<Errorable<null>> {
     const tool = 'helm';
     const fileExtension = shell.isWindows() ? 'zip' : 'tar.gz';
     const archiveKind = shell.isWindows() ? ArchiveKind.Zip : ArchiveKind.Tar;
-    const urlTemplate = `https://get.helm.sh/helm-v2.14.3-{os_placeholder}-amd64.${fileExtension}`;
+    const urlTemplate = `https://get.helm.sh/helm-v3.0.0-{os_placeholder}-amd64.${fileExtension}`;
     return await installToolFromArchive(tool, urlTemplate, shell, archiveKind);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1914,9 +1914,11 @@ export async function installDependencies() {
     const gotDraft = await draft.checkPresent(DraftCheckPresentMode.Silent);
     const gotMinikube = await minikube.checkPresent(MinikubeCheckPresentMode.Silent);
 
+    const warn = (m: string) => kubeChannel.showOutput(m);
+
     const installPromises = [
         installDependency("kubectl", gotKubectl, installKubectl),
-        installDependency("Helm", gotHelm, installHelm),
+        installDependency("Helm", gotHelm, (sh) => installHelm(sh, warn)),
         installDependency("Draft", gotDraft, installDraft),
     ];
 

--- a/src/kubeChannel.ts
+++ b/src/kubeChannel.ts
@@ -1,13 +1,13 @@
 import * as vscode from "vscode";
 
 export interface IKubeChannel {
-    showOutput(message: any, title?: string): void;
+    showOutput(message: string, title?: string): void;
 }
 
 class KubeChannel implements IKubeChannel {
     private readonly channel: vscode.OutputChannel = vscode.window.createOutputChannel("Kubernetes");
 
-    showOutput(message: any, title?: string): void {
+    showOutput(message: string, title?: string): void {
         if (title) {
             const simplifiedTime = (new Date()).toISOString().replace(/z|t/gi, ' ').trim(); // YYYY-MM-DD HH:mm:ss.sss
             const hightlightingTitle = `[${title} ${simplifiedTime}]`;


### PR DESCRIPTION
Previously the version of Helm to download in 'install dependencies' was hardcoded.  This PR uses @bacongobbler's trick of querying the GitHub latest release page to find out which release it redirects to, and then downloads that.  If the query fails it still falls back to a hardcoded version rather than failing: this fallback has been updated to 3.0.0 (yay Helm 3).