### PR TITLE
Add dotnet attach debugging support

### DIFF
--- a/debug-on-kubernetes.md
+++ b/debug-on-kubernetes.md
@@ -3,13 +3,14 @@
 One of the key features of VS Code Kubernetes Extension is its one-click debugging support. This document shows you how to configure the feature and use it to debug your application.
 
 ## 1. Supported languages
+   * `dotnet` (Required: [C# for Visual Studio Code (powered by OmniSharp).](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
    * `java` (Required: [Debugger for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-debug) extension)
    * `python` (Required: [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) extension)
    * `node`
 
 ## 2. Commands for debugging
    * `Kubernetes: Debug (Launch)` - Run the current application as a Kubernetes Deployment and attach a debugging session to it (currently works only for Java/Node.js deployments)
-   * `Kubernetes: Debug (Attach)` - Attach a debugging session to an existing Kubernetes Deployment (currently works only for Java deployments and Python deployments running `ptvsd`)
+   * `Kubernetes: Debug (Attach)` - Attach a debugging session to an existing Kubernetes Deployment (currently works only for dotnet deployments, Java deployments and Python deployments running `ptvsd`)
 
 ## 3. Extension Settings for debugging
    * `vs-kubernetes` - Parent for Kubernetes-related extension settings
@@ -77,3 +78,25 @@ To learn more about the features provided by the VS Code Kubernetes Extension, t
    2. Either use [`ptvsd.enable_attach()`](https://github.com/microsoft/ptvsd#enabling-debugging) in your code or prepend your entrypont with [the ptvsd command](https://github.com/microsoft/ptvsd#ptvsd-cli-usage).
 
 Currently only attaching to a Python container running ptvsd is supported.
+
+## 6. dotnet debugging
+   1. Prerequisites
+      * [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) extension must be installed on local machine.
+      * `ps` must be available on the docker container. `ps` is used to try and autoselect the process id to debug. It is also used by the `C#` extension to look up processes for the process picker if there is more than one dotnet process running. You can install it by running the following command on the container:
+
+      `apt-get update && apt-get -y install procps`
+
+      * [`vsdbg`](https://github.com/OmniSharp/omnisharp-vscode/wiki/Attaching-to-remote-processes) must be installed on the container. You can download it by running the following command on the container.
+https://github.com/OmniSharp/omnisharp-vscode/wiki/Attaching-to-remote-processes
+      `curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l ~/vsdbg`
+
+      \- or -
+
+      `wget https://aka.ms/getvsdbgsh -O - 2>/dev/null | /bin/sh /dev/stdin -v latest -l ~/vsdbg`
+
+   2. Notes:
+      * `dotnet` debugging is only supported for the `attach` scenario. The `launch` scenario is not yet supported.
+      * If `dotnet` does not show up in debugger picker list, than the extension was able to view the processes running on the container and there were no `dotnet` processes running at that time.
+      * If `ps` is not installed on the machine, than `dotnet` will show up in the debugger pick list. If `dotnet` is chosen it will give you an error message with a link to this page.
+      * If `dotnet` is chosen as the debugger and only one `dotnet` process is running on the container, that process will automatically be chosen.  If there is more than one dotnet process running at that time, you will be presented a process pick list, and you can choose the process you would like to debug.
+      * The [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) extension is powered by OmniSharp. Found out more information regarding remote debugging with OmniSharp [here](https://github.com/OmniSharp/omnisharp-vscode/wiki/Attaching-to-remote-processes).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-kubernetes-tools",
-    "version": "1.0.9",
+    "version": "1.0.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/debug/debugProvider.ts
+++ b/src/debug/debugProvider.ts
@@ -1,6 +1,7 @@
 import { Kubectl } from "../kubectl";
 import { IDockerfile } from "../docker/parser";
 import { Dictionary } from "../utils/dictionary";
+import { ProcessInfo } from "./debugUtils";
 
 export interface PortInfo {
     readonly debugPort: number;
@@ -26,7 +27,7 @@ export interface IDebugProvider {
      * @param port the debugging port exposed by the target program.
      * @return A thenable that resolves when debugging could be successfully started.
      */
-    startDebugging(workspaceFolder: string, sessionName: string, port: number): Promise<boolean>;
+    startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, pod: string, pidToDebug: number | undefined): Promise<boolean>;
 
     /**
      * The docker image is supported by the provider or not.
@@ -54,4 +55,17 @@ export interface IDebugProvider {
      * @return the resolved port info.
      */
     resolvePortsFromContainer(kubectl: Kubectl, pod: string, podNamespace: string | undefined, container: string): Promise<PortInfo | undefined>;
+
+    /**
+     * Filters the process list to those processes that can be debugged by the the provider.
+     *
+     * @param processes the running processes on the container
+     * @return the list of processes supported by the provider
+     */
+    filterSupportedProcesses(processes: ProcessInfo[]) : ProcessInfo[] | undefined 
+
+    /**
+     * Returns true if the debugger requires a port to connect to.
+     */
+    isPortRequired(): boolean;
 }

--- a/src/debug/debugProvider.ts
+++ b/src/debug/debugProvider.ts
@@ -62,7 +62,7 @@ export interface IDebugProvider {
      * @param processes the running processes on the container
      * @return the list of processes supported by the provider
      */
-    filterSupportedProcesses(processes: ProcessInfo[]) : ProcessInfo[] | undefined 
+    filterSupportedProcesses(processes: ProcessInfo[]): ProcessInfo[] | undefined;
 
     /**
      * Returns true if the debugger requires a port to connect to.

--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -5,7 +5,8 @@ import * as path from "path";
 import * as portfinder from "portfinder";
 import { ChildProcess } from "child_process";
 
-import { IDebugProvider } from "./debugProvider";
+import { IDebugProvider, PortInfo } from "./debugProvider";
+import { ProcessInfo, getProcesses } from "./debugUtils";
 import * as providerRegistry from "./providerRegistry";
 
 import { kubeChannel } from "../kubeChannel";
@@ -115,7 +116,7 @@ export class DebugSession implements IDebugSession {
 
                 // Start debug session.
                 p.report({ message: `Starting ${this.debugProvider!.getDebuggerType()} debug session...`});  // safe because checked outside the lambda
-                await this.startDebugSession(appName, cwd, proxyResult);
+                await this.startDebugSession(appName, cwd, proxyResult, podName, undefined);
             } catch (error) {
                 vscode.window.showErrorMessage(error);
                 kubeChannel.showOutput(`Debug on Kubernetes failed. The errors were: ${error}.`);
@@ -145,12 +146,6 @@ export class DebugSession implements IDebugSession {
 
         const { targetPod, targetPodNS, containers } = targetPodInfo;
 
-        // Select the image type to attach.
-        this.debugProvider = await this.pickupAndInstallDebugProvider();
-        if (!this.debugProvider) {
-            return;
-        }
-
         // Select the target container to attach.
         // TODO: consolidate with container selection in extension.ts.
         const targetContainer = await this.pickContainer(containers);
@@ -158,26 +153,46 @@ export class DebugSession implements IDebugSession {
             return;
         }
 
-        // Find the debug port to attach.
-        const portInfo = await this.debugProvider.resolvePortsFromContainer(this.kubectl, targetPod, targetPodNS, targetContainer);
-        if (!portInfo || !portInfo.debugPort) {
-            await this.openInBrowser("Cannot resolve the debug port to attach. See the documentation for how to use this command.", debugCommandDocumentationUrl);
+        const processes = await getProcesses(this.kubectl, targetPod, targetPodNS, targetContainer);
+
+        // Select the image type to attach.
+        this.debugProvider = await this.pickupAndInstallDebugProvider(undefined, processes);
+        if (!this.debugProvider) {
             return;
+        }
+
+        const supportedProcesses = processes ? this.debugProvider.filterSupportedProcesses(processes) : undefined;
+        const pidToDebug = supportedProcesses && supportedProcesses.length === 1 ? +supportedProcesses[0].pid : undefined;
+
+        // Find the debug port to attach.
+        const isPortRequired = this.debugProvider.isPortRequired();
+        var portInfo: PortInfo | undefined = undefined;
+        if (isPortRequired) {
+            portInfo = await this.debugProvider.resolvePortsFromContainer(this.kubectl, targetPod, targetPodNS, targetContainer);
+            if (!portInfo || !portInfo.debugPort) {
+                await this.openInBrowser("Cannot resolve the debug port to attach. See the documentation for how to use this command.", debugCommandDocumentationUrl);
+                return;
+            }
         }
 
         vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, async (p) => {
             try {
-                // Setup port-forward.
-                p.report({ message: "Setting up port forwarding..."});
-                const proxyResult = await this.setupPortForward(targetPod, targetPodNS, portInfo.debugPort);
+                var proxyResult: ProxyResult | undefined;
+                if (isPortRequired) {
+                    p.report({ message: "Setting up port forwarding..."});
+                    if (portInfo) {
+                        proxyResult = await this.setupPortForward(targetPod, targetPodNS, portInfo.debugPort);
+                    }
 
-                if (!proxyResult.proxyProcess) {
-                    return;  // No port forwarding, so can't debug
+                    if (!proxyResult || !proxyResult.proxyProcess) {
+                        return;  // No port forwarding, so can't debug
+                    }
                 }
 
                 // Start debug session.
                 p.report({ message: `Starting ${this.debugProvider!.getDebuggerType()} debug session...`});  // safe because checked outside lambda
-                await this.startDebugSession(undefined, workspaceFolder.uri.fsPath, proxyResult);
+
+                await this.startDebugSession(undefined, workspaceFolder.uri.fsPath, proxyResult, targetPod, pidToDebug);
             } catch (error) {
                 vscode.window.showErrorMessage(error);
                 kubeChannel.showOutput(`Debug on Kubernetes failed. The errors were: ${error}.`);
@@ -254,8 +269,8 @@ export class DebugSession implements IDebugSession {
         return selectedContainer.name;
     }
 
-    private async pickupAndInstallDebugProvider(baseImage?: string): Promise<IDebugProvider | undefined> {
-        const debugProvider = await providerRegistry.getDebugProvider(baseImage);
+    private async pickupAndInstallDebugProvider(baseImage?: string, runningProcesses?: ProcessInfo[]): Promise<IDebugProvider | undefined> {
+        const debugProvider = await providerRegistry.getDebugProvider(baseImage, runningProcesses);
         if (!debugProvider) {
             return undefined;
         } else if (!await debugProvider.isDebuggerInstalled()) {
@@ -326,11 +341,15 @@ export class DebugSession implements IDebugSession {
         return proxyResult;
     }
 
-    private async startDebugSession(appName: string | undefined, cwd: string, proxyResult: ProxyResult): Promise<void> {
+    private async startDebugSession(appName: string | undefined, cwd: string, proxyResult: ProxyResult | undefined, pod: string, pidToDebug: number | undefined): Promise<void> {
         kubeChannel.showOutput("Starting debug session...", "Start debug session");
         const sessionName = appName || `${Date.now()}`;
-        await this.startDebugging(cwd, sessionName, proxyResult.proxyDebugPort, proxyResult.proxyAppPort, async () => {
-            if (proxyResult.proxyProcess) {
+
+        const proxyDebugPort = proxyResult ? proxyResult.proxyDebugPort : undefined;
+        const proxyAppPort = proxyResult ? proxyResult.proxyAppPort : undefined;
+
+        await this.startDebugging(cwd, sessionName, proxyDebugPort, proxyAppPort, pod, pidToDebug, async () => {
+            if (proxyResult && proxyResult.proxyProcess) {
                 proxyResult.proxyProcess.kill();
             }
             if (appName) {
@@ -421,7 +440,7 @@ export class DebugSession implements IDebugSession {
         return forwardingRegExp.test(message);
     }
 
-    private async startDebugging(workspaceFolder: string, sessionName: string, proxyDebugPort: number, proxyAppPort: number, onTerminateCallback: () => Promise<any>): Promise<boolean> {
+    private async startDebugging(workspaceFolder: string, sessionName: string, proxyDebugPort: number | undefined, proxyAppPort: number | undefined, pod: string, pidToDebug: number | undefined, onTerminateCallback: () => Promise<any>): Promise<boolean> {
         const disposables: vscode.Disposable[] = [];
         disposables.push(vscode.debug.onDidStartDebugSession((debugSession) => {
             if (debugSession.name === sessionName) {
@@ -444,7 +463,7 @@ export class DebugSession implements IDebugSession {
             return false;
         }
 
-        const success = await this.debugProvider.startDebugging(workspaceFolder, sessionName, proxyDebugPort);
+        const success = await this.debugProvider.startDebugging(workspaceFolder, sessionName, proxyDebugPort, pod, pidToDebug);
         if (!success) {
             disposables.forEach((d) => d.dispose());
             await onTerminateCallback();

--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -166,7 +166,7 @@ export class DebugSession implements IDebugSession {
 
         // Find the debug port to attach.
         const isPortRequired = this.debugProvider.isPortRequired();
-        var portInfo: PortInfo | undefined = undefined;
+        let portInfo: PortInfo | undefined = undefined;
         if (isPortRequired) {
             portInfo = await this.debugProvider.resolvePortsFromContainer(this.kubectl, targetPod, targetPodNS, targetContainer);
             if (!portInfo || !portInfo.debugPort) {
@@ -177,7 +177,7 @@ export class DebugSession implements IDebugSession {
 
         vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, async (p) => {
             try {
-                var proxyResult: ProxyResult | undefined;
+                let proxyResult: ProxyResult | undefined;
                 if (isPortRequired) {
                     p.report({ message: "Setting up port forwarding..."});
                     if (portInfo) {

--- a/src/debug/debugUtils.ts
+++ b/src/debug/debugUtils.ts
@@ -57,31 +57,40 @@ export async function promptForAppPort(ports: string[], defaultPort: string, env
  * @param container the container name.
  * @return the commands associated with the processes.
  */
-export async function getCommandsOfProcesses(kubectl: Kubectl, pod: string, podNamespace: string | undefined, container: string): Promise<string[]> {
-    const commandLines: string[] = [];
-    const nsarg = podNamespace ? `--namespace ${podNamespace}` : '';
+export async function getProcesses(kubectl: Kubectl, pod: string, podNamespace: string | undefined, container: string | undefined): Promise<ProcessInfo[] | undefined> {
+    const processes: ProcessInfo[] = [];
+    const nsarg = podNamespace && podNamespace !== "default" ? `--namespace ${podNamespace}` : '';
     const containerCommand = container ? `-c ${container}` : '';
-    const execCmd = `exec ${pod} ${nsarg} ${containerCommand} -- ps -ef`;
+    const execCmd = `exec ${pod} ${nsarg} ${containerCommand} -- ps -o pid,command -e -w -w`;
     const execResult = await kubectl.invokeAsync(execCmd);
     if (execResult && execResult.code === 0) {
         /**
-         * PID   USER     TIME   COMMAND
-         *  1    root     2:09   java -Djava.security.egd=file:/dev/./urandom -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1044,quiet=y -jar target/app.jar
-         * 44    root     0:00   sh
-         * 48    root     0:00   ps -ef
+         * PID   COMMAND
+         *  1    java -Djava.security.egd=file:/dev/./urandom -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1044,quiet=y -jar target/app.jar
+         * 44    sh
+         * 48    ps  -o pid,comm -e -w -w
          */
-        const rows = execResult.stdout.split("\n");
-        const columnCount = rows[0].trim().split(/\s+/).length;
-        // The 1st row is the header, loop from the 2nd row.
-        for (let i = 1; i < rows.length; i++) {
-            const cols = rows[i].trim().split(/\s+/);
-            if (cols.length < columnCount) {
-                continue;
-            }
 
-            commandLines.push(cols.slice(columnCount - 1, cols.length).join(" "));
+        const outputRegEx = /^\s*(\d+)\s*(.*)$/gm;
+        var match = outputRegEx.exec(execResult.stdout);
+        while (match != null) {
+            processes.push({
+                pid: +match[1],
+                command: match[2]
+            });
+            match = outputRegEx.exec(execResult.stdout);
         }
+        return processes;
     }
+    return undefined
+}
 
-    return commandLines;
+/**
+ * Represents information about a running process.
+ */
+export interface ProcessInfo {
+    /** The process ID */
+    readonly pid: number;
+    /** The full command that launched the process */
+    readonly command: string;
 }

--- a/src/debug/debugUtils.ts
+++ b/src/debug/debugUtils.ts
@@ -72,8 +72,8 @@ export async function getProcesses(kubectl: Kubectl, pod: string, podNamespace: 
          */
 
         const outputRegEx = /^\s*(\d+)\s*(.*)$/gm;
-        var match = outputRegEx.exec(execResult.stdout);
-        while (match != null) {
+        let match = outputRegEx.exec(execResult.stdout);
+        while (match) {
             processes.push({
                 pid: +match[1],
                 command: match[2]
@@ -82,7 +82,7 @@ export async function getProcesses(kubectl: Kubectl, pod: string, podNamespace: 
         }
         return processes;
     }
-    return undefined
+    return undefined;
 }
 
 /**

--- a/src/debug/dotNetDebugProvider.ts
+++ b/src/debug/dotNetDebugProvider.ts
@@ -42,7 +42,7 @@ export class DotNetDebugProvider implements IDebugProvider {
                 pipeProgram: "kubectl",
                 pipeArgs: [ "exec", "-i", pod, "--" ],
                 debuggerPath: "/vsdbg/vsdbg",
-                pipeCwd: "${workspaceRoot}",
+                pipeCwd: workspaceFolder,
                 quoteArgs: false
             }
         };

--- a/src/debug/dotNetDebugProvider.ts
+++ b/src/debug/dotNetDebugProvider.ts
@@ -68,8 +68,8 @@ export class DotNetDebugProvider implements IDebugProvider {
     }
 
     public filterSupportedProcesses(processes: ProcessInfo[]): ProcessInfo[] | undefined {
-        return processes.filter(processInfo => (processInfo.command.toLowerCase().startsWith('dotnet ') ||
-                                                processInfo.command.indexOf('/dotnet ') >= 0)); // full path
+        return processes.filter((processInfo) => (processInfo.command.toLowerCase().startsWith('dotnet ') ||
+                                                  processInfo.command.indexOf('/dotnet ') >= 0)); // full path
     }
 
     public isPortRequired(): boolean {

--- a/src/debug/dotNetDebugProvider.ts
+++ b/src/debug/dotNetDebugProvider.ts
@@ -1,0 +1,78 @@
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { IDebugProvider, PortInfo } from "./debugProvider";
+import { ProcessInfo } from "./debugUtils";
+import * as extensionUtils from "../extensionUtils";
+import { Kubectl } from "../kubectl";
+import { kubeChannel } from "../kubeChannel";
+import { IDockerfile } from "../docker/parser";
+import { Dictionary } from "../utils/dictionary";
+
+// Use the csharp debugger extension provided by Microsoft for csharp debugging.
+const defaultDotnetDebuggerExtensionId = "ms-vscode.csharp";
+const defaultDotnetDebuggerExtension = "C# for Visual Studio Code";
+
+const defaultDotnetDebuggerConfigType = "dotnet";
+
+export class DotNetDebugProvider implements IDebugProvider {
+    public getDebuggerType(): string {
+        return defaultDotnetDebuggerConfigType;
+    }
+
+    public async isDebuggerInstalled(): Promise<boolean> {
+        if (vscode.extensions.getExtension(defaultDotnetDebuggerExtensionId)) {
+            return true;
+        }
+        const answer = await vscode.window.showInformationMessage(`Dotnet debugging requires the '${defaultDotnetDebuggerExtension}' extension. Would you like to install it now?`, "Install Now");
+        if (answer === "Install Now") {
+            return await extensionUtils.installVscodeExtension(defaultDotnetDebuggerExtensionId);
+        }
+        return false;
+    }
+
+    public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, pod: string, pidToDebug: number | undefined): Promise<boolean> {
+        const processId = pidToDebug ? pidToDebug.toString() : "${command:pickRemoteProcess}";
+        const debugConfiguration = {
+            "name": ".NET Core Kubernetes Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": processId,
+            "pipeTransport": {
+                "pipeProgram": "kubectl",
+                "pipeArgs": [ "exec", "-i", pod, "--" ],
+                "debuggerPath": "/vsdbg/vsdbg",
+                "pipeCwd": "${workspaceRoot}",
+                "quoteArgs": false
+            }
+        };
+        const currentFolder = (vscode.workspace.workspaceFolders || []).find((folder) => folder.name === path.basename(workspaceFolder));
+        const result = await vscode.debug.startDebugging(currentFolder, debugConfiguration);
+        if (!result) {
+           kubeChannel.showOutput(defaultDotnetDebuggerConfigType + " debug attach failed for pod " + pod + ".\nSee https://github.com/Azure/vscode-kubernetes-tools/blob/master/debug-on-kubernetes.md for troubleshooting.", "Failed to attach");
+        }
+        return result;
+    }
+
+    public isSupportedImage(baseImage: string): boolean {
+        // todo: add support for debug from file
+        return false;
+    }
+
+    public async resolvePortsFromFile(dockerfile: IDockerfile, env: Dictionary<string>): Promise<PortInfo | undefined> {
+        return undefined;
+    }
+
+    public async resolvePortsFromContainer(kubectl: Kubectl, pod: string, podNamespace: string | undefined, container: string): Promise<PortInfo | undefined> {
+        return undefined;
+    }
+
+    public filterSupportedProcesses(processes: ProcessInfo[]) : ProcessInfo[] | undefined {
+        return processes.filter(processInfo => processInfo.command.toLowerCase().startsWith('dotnet ') ||
+                                               processInfo.command.indexOf('/dotnet ') >= 0) // full path
+    }
+
+    public isPortRequired(): boolean {
+        return false;
+    }
+}

--- a/src/debug/dotNetDebugProvider.ts
+++ b/src/debug/dotNetDebugProvider.ts
@@ -34,22 +34,22 @@ export class DotNetDebugProvider implements IDebugProvider {
     public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, pod: string, pidToDebug: number | undefined): Promise<boolean> {
         const processId = pidToDebug ? pidToDebug.toString() : "${command:pickRemoteProcess}";
         const debugConfiguration = {
-            "name": ".NET Core Kubernetes Attach",
-            "type": "coreclr",
-            "request": "attach",
-            "processId": processId,
-            "pipeTransport": {
-                "pipeProgram": "kubectl",
-                "pipeArgs": [ "exec", "-i", pod, "--" ],
-                "debuggerPath": "/vsdbg/vsdbg",
-                "pipeCwd": "${workspaceRoot}",
-                "quoteArgs": false
+            name: ".NET Core Kubernetes Attach",
+            type: "coreclr",
+            request: "attach",
+            processId: processId,
+            pipeTransport: {
+                pipeProgram: "kubectl",
+                pipeArgs: [ "exec", "-i", pod, "--" ],
+                debuggerPath: "/vsdbg/vsdbg",
+                pipeCwd: "${workspaceRoot}",
+                quoteArgs: false
             }
         };
         const currentFolder = (vscode.workspace.workspaceFolders || []).find((folder) => folder.name === path.basename(workspaceFolder));
         const result = await vscode.debug.startDebugging(currentFolder, debugConfiguration);
         if (!result) {
-           kubeChannel.showOutput(defaultDotnetDebuggerConfigType + " debug attach failed for pod " + pod + ".\nSee https://github.com/Azure/vscode-kubernetes-tools/blob/master/debug-on-kubernetes.md for troubleshooting.", "Failed to attach");
+           kubeChannel.showOutput(`${defaultDotnetDebuggerConfigType} debug attach failed for pod ${pod}.\nSee https://github.com/Azure/vscode-kubernetes-tools/blob/master/debug-on-kubernetes.md for troubleshooting.`, "Failed to attach");
         }
         return result;
     }
@@ -67,9 +67,9 @@ export class DotNetDebugProvider implements IDebugProvider {
         return undefined;
     }
 
-    public filterSupportedProcesses(processes: ProcessInfo[]) : ProcessInfo[] | undefined {
-        return processes.filter(processInfo => processInfo.command.toLowerCase().startsWith('dotnet ') ||
-                                               processInfo.command.indexOf('/dotnet ') >= 0) // full path
+    public filterSupportedProcesses(processes: ProcessInfo[]): ProcessInfo[] | undefined {
+        return processes.filter(processInfo => (processInfo.command.toLowerCase().startsWith('dotnet ') ||
+                                                processInfo.command.indexOf('/dotnet ') >= 0)); // full path
     }
 
     public isPortRequired(): boolean {

--- a/src/debug/dotNetDebugProvider.ts
+++ b/src/debug/dotNetDebugProvider.ts
@@ -31,7 +31,7 @@ export class DotNetDebugProvider implements IDebugProvider {
         return false;
     }
 
-    public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, pod: string, pidToDebug: number | undefined): Promise<boolean> {
+    public async startDebugging(workspaceFolder: string, _sessionName: string, _port: number | undefined, pod: string, pidToDebug: number | undefined): Promise<boolean> {
         const processId = pidToDebug ? pidToDebug.toString() : "${command:pickRemoteProcess}";
         const debugConfiguration = {
             name: ".NET Core Kubernetes Attach",
@@ -54,16 +54,16 @@ export class DotNetDebugProvider implements IDebugProvider {
         return result;
     }
 
-    public isSupportedImage(baseImage: string): boolean {
+    public isSupportedImage(_baseImage: string): boolean {
         // todo: add support for debug from file
         return false;
     }
 
-    public async resolvePortsFromFile(dockerfile: IDockerfile, env: Dictionary<string>): Promise<PortInfo | undefined> {
+    public async resolvePortsFromFile(_dockerfile: IDockerfile, _env: Dictionary<string>): Promise<PortInfo | undefined> {
         return undefined;
     }
 
-    public async resolvePortsFromContainer(kubectl: Kubectl, pod: string, podNamespace: string | undefined, container: string): Promise<PortInfo | undefined> {
+    public async resolvePortsFromContainer(_kubectl: Kubectl, _pod: string, _podNamespace: string | undefined, _container: string): Promise<PortInfo | undefined> {
         return undefined;
     }
 

--- a/src/debug/javaDebugProvider.ts
+++ b/src/debug/javaDebugProvider.ts
@@ -35,7 +35,7 @@ export class JavaDebugProvider implements IDebugProvider {
         return false;
     }
 
-    public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, pod: string, pidToDebug: number | undefined): Promise<boolean> {
+    public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, _pod: string, _pidToDebug: number | undefined): Promise<boolean> {
         const debugConfiguration = {
             type: "java",
             request: "attach",
@@ -121,7 +121,7 @@ export class JavaDebugProvider implements IDebugProvider {
         };
     }
 
-    public filterSupportedProcesses(processes: debugUtils.ProcessInfo[]): debugUtils.ProcessInfo[] | undefined {
+    public filterSupportedProcesses(_processes: debugUtils.ProcessInfo[]): debugUtils.ProcessInfo[] | undefined {
         return undefined;
     }
 

--- a/src/debug/javaDebugProvider.ts
+++ b/src/debug/javaDebugProvider.ts
@@ -35,7 +35,7 @@ export class JavaDebugProvider implements IDebugProvider {
         return false;
     }
 
-    public async startDebugging(workspaceFolder: string, sessionName: string, port: number): Promise<boolean> {
+    public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, pod: string, pidToDebug: number | undefined): Promise<boolean> {
         const debugConfiguration = {
             type: "java",
             request: "attach",
@@ -94,14 +94,17 @@ export class JavaDebugProvider implements IDebugProvider {
 
     public async resolvePortsFromContainer(kubectl: Kubectl, pod: string, podNamespace: string | undefined, container: string): Promise<PortInfo | undefined> {
         let rawDebugPortInfo: string | undefined;
-        const commandLines = await debugUtils.getCommandsOfProcesses(kubectl, pod, podNamespace, container);
-        for (const commandLine of commandLines) {
-            // java -Djava.security.egd=file:/dev/./urandom -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1044,quiet=y -jar target/app.jar
-            const matches = commandLine.match(fullJavaDebugOptsRegExp);
-            if (matches && matches.length > 0) {
-                const addresses = matches[2].split("=")[1].split(":");
-                rawDebugPortInfo = addresses[addresses.length - 1];
-                break;
+        const processes = await debugUtils.getProcesses(kubectl, pod, podNamespace, container);
+        const commandLines = processes ? processes.map(({ command }) => command) : undefined;
+        if (commandLines){
+            for (const commandLine of commandLines) {
+                // java -Djava.security.egd=file:/dev/./urandom -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1044,quiet=y -jar target/app.jar
+                const matches = commandLine.match(fullJavaDebugOptsRegExp);
+                if (matches && matches.length > 0) {
+                    const addresses = matches[2].split("=")[1].split(":");
+                    rawDebugPortInfo = addresses[addresses.length - 1];
+                    break;
+                }
             }
         }
 
@@ -116,5 +119,13 @@ export class JavaDebugProvider implements IDebugProvider {
         return {
             debugPort: Number(rawDebugPortInfo)
         };
+    }
+
+    public filterSupportedProcesses(processes: debugUtils.ProcessInfo[]) : debugUtils.ProcessInfo[] | undefined {
+        return undefined
+    }
+
+    public isPortRequired(): boolean {
+        return true;
     }
 }

--- a/src/debug/javaDebugProvider.ts
+++ b/src/debug/javaDebugProvider.ts
@@ -96,7 +96,7 @@ export class JavaDebugProvider implements IDebugProvider {
         let rawDebugPortInfo: string | undefined;
         const processes = await debugUtils.getProcesses(kubectl, pod, podNamespace, container);
         const commandLines = processes ? processes.map(({ command }) => command) : undefined;
-        if (commandLines){
+        if (commandLines) {
             for (const commandLine of commandLines) {
                 // java -Djava.security.egd=file:/dev/./urandom -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1044,quiet=y -jar target/app.jar
                 const matches = commandLine.match(fullJavaDebugOptsRegExp);
@@ -121,8 +121,8 @@ export class JavaDebugProvider implements IDebugProvider {
         };
     }
 
-    public filterSupportedProcesses(processes: debugUtils.ProcessInfo[]) : debugUtils.ProcessInfo[] | undefined {
-        return undefined
+    public filterSupportedProcesses(processes: debugUtils.ProcessInfo[]): debugUtils.ProcessInfo[] | undefined {
+        return undefined;
     }
 
     public isPortRequired(): boolean {

--- a/src/debug/nodejsDebugProvider.ts
+++ b/src/debug/nodejsDebugProvider.ts
@@ -95,8 +95,8 @@ export class NodejsDebugProvider implements IDebugProvider {
         return undefined;
     }
 
-    public filterSupportedProcesses(processes: ProcessInfo[]) : ProcessInfo[] | undefined {
-        return undefined
+    public filterSupportedProcesses(processes: ProcessInfo[]): ProcessInfo[] | undefined {
+        return undefined;
     }
 
     public isPortRequired(): boolean {

--- a/src/debug/nodejsDebugProvider.ts
+++ b/src/debug/nodejsDebugProvider.ts
@@ -6,6 +6,7 @@ import { suggestedShellForContainer } from '../utils/container-shell';
 import * as config from '../components/config/config';
 import { Kubectl } from "../kubectl";
 import { kubeChannel } from "../kubeChannel";
+import { ProcessInfo } from "./debugUtils";
 
 const debuggerType = 'nodejs';
 
@@ -21,7 +22,7 @@ export class NodejsDebugProvider implements IDebugProvider {
         return true;
     }
 
-    public async startDebugging(workspaceFolder: string, sessionName: string, port: number): Promise<boolean> {
+    public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, pod: string, pidToDebug: number | undefined): Promise<boolean> {
 
         const debugConfiguration: vscode.DebugConfiguration = {
             type: "node",
@@ -92,5 +93,13 @@ export class NodejsDebugProvider implements IDebugProvider {
         }
 
         return undefined;
+    }
+
+    public filterSupportedProcesses(processes: ProcessInfo[]) : ProcessInfo[] | undefined {
+        return undefined
+    }
+
+    public isPortRequired(): boolean {
+        return true;
     }
 }

--- a/src/debug/nodejsDebugProvider.ts
+++ b/src/debug/nodejsDebugProvider.ts
@@ -22,7 +22,7 @@ export class NodejsDebugProvider implements IDebugProvider {
         return true;
     }
 
-    public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, pod: string, pidToDebug: number | undefined): Promise<boolean> {
+    public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, _pod: string, _pidToDebug: number | undefined): Promise<boolean> {
 
         const debugConfiguration: vscode.DebugConfiguration = {
             type: "node",
@@ -95,7 +95,7 @@ export class NodejsDebugProvider implements IDebugProvider {
         return undefined;
     }
 
-    public filterSupportedProcesses(processes: ProcessInfo[]): ProcessInfo[] | undefined {
+    public filterSupportedProcesses(_processes: ProcessInfo[]): ProcessInfo[] | undefined {
         return undefined;
     }
 

--- a/src/debug/providerRegistry.ts
+++ b/src/debug/providerRegistry.ts
@@ -48,7 +48,7 @@ export async function getDebugProvider(baseImage?: string, runningProcesses?: Pr
                 }
             }
         } else {
-            candidateProviders = supportedProviders
+            candidateProviders = supportedProviders;
         }
 
         if (candidateProviders.length === 0) {

--- a/src/debug/providerRegistry.ts
+++ b/src/debug/providerRegistry.ts
@@ -51,7 +51,7 @@ export async function getDebugProvider(baseImage?: string, runningProcesses?: Pr
             candidateProviders = supportedProviders;
         }
 
-        if (candidateProviders.length === 0) {
+        if (candidateProviders.length === 1) {
             // there is only one debugger that qualifies, so use it
             debugProvider = candidateProviders[0];
         } else if (candidateProviders.length > 1) {

--- a/src/debug/providerRegistry.ts
+++ b/src/debug/providerRegistry.ts
@@ -1,18 +1,21 @@
 import * as vscode from "vscode";
 
 import { IDebugProvider } from "./debugProvider";
+import { DotNetDebugProvider } from "./dotNetDebugProvider";
 import { JavaDebugProvider } from "./javaDebugProvider";
 import { NodejsDebugProvider } from "./nodejsDebugProvider";
 import { PythonDebugProvider } from "./pythonDebugProvider";
+import { ProcessInfo } from "./debugUtils";
 
 const supportedProviders: IDebugProvider[] = [
+    new DotNetDebugProvider(),
     new JavaDebugProvider(),
     new NodejsDebugProvider(),
     new PythonDebugProvider()
 ];
 
-async function showProviderPick(): Promise<IDebugProvider | undefined> {
-    const providerItems = supportedProviders.map((provider) => {
+async function showProviderPick(providers: IDebugProvider[]): Promise<IDebugProvider | undefined> {
+    const providerItems = providers.map((provider) => {
         return {
             label: provider.getDebuggerType(),
             description: "",
@@ -27,14 +30,38 @@ async function showProviderPick(): Promise<IDebugProvider | undefined> {
     return pickedProvider.provider;
 }
 
-export async function getDebugProvider(baseImage?: string): Promise<IDebugProvider | undefined> {
+export async function getDebugProvider(baseImage?: string, runningProcesses?: ProcessInfo[]): Promise<IDebugProvider | undefined> {
     let debugProvider = null;
     if (baseImage) {
         debugProvider = supportedProviders.find((provider) => provider.isSupportedImage(baseImage));
     }
-    if (!debugProvider) {
-        debugProvider = await showProviderPick();
+
+    if (!debugProvider)
+    {
+        let candidateProviders: IDebugProvider[];
+        if (runningProcesses) {
+            candidateProviders = [] as IDebugProvider[];
+            for (const provider of supportedProviders) {
+                const filteredProcesses = provider.filterSupportedProcesses(runningProcesses);
+                if (!filteredProcesses || filteredProcesses.length > 0) {
+                    candidateProviders.push(provider);
+                }
+            }
+        } else {
+            candidateProviders = supportedProviders
+        }
+
+        if (candidateProviders.length === 0) {
+            // there is only one debugger that qualifies, so use it
+            debugProvider = candidateProviders[0];
+        } else if (candidateProviders.length > 1) {
+            // more than 1 debugger qualifies, so show picker showing candidates
+            debugProvider = await showProviderPick(candidateProviders);
+        } else {
+            throw "No valid debuggers were found for the processes currently running on the container.";
+        }
     }
+
     return debugProvider;
 }
 

--- a/src/debug/pythonDebugProvider.ts
+++ b/src/debug/pythonDebugProvider.ts
@@ -91,8 +91,8 @@ export class PythonDebugProvider implements IDebugProvider {
         return undefined;
     }
 
-    public filterSupportedProcesses(processes: ProcessInfo[]) : ProcessInfo[] | undefined {
-        return undefined
+    public filterSupportedProcesses(processes: ProcessInfo[]): ProcessInfo[] | undefined {
+        return undefined;
     }
 
     public isPortRequired(): boolean {

--- a/src/debug/pythonDebugProvider.ts
+++ b/src/debug/pythonDebugProvider.ts
@@ -7,6 +7,7 @@ import * as config from '../components/config/config';
 import * as extensionUtils from "../extensionUtils";
 import { Kubectl } from "../kubectl";
 import { kubeChannel } from "../kubeChannel";
+import { ProcessInfo } from "./debugUtils";
 
 const debuggerType = 'python';
 const defaultPythonDebuggerExtensionId = 'ms-python.python';
@@ -23,14 +24,14 @@ export class PythonDebugProvider implements IDebugProvider {
         if (vscode.extensions.getExtension(defaultPythonDebuggerExtensionId)) {
             return true;
         }
-        const answer = await vscode.window.showInformationMessage(`Pyhon debugging requires the '${defaultPythonDebuggerExtensionId}' extension. Would you like to install it now?`, "Install Now");
+        const answer = await vscode.window.showInformationMessage(`Python debugging requires the '${defaultPythonDebuggerExtensionId}' extension. Would you like to install it now?`, "Install Now");
         if (answer === "Install Now") {
             return await extensionUtils.installVscodeExtension(defaultPythonDebuggerExtensionId);
         }
         return false;
     }
 
-    public async startDebugging(workspaceFolder: string, sessionName: string, port: number): Promise<boolean> {
+    public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, pod: string, pidToDebug: number | undefined): Promise<boolean> {
         const debugConfiguration: vscode.DebugConfiguration = {
             type: "python",
             request: "attach",
@@ -88,5 +89,13 @@ export class PythonDebugProvider implements IDebugProvider {
         }
 
         return undefined;
+    }
+
+    public filterSupportedProcesses(processes: ProcessInfo[]) : ProcessInfo[] | undefined {
+        return undefined
+    }
+
+    public isPortRequired(): boolean {
+        return true;
     }
 }

--- a/src/debug/pythonDebugProvider.ts
+++ b/src/debug/pythonDebugProvider.ts
@@ -31,7 +31,7 @@ export class PythonDebugProvider implements IDebugProvider {
         return false;
     }
 
-    public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, pod: string, pidToDebug: number | undefined): Promise<boolean> {
+    public async startDebugging(workspaceFolder: string, sessionName: string, port: number | undefined, _pod: string, _pidToDebug: number | undefined): Promise<boolean> {
         const debugConfiguration: vscode.DebugConfiguration = {
             type: "python",
             request: "attach",
@@ -91,7 +91,7 @@ export class PythonDebugProvider implements IDebugProvider {
         return undefined;
     }
 
-    public filterSupportedProcesses(processes: ProcessInfo[]): ProcessInfo[] | undefined {
+    public filterSupportedProcesses(_processes: ProcessInfo[]): ProcessInfo[] | undefined {
         return undefined;
     }
 


### PR DESCRIPTION
## 6. dotnet debugging
   1. Prerequisites
      * [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) extension must be installed on local machine.
      * `ps` must be available on the docker container. `ps` is used to try and autoselect the process id to debug. It is also used by the `C#` extension to look up processes for the process picker if there is more than one dotnet process running. You can install it by running the following command on the container:

      `apt-get update && apt-get -y install procps`

      * [`vsdbg`](https://github.com/OmniSharp/omnisharp-vscode/wiki/Attaching-to-remote-processes) must be installed on the container. You can download it by running the following command on the container.
https://github.com/OmniSharp/omnisharp-vscode/wiki/Attaching-to-remote-processes
      `curl -sSL https://aka.ms/getvsdbgsh | /bin/sh /dev/stdin -v latest -l ~/vsdbg`

      \- or -

      `wget https://aka.ms/getvsdbgsh -O - 2>/dev/null | /bin/sh /dev/stdin -v latest -l ~/vsdbg`

   2. Notes:
      * `dotnet` debugging is only supported for the `attach` scenario. The `launch` scenario is not yet supported.
      * If `dotnet` does not show up in debugger picker list, than the extension was able to view the processes running on the container and there were no `dotnet` processes running at that time.
      * If `ps` is not installed on the machine, than `dotnet` will show up in the debugger pick list. If `dotnet` is chosen it will give you an error message with a link to this page.
      * If `dotnet` is chosen as the debugger and only one `dotnet` process is running on the container, that process will automatically be chosen.  If there is more than one dotnet process running at that time, you will be presented a process pick list, and you can choose the process you would like to debug.
      * The [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) extension is powered by OmniSharp. Found out more information regarding remote debugging with OmniSharp [here](https://github.com/OmniSharp/omnisharp-vscode/wiki/Attaching-to-remote-processes).