### PR TITLE
Add syntax highlighting for Chart.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1093,6 +1093,7 @@
             {
                 "id": "yaml",
                 "filenames": [
+                    "Chart.lock",
                     "requirements.lock",
                     "**/.kube/config"
                 ]


### PR DESCRIPTION
Chart.lock replaces requiremens.lock in Helm 3.