### PR TITLE
Update Kubernetes Clusters View content automatically when something changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4589,9 +4589,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.11",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "lowercase-keys": {
             "version": "1.0.1",
@@ -4763,9 +4763,9 @@
             }
         },
         "mixin-deep": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+            "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
             "requires": {
                 "for-in": "^1.0.2",
                 "is-extendable": "^1.0.1"
@@ -5849,9 +5849,9 @@
             "dev": true
         },
         "set-value": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-            "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+            "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
             "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
@@ -6789,43 +6789,22 @@
             "dev": true
         },
         "union-value": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+            "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
             "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "get-value": "^2.0.6",
                 "is-extendable": "^0.1.1",
-                "set-value": "^0.4.3"
+                "set-value": "^2.0.1"
             },
             "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "^0.1.0"
-                    }
-                },
                 "is-extendable": {
                     "version": "0.1.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
                     "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
                     "dev": true
-                },
-                "set-value": {
-                    "version": "0.4.3",
-                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.1",
-                        "to-object-path": "^0.3.0"
-                    }
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -279,8 +279,7 @@
                         "vs-kubernetes.nodejs-debug-port": 9229,
                         "checkForMinikubeUpgrade": true,
                         "logsDisplay": "webview",
-                        "imageBuildTool": "Docker",
-                        "resource-to-be-watched": ""
+                        "imageBuildTool": "Docker"
                     }
                 },
                 "vsdocker.imageUser": {

--- a/package.json
+++ b/package.json
@@ -462,12 +462,12 @@
                 },
                 {
                     "command": "extension.vsKubernetesAddWatch",
-                    "group": "1@2",
+                    "group": "3@1",
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.kind/i"
                 },
                 {
                     "command": "extension.vsKubernetesDeleteWatch",
-                    "group": "1@3",
+                    "group": "3@2",
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.kind/i"
                 },
                 {
@@ -741,7 +741,7 @@
             },
             {
                 "command": "extension.vsKubernetesDeleteWatch",
-                "title": "Delete Watch",
+                "title": "Stop Watching",
                 "category": "Kubernetes"
             },
             {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
     "activationEvents": [
         "onCommand:extension.vsKubernetesCreate",
         "onCommand:extension.vsKubernetesCreateFile",
+        "onCommand:extension.vsKubernetesAddWatcher",
         "onCommand:extension.vsKubernetesDelete",
         "onCommand:extension.vsKubernetesDeleteNow",
         "onCommand:extension.vsKubernetesDeleteUri",
+        "onCommand:extension.vsKubernetesDeleteWatcher",
         "onCommand:extension.vsKubernetesDescribe.Refresh",
         "onCommand:extension.vsKubernetesApply",
         "onCommand:extension.vsKubernetesApplyFile",
@@ -460,6 +462,16 @@
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.kind/i"
                 },
                 {
+                    "command": "extension.vsKubernetesAddWatcher",
+                    "group": "1@2",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.kind/i"
+                },
+                {
+                    "command": "extension.vsKubernetesDeleteWatcher",
+                    "group": "1@3",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.kind/i"
+                },
+                {
                     "command": "extension.vsKubernetesLoad",
                     "group": "0",
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource(?!\\.namespace).*/i"
@@ -699,6 +711,11 @@
                 "category": "Kubernetes"
             },
             {
+                "command": "extension.vsKubernetesAddWatcher",
+                "title": "Watch",
+                "category": "Kubernetes"
+            },
+            {
                 "command": "extension.vsKubernetesDelete",
                 "title": "Delete",
                 "category": "Kubernetes"
@@ -711,6 +728,11 @@
             {
                 "command": "extension.vsKubernetesDeleteUri",
                 "title": "Delete Kubernetes resource",
+                "category": "Kubernetes"
+            },
+            {
+                "command": "extension.vsKubernetesDeleteWatcher",
+                "title": "Delete Watch",
                 "category": "Kubernetes"
             },
             {

--- a/package.json
+++ b/package.json
@@ -258,7 +258,7 @@
                             "type": "number",
                             "description": "Remote debugging port for Python. Usually 5678."
                         },
-                        "vs-kubernetes.resource-to-watch": {
+                        "vs-kubernetes.resources-to-watch": {
                             "type": "array",
                             "description": "List of resources to be watched."
                         }
@@ -463,12 +463,12 @@
                 {
                     "command": "extension.vsKubernetesAddWatch",
                     "group": "3@1",
-                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.kind/i"
+                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /k8s-watchable/i"
                 },
                 {
                     "command": "extension.vsKubernetesDeleteWatch",
                     "group": "3@2",
-                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.kind/i"
+                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /k8s-watchable/i"
                 },
                 {
                     "command": "extension.vsKubernetesLoad",
@@ -519,16 +519,6 @@
                     "command": "extension.vsKubernetesPortForward",
                     "group": "2@6",
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\.service/i"
-                },
-                {
-                    "command": "extension.vsKubernetesAddWatch",
-                    "group": "2@7",
-                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\./i"
-                },
-                {
-                    "command": "extension.vsKubernetesDeleteWatch",
-                    "group": "2@8",
-                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\./i"
                 },
                 {
                     "command": "extension.vsKubernetesPortForward",

--- a/package.json
+++ b/package.json
@@ -522,6 +522,16 @@
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\.service/i"
                 },
                 {
+                    "command": "extension.vsKubernetesAddWatcher",
+                    "group": "2@7",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\./i"
+                },
+                {
+                    "command": "extension.vsKubernetesDeleteWatcher",
+                    "group": "2@8",
+                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\./i"
+                },
+                {
                     "command": "extension.vsKubernetesPortForward",
                     "group": "2@6",
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\.deployment/i"

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "activationEvents": [
         "onCommand:extension.vsKubernetesCreate",
         "onCommand:extension.vsKubernetesCreateFile",
-        "onCommand:extension.vsKubernetesAddWatcher",
+        "onCommand:extension.vsKubernetesAddWatch",
         "onCommand:extension.vsKubernetesDelete",
         "onCommand:extension.vsKubernetesDeleteNow",
         "onCommand:extension.vsKubernetesDeleteUri",
-        "onCommand:extension.vsKubernetesDeleteWatcher",
+        "onCommand:extension.vsKubernetesDeleteWatch",
         "onCommand:extension.vsKubernetesDescribe.Refresh",
         "onCommand:extension.vsKubernetesApply",
         "onCommand:extension.vsKubernetesApplyFile",
@@ -194,7 +194,7 @@
                             "type": "boolean",
                             "description": "Once the debug session is terminated, automatically clean up the created Deployment and associated Pod by the command \"Kubernetes: Debug (Launch)\"."
                         },
-                        "vs-kubernevs-kubernetes.tes.outputFormat": {
+                        "vs-kubernetes.outputFormat": {
                             "enum": [
                                 "json",
                                 "yaml"
@@ -462,12 +462,12 @@
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.kind/i"
                 },
                 {
-                    "command": "extension.vsKubernetesAddWatcher",
+                    "command": "extension.vsKubernetesAddWatch",
                     "group": "1@2",
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.kind/i"
                 },
                 {
-                    "command": "extension.vsKubernetesDeleteWatcher",
+                    "command": "extension.vsKubernetesDeleteWatch",
                     "group": "1@3",
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.kind/i"
                 },
@@ -522,12 +522,12 @@
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\.service/i"
                 },
                 {
-                    "command": "extension.vsKubernetesAddWatcher",
+                    "command": "extension.vsKubernetesAddWatch",
                     "group": "2@7",
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\./i"
                 },
                 {
-                    "command": "extension.vsKubernetesDeleteWatcher",
+                    "command": "extension.vsKubernetesDeleteWatch",
                     "group": "2@8",
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource\\./i"
                 },
@@ -721,7 +721,7 @@
                 "category": "Kubernetes"
             },
             {
-                "command": "extension.vsKubernetesAddWatcher",
+                "command": "extension.vsKubernetesAddWatch",
                 "title": "Watch",
                 "category": "Kubernetes"
             },
@@ -741,7 +741,7 @@
                 "category": "Kubernetes"
             },
             {
-                "command": "extension.vsKubernetesDeleteWatcher",
+                "command": "extension.vsKubernetesDeleteWatch",
                 "title": "Delete Watch",
                 "category": "Kubernetes"
             },

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
                             "type": "boolean",
                             "description": "Once the debug session is terminated, automatically clean up the created Deployment and associated Pod by the command \"Kubernetes: Debug (Launch)\"."
                         },
-                        "vs-kubernetes.outputFormat": {
+                        "vs-kubernevs-kubernetes.tes.outputFormat": {
                             "enum": [
                                 "json",
                                 "yaml"
@@ -255,6 +255,10 @@
                         "vs-kubernetes.python-debug-port": {
                             "type": "number",
                             "description": "Remote debugging port for Python. Usually 5678."
+                        },
+                        "vs-kubernetes.resource-to-watch": {
+                            "type": "array",
+                            "description": "List of resources to be watched."
                         }
                     },
                     "default": {
@@ -273,7 +277,8 @@
                         "vs-kubernetes.nodejs-debug-port": 9229,
                         "checkForMinikubeUpgrade": true,
                         "logsDisplay": "webview",
-                        "imageBuildTool": "Docker"
+                        "imageBuildTool": "Docker",
+                        "resource-to-be-watched": ""
                     }
                 },
                 "vsdocker.imageUser": {
@@ -1241,8 +1246,8 @@
         "got": "9.6.0",
         "graceful-fs": "^4.1.11",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.10",
-        "mixin-deep": "^1.3.1",
+        "lodash": "^4.17.15",
+        "mixin-deep": "^1.3.2",
         "mkdirp": "^0.5.1",
         "moment": "^2.24.0",
         "natives": "^1.1.3",

--- a/src/api/contract/cluster-explorer/v1.ts
+++ b/src/api/contract/cluster-explorer/v1.ts
@@ -101,7 +101,7 @@ export namespace ClusterExplorerV1 {
     }
 
     export interface NodeSources {
-        resourceFolder(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string, apiName: string): NodeSource;
+        resourceFolder(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string): NodeSource;
         groupingFolder(displayName: string, contextValue: string | undefined, ...children: NodeSource[]): NodeSource;
     }
 }

--- a/src/api/contract/cluster-explorer/v1.ts
+++ b/src/api/contract/cluster-explorer/v1.ts
@@ -101,7 +101,7 @@ export namespace ClusterExplorerV1 {
     }
 
     export interface NodeSources {
-        resourceFolder(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string): NodeSource;
+        resourceFolder(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string, apiName: string): NodeSource;
         groupingFolder(displayName: string, contextValue: string | undefined, ...children: NodeSource[]): NodeSource;
     }
 }

--- a/src/api/implementation/cluster-explorer/v1.ts
+++ b/src/api/implementation/cluster-explorer/v1.ts
@@ -129,13 +129,13 @@ export class ContributedNode implements ClusterExplorerCustomNode {
     getTreeItem(): vscode.TreeItem {
         return this.impl.getTreeItem();
     }
-    async getPathApi(_namespace: string): Promise<string> {
-        return '';
+    async apiURI(_kubectl: Kubectl, _namespace: string): Promise<string | undefined> {
+        return undefined;
     }
 }
 
-function resourceFolderContributor(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string): ClusterExplorerV1.NodeSource {
-    const nodeSource = new CustomResourceFolderNodeSource(new ResourceKind(displayName, pluralDisplayName, manifestKind, abbreviation));
+function resourceFolderContributor(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string, apiName: string): ClusterExplorerV1.NodeSource {
+    const nodeSource = new CustomResourceFolderNodeSource(new ResourceKind(displayName, pluralDisplayName, manifestKind, abbreviation, apiName));
     return apiNodeSourceOf(nodeSource);
 }
 

--- a/src/api/implementation/cluster-explorer/v1.ts
+++ b/src/api/implementation/cluster-explorer/v1.ts
@@ -134,8 +134,8 @@ export class ContributedNode implements ClusterExplorerCustomNode {
     }
 }
 
-function resourceFolderContributor(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string, apiName: string): ClusterExplorerV1.NodeSource {
-    const nodeSource = new CustomResourceFolderNodeSource(new ResourceKind(displayName, pluralDisplayName, manifestKind, abbreviation, apiName));
+function resourceFolderContributor(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string): ClusterExplorerV1.NodeSource {
+    const nodeSource = new CustomResourceFolderNodeSource(new ResourceKind(displayName, pluralDisplayName, manifestKind, abbreviation));
     return apiNodeSourceOf(nodeSource);
 }
 

--- a/src/api/implementation/cluster-explorer/v1.ts
+++ b/src/api/implementation/cluster-explorer/v1.ts
@@ -130,7 +130,7 @@ export class ContributedNode implements ClusterExplorerCustomNode {
         return this.impl.getTreeItem();
     }
     async getPathApi(_namespace: string): Promise<string> {
-        return ''; //todo ma che so?
+        return '';
     }
 }
 

--- a/src/api/implementation/cluster-explorer/v1.ts
+++ b/src/api/implementation/cluster-explorer/v1.ts
@@ -129,7 +129,7 @@ export class ContributedNode implements ClusterExplorerCustomNode {
     getTreeItem(): vscode.TreeItem {
         return this.impl.getTreeItem();
     }
-    getPathApi(_namespace: string): string {
+    async getPathApi(_namespace: string): Promise<string> {
         return ''; //todo ma che so?
     }
 }

--- a/src/api/implementation/cluster-explorer/v1.ts
+++ b/src/api/implementation/cluster-explorer/v1.ts
@@ -129,6 +129,9 @@ export class ContributedNode implements ClusterExplorerCustomNode {
     getTreeItem(): vscode.TreeItem {
         return this.impl.getTreeItem();
     }
+    getPathApi(_namespace: string): string {
+        return ''; //todo ma che so?
+    }
 }
 
 function resourceFolderContributor(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string): ClusterExplorerV1.NodeSource {

--- a/src/components/clusterexplorer/explorer.ts
+++ b/src/components/clusterexplorer/explorer.ts
@@ -83,7 +83,7 @@ export interface TreeViewNodeStateChangeEvent<T> extends vscode.TreeViewExpansio
 	state: vscode.TreeItemCollapsibleState;
 }
 
-export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplorerNode>, vscode.Disposable {
+export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplorerNode> {
     private onDidChangeTreeDataEmitter: vscode.EventEmitter<ClusterExplorerNode | undefined> = new vscode.EventEmitter<ClusterExplorerNode | undefined>();
     readonly onDidChangeTreeData: vscode.Event<ClusterExplorerNode | undefined> = this.onDidChangeTreeDataEmitter.event;
 
@@ -222,10 +222,6 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
         }, 500);
     }
 
-    dispose() {
-        this.disposable && this.disposable.dispose();
-    }
-
     private onElementCollapsed(e: vscode.TreeViewExpansionEvent<ClusterExplorerNode>) {
         const node = e.element;
         this.collapse(node);
@@ -273,5 +269,3 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
         });
     }
 }
-
-

--- a/src/components/clusterexplorer/explorer.ts
+++ b/src/components/clusterexplorer/explorer.ts
@@ -135,17 +135,26 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
         const watchManager = WatchManager.getInstance();
         const params = {};
         const callback = (type: string, obj: any) => {
+                            const treeItem = node.getTreeItem();
                             if (type === 'ADDED') {
                                 // tslint:disable-next-line:no-console
                                 console.log('new pod:');
-                                this.refresh(node);
+                                providerResult.transform(treeItem, (ti) => {
+                                    if (ti.collapsibleState !== vscode.TreeItemCollapsibleState.Collapsed) {
+                                        this.refresh(node);
+                                    }
+                                });
                             } else if (type === 'MODIFIED') {
                                 // tslint:disable-next-line:no-console
                                 console.log('changed pod:');
                             } else if (type === 'DELETED') {
                                 // tslint:disable-next-line:no-console
                                 console.log('deleted pod:');
-                                this.refresh(node);
+                                providerResult.transform(treeItem, (ti) => {
+                                    if (ti.collapsibleState !== vscode.TreeItemCollapsibleState.Collapsed) {
+                                        this.refresh(node);
+                                    }
+                                });
                             } else {
                                 // tslint:disable-next-line:no-console
                                 console.log('unknown pod: ' + type);
@@ -211,3 +220,5 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
         });
     }
 }
+
+

--- a/src/components/clusterexplorer/explorer.ts
+++ b/src/components/clusterexplorer/explorer.ts
@@ -265,10 +265,6 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
                 break;
             }
             default: {
-                const treeItem = node.getTreeItem();
-                providerResult.transform(treeItem, (ti) => {
-                    id = ti.id || '';
-                });
                 break;
             }
         }

--- a/src/components/clusterexplorer/explorer.ts
+++ b/src/components/clusterexplorer/explorer.ts
@@ -167,8 +167,13 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
                             // tslint:disable-next-line:no-console
                             console.log(obj);
                         };
-        const ti = await this.getTreeItem(node);
-        const label = ti.label || '';
+        let label = '';
+        if ("kind" in node) {
+            label = node.kind.abbreviation;
+        }
+        if ("kindName" in node) {
+            label = node.kindName;
+        }
         const watchManager = WatchManager.getInstance();
         watchManager.addWatch(label, apiUri, params, callback);
     }
@@ -229,13 +234,11 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
     }
 
     private onElementCollapsed(e: vscode.TreeViewExpansionEvent<ClusterExplorerNode>) {
-        const node = e.element;
-        this.collapse(node);
+        this.collapse(e.element);
 	}
 
 	private onElementExpanded(e: vscode.TreeViewExpansionEvent<ClusterExplorerNode>) {
-        const node = e.element;
-        this.expand(node);
+        this.expand(e.element);
     }
 
     private expand(node: ClusterExplorerNode) {

--- a/src/components/clusterexplorer/explorer.ts
+++ b/src/components/clusterexplorer/explorer.ts
@@ -152,6 +152,7 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
         const params = {};
         const callback = (type: string, _obj: any) => {
                             if (type) {
+                                console.log(`watch action: ${type}`);
                                 this.queueRefresh(node);
                             }
                         };
@@ -230,7 +231,7 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
             if (ti.collapsibleState === vscode.TreeItemCollapsibleState.Collapsed) {
                 ti.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
             }
-            if (WatchManager.getInstance().isWatched(watchId) ||
+            if (WatchManager.getInstance().existsWatch(watchId) ||
                 (ti.label &&
                 resourcesToWatch.length > 0 &&
                 resourcesToWatch.indexOf(ti.label) !== -1)) {
@@ -247,7 +248,9 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
             }
         });
         const watchId = this.getWatchId(node);
-        WatchManager.getInstance().removeWatch(watchId);
+        if (WatchManager.getInstance().existsWatch(watchId)) {
+            WatchManager.getInstance().removeWatch(watchId);
+        }
     }
 
     public getWatchId(node: ClusterExplorerNode) {

--- a/src/components/clusterexplorer/explorer.ts
+++ b/src/components/clusterexplorer/explorer.ts
@@ -145,7 +145,7 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
     async watch(node: ClusterExplorerNode): Promise<void> {
         const id = this.getWatchId(node);
         const namespace = await kubectlUtils.currentNamespace(this.kubectl);
-        const apiUri = node.getPathApi(namespace);
+        const apiUri = await node.getPathApi(namespace);
         if (!apiUri) {
             return;
         }

--- a/src/components/clusterexplorer/explorer.ts
+++ b/src/components/clusterexplorer/explorer.ts
@@ -140,9 +140,9 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
                                 // tslint:disable-next-line:no-console
                                 console.log('new pod:');
                                 providerResult.transform(treeItem, (ti) => {
-                                    if (ti.collapsibleState !== vscode.TreeItemCollapsibleState.Collapsed) {
+                                    //if (ti.collapsibleState !== vscode.TreeItemCollapsibleState.Collapsed) {
                                         this.refresh(node);
-                                    }
+                                    //}
                                 });
                             } else if (type === 'MODIFIED') {
                                 // tslint:disable-next-line:no-console
@@ -151,9 +151,9 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
                                 // tslint:disable-next-line:no-console
                                 console.log('deleted pod:');
                                 providerResult.transform(treeItem, (ti) => {
-                                    if (ti.collapsibleState !== vscode.TreeItemCollapsibleState.Collapsed) {
+                                    //if (ti.collapsibleState !== vscode.TreeItemCollapsibleState.Collapsed) {
                                         this.refresh(node);
-                                    }
+                                    //}
                                 });
                             } else {
                                 // tslint:disable-next-line:no-console

--- a/src/components/clusterexplorer/node.configurationvalue.ts
+++ b/src/components/clusterexplorer/node.configurationvalue.ts
@@ -24,4 +24,7 @@ export class ConfigurationValueNode extends ClusterExplorerNodeImpl implements C
     getChildren(_kubectl: Kubectl, _host: Host): vscode.ProviderResult<ClusterExplorerNode[]> {
         return [];
     }
+    getPathApi(_namespace: string): string {
+        return ''; //todo ma che so??
+    }
 }

--- a/src/components/clusterexplorer/node.configurationvalue.ts
+++ b/src/components/clusterexplorer/node.configurationvalue.ts
@@ -25,6 +25,6 @@ export class ConfigurationValueNode extends ClusterExplorerNodeImpl implements C
         return [];
     }
     getPathApi(_namespace: string): string {
-        return ''; //todo ma che so??
+        return '';
     }
 }

--- a/src/components/clusterexplorer/node.configurationvalue.ts
+++ b/src/components/clusterexplorer/node.configurationvalue.ts
@@ -24,7 +24,7 @@ export class ConfigurationValueNode extends ClusterExplorerNodeImpl implements C
     getChildren(_kubectl: Kubectl, _host: Host): vscode.ProviderResult<ClusterExplorerNode[]> {
         return [];
     }
-    async getPathApi(_namespace: string): Promise<string> {
-        return '';
+    async apiURI(_kubectl: Kubectl, _namespace: string): Promise<string | undefined> {
+        return undefined;
     }
 }

--- a/src/components/clusterexplorer/node.configurationvalue.ts
+++ b/src/components/clusterexplorer/node.configurationvalue.ts
@@ -24,7 +24,7 @@ export class ConfigurationValueNode extends ClusterExplorerNodeImpl implements C
     getChildren(_kubectl: Kubectl, _host: Host): vscode.ProviderResult<ClusterExplorerNode[]> {
         return [];
     }
-    getPathApi(_namespace: string): string {
+    async getPathApi(_namespace: string): Promise<string> {
         return '';
     }
 }

--- a/src/components/clusterexplorer/node.context.ts
+++ b/src/components/clusterexplorer/node.context.ts
@@ -54,6 +54,9 @@ export class ContextNode extends ClusterExplorerNodeImpl implements ClusterExplo
         }
         return treeItem;
     }
+    getPathApi(_namespace: string): string {
+        return '';
+    }
 }
 export class MiniKubeContextNode extends ContextNode {
     get icon(): vscode.Uri {

--- a/src/components/clusterexplorer/node.context.ts
+++ b/src/components/clusterexplorer/node.context.ts
@@ -54,7 +54,7 @@ export class ContextNode extends ClusterExplorerNodeImpl implements ClusterExplo
         }
         return treeItem;
     }
-    getPathApi(_namespace: string): string {
+    async getPathApi(_namespace: string): Promise<string> {
         return '';
     }
 }

--- a/src/components/clusterexplorer/node.context.ts
+++ b/src/components/clusterexplorer/node.context.ts
@@ -54,8 +54,8 @@ export class ContextNode extends ClusterExplorerNodeImpl implements ClusterExplo
         }
         return treeItem;
     }
-    async getPathApi(_namespace: string): Promise<string> {
-        return '';
+    async apiURI(_kubectl: Kubectl, _namespace: string): Promise<string | undefined> {
+        return undefined;
     }
 }
 export class MiniKubeContextNode extends ContextNode {

--- a/src/components/clusterexplorer/node.folder.crdtypes.ts
+++ b/src/components/clusterexplorer/node.folder.crdtypes.ts
@@ -16,7 +16,7 @@ export class CRDTypesFolderNode extends GroupingFolderNode {
         return objects.map((obj) => ResourceFolderNode.create(this.customResourceKind(obj)));
     }
     private customResourceKind(crd: CRD): kuberesources.ResourceKind {
-        return new kuberesources.ResourceKind(crd.spec.names.singular, crd.spec.names.plural, crd.spec.names.kind, this.safeAbbreviation(crd));
+        return new kuberesources.ResourceKind(crd.spec.names.singular, crd.spec.names.plural, crd.spec.names.kind, this.safeAbbreviation(crd), crd.spec.names.plural);
     }
     private safeAbbreviation(crd: CRD): string {
         const shortNames = crd.spec.names.shortNames;

--- a/src/components/clusterexplorer/node.folder.resource.ts
+++ b/src/components/clusterexplorer/node.folder.resource.ts
@@ -37,6 +37,9 @@ export class ResourceFolderNode extends FolderNode implements ClusterExplorerRes
     }
 
     async apiURI(kubectl: Kubectl, namespace: string): Promise<string | undefined> {
+        if (!this.kind.apiName) {
+            return undefined;
+        }
         const resources = this.kind.apiName.replace(/\s/g, '').toLowerCase();
         const version = await getResourceVersion(kubectl, resources);
         if (!version) {

--- a/src/components/clusterexplorer/node.folder.resource.ts
+++ b/src/components/clusterexplorer/node.folder.resource.ts
@@ -8,6 +8,7 @@ import { FolderNode } from './node.folder';
 import { ResourceNode } from './node.resource';
 import { getLister } from './resourceui';
 import { NODE_TYPES } from './explorer';
+import { getResourceVersion } from '../../kubectlUtils';
 
 export class ResourceFolderNode extends FolderNode implements ClusterExplorerResourceFolderNode {
 
@@ -33,5 +34,30 @@ export class ResourceFolderNode extends FolderNode implements ClusterExplorerRes
             const bits = line.split(' ');
             return ResourceNode.create(this.kind, bits[0], undefined, undefined);
         });
+    }
+
+    async apiURI(kubectl: Kubectl, namespace: string): Promise<string | undefined> {
+        const resources = this.kind.apiName.replace(/\s/g, '').toLowerCase();
+        const version = await getResourceVersion(kubectl, resources);
+        if (!version) {
+            return undefined;
+        }
+        const baseUri = (version === 'v1') ? `/api/${version}/` : `/apis/${version}/`;
+        const namespaceUri = this.namespaceUriPart(namespace, resources);
+        return `${baseUri}${namespaceUri}${resources}`;
+    }
+
+    private namespaceUriPart(ns: string, resources: string): string {
+        let namespaceUri = `namespaces/${ns}/`;
+        switch (resources) {
+            case "namespaces" || "nodes" || "persistentvolumes" || "storageclasses": {
+                namespaceUri = '';
+                break;
+            }
+            default: {
+                break;
+            }
+        }
+        return namespaceUri;
     }
 }

--- a/src/components/clusterexplorer/node.folder.ts
+++ b/src/components/clusterexplorer/node.folder.ts
@@ -20,7 +20,21 @@ export abstract class FolderNode extends ClusterExplorerNodeImpl implements Clus
     }
 
     getPathApi(namespace: string): string {
-        const namespaceUri = ["namespaces", "nodes"].indexOf(this.displayName.toLowerCase()) !== -1 ? "" : `namespaces/${namespace}/`;
-        return `/api/v1/${namespaceUri}${this.displayName.toLowerCase()}`;
+        let namespaceUri = '';
+        let baseUri = '/api/v1/';
+        switch (this.displayName.toLowerCase()) {
+            case "namespaces" || "nodes": {
+                break;
+            }
+            case "jobs": {
+                baseUri = '/apis/batch/v1/';
+                break;
+            }
+            default: {
+                namespaceUri = `namespaces/${namespace}/`;
+                break;
+            }
+        }
+        return `${baseUri}${namespaceUri}${this.displayName.toLowerCase()}`;
     }
 }

--- a/src/components/clusterexplorer/node.folder.ts
+++ b/src/components/clusterexplorer/node.folder.ts
@@ -18,4 +18,9 @@ export abstract class FolderNode extends ClusterExplorerNodeImpl implements Clus
         treeItem.contextValue = this.contextValue || `vsKubernetes.${this.id}`;
         return treeItem;
     }
+
+    getPathApi(namespace: string): string {
+        const namespaceUri = ["namespaces", "nodes"].indexOf(this.displayName.toLowerCase()) !== -1 ? "" : `namespaces/${namespace}/`;
+        return `/api/v1/${namespaceUri}${this.displayName.toLowerCase()}`;
+    }
 }

--- a/src/components/clusterexplorer/node.folder.ts
+++ b/src/components/clusterexplorer/node.folder.ts
@@ -4,7 +4,6 @@ import { Kubectl } from '../../kubectl';
 import { Host } from '../../host';
 import { ClusterExplorerNode, ClusterExplorerNodeBase, ClusterExplorerNodeImpl } from './node';
 import { KubernetesExplorerNodeType } from './explorer';
-import { getResourceVersion } from '../../extension';
 
 export abstract class FolderNode extends ClusterExplorerNodeImpl implements ClusterExplorerNodeBase {
 
@@ -20,20 +19,7 @@ export abstract class FolderNode extends ClusterExplorerNodeImpl implements Clus
         return treeItem;
     }
 
-    async getPathApi(namespace: string): Promise<string> {
-        const resources = this.displayName.replace(/\s/g, '').toLowerCase();
-        const version = await getResourceVersion(resources);
-        const baseUri = (version === 'v1') ? `/api/${version}/` : `/apis/${version}/`;
-        let namespaceUri = `namespaces/${namespace}/`;
-        switch (resources) {
-            case "namespaces" || "nodes" || "persistentvolumes" || "storageclasses": {
-                namespaceUri = '';
-                break;
-            }
-            default: {
-                break;
-            }
-        }
-        return `${baseUri}${namespaceUri}${resources}`;
+    async apiURI(_kubectl: Kubectl, _namespace: string): Promise<string | undefined> {
+        return undefined;
     }
 }

--- a/src/components/clusterexplorer/node.helmrelease.ts
+++ b/src/components/clusterexplorer/node.helmrelease.ts
@@ -26,7 +26,7 @@ export class HelmReleaseNode extends ClusterExplorerNodeImpl implements ClusterE
         return treeItem;
     }
     getPathApi(_namespace: string): string {
-        return ''; //todo
+        return '';
     }
 }
 

--- a/src/components/clusterexplorer/node.helmrelease.ts
+++ b/src/components/clusterexplorer/node.helmrelease.ts
@@ -25,7 +25,7 @@ export class HelmReleaseNode extends ClusterExplorerNodeImpl implements ClusterE
         treeItem.iconPath = getIconForHelmRelease(this.status.toLowerCase());
         return treeItem;
     }
-    getPathApi(_namespace: string): string {
+    async getPathApi(_namespace: string): Promise<string> {
         return '';
     }
 }

--- a/src/components/clusterexplorer/node.helmrelease.ts
+++ b/src/components/clusterexplorer/node.helmrelease.ts
@@ -25,6 +25,9 @@ export class HelmReleaseNode extends ClusterExplorerNodeImpl implements ClusterE
         treeItem.iconPath = getIconForHelmRelease(this.status.toLowerCase());
         return treeItem;
     }
+    getPathApi(_namespace: string): string {
+        return ''; //todo
+    }
 }
 
 function getIconForHelmRelease(status: string): vscode.Uri {

--- a/src/components/clusterexplorer/node.helmrelease.ts
+++ b/src/components/clusterexplorer/node.helmrelease.ts
@@ -25,8 +25,8 @@ export class HelmReleaseNode extends ClusterExplorerNodeImpl implements ClusterE
         treeItem.iconPath = getIconForHelmRelease(this.status.toLowerCase());
         return treeItem;
     }
-    async getPathApi(_namespace: string): Promise<string> {
-        return '';
+    async apiURI(_kubectl: Kubectl, _namespace: string): Promise<string | undefined> {
+        return undefined;
     }
 }
 

--- a/src/components/clusterexplorer/node.message.ts
+++ b/src/components/clusterexplorer/node.message.ts
@@ -24,7 +24,7 @@ export class MessageNode extends ClusterExplorerNodeImpl implements ClusterExplo
     getChildren(_kubectl: Kubectl, _host: Host): vscode.ProviderResult<ClusterExplorerNode[]> {
         return [];
     }
-    getPathApi(_namespace: string): string {
+    async getPathApi(_namespace: string): Promise<string> {
         return '';
     }
 }

--- a/src/components/clusterexplorer/node.message.ts
+++ b/src/components/clusterexplorer/node.message.ts
@@ -24,7 +24,7 @@ export class MessageNode extends ClusterExplorerNodeImpl implements ClusterExplo
     getChildren(_kubectl: Kubectl, _host: Host): vscode.ProviderResult<ClusterExplorerNode[]> {
         return [];
     }
-    async getPathApi(_namespace: string): Promise<string> {
-        return '';
+    async apiURI(_kubectl: Kubectl, _namespace: string): Promise<string | undefined> {
+        return undefined;
     }
 }

--- a/src/components/clusterexplorer/node.message.ts
+++ b/src/components/clusterexplorer/node.message.ts
@@ -24,4 +24,7 @@ export class MessageNode extends ClusterExplorerNodeImpl implements ClusterExplo
     getChildren(_kubectl: Kubectl, _host: Host): vscode.ProviderResult<ClusterExplorerNode[]> {
         return [];
     }
+    getPathApi(_namespace: string): string {
+        return '';
+    }
 }

--- a/src/components/clusterexplorer/node.resource.ts
+++ b/src/components/clusterexplorer/node.resource.ts
@@ -56,6 +56,10 @@ export class ResourceNode extends ClusterExplorerNodeImpl implements ClusterExpl
     get isExpandable(): boolean {
         return getChildSources(this.kind).length > 0;
     }
+
+    getPathApi(_namespace: string): string {
+        return ''; //todo
+    }
 }
 
 export interface ResourceExtraInfo {

--- a/src/components/clusterexplorer/node.resource.ts
+++ b/src/components/clusterexplorer/node.resource.ts
@@ -57,8 +57,10 @@ export class ResourceNode extends ClusterExplorerNodeImpl implements ClusterExpl
         return getChildSources(this.kind).length > 0;
     }
 
-    getPathApi(_namespace: string): string {
-        return ''; //todo
+    getPathApi(namespace: string): string {
+        const kind = this.kind.pluralDisplayName.toLowerCase();
+        const namespaceUri = ["namespaces", "nodes"].indexOf(kind) !== -1 ? kind : `namespaces/${namespace}/${kind}`;
+        return `/api/v1/${namespaceUri}/${this.name}`;
     }
 }
 

--- a/src/components/clusterexplorer/node.resource.ts
+++ b/src/components/clusterexplorer/node.resource.ts
@@ -58,6 +58,9 @@ export class ResourceNode extends ClusterExplorerNodeImpl implements ClusterExpl
     }
 
     async apiURI(kubectl: Kubectl, namespace: string): Promise<string | undefined> {
+        if (!this.kind.apiName) {
+            return undefined;
+        }
         const resources = this.kind.apiName.replace(/\s/g, '').toLowerCase();
         const version = await kubectlUtils.getResourceVersion(kubectl, resources);
         if (!version) {

--- a/src/components/clusterexplorer/node.ts
+++ b/src/components/clusterexplorer/node.ts
@@ -11,6 +11,7 @@ export interface ClusterExplorerNodeBase {
     readonly nodeCategory: 'kubernetes-explorer-node';
     getChildren(kubectl: Kubectl, host: Host): vscode.ProviderResult<ClusterExplorerNode[]>;
     getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem>;
+    getPathApi(namespace: string): string;
 }
 
 export interface ClusterExplorerContextNode extends ClusterExplorerNodeBase {

--- a/src/components/clusterexplorer/node.ts
+++ b/src/components/clusterexplorer/node.ts
@@ -11,7 +11,7 @@ export interface ClusterExplorerNodeBase {
     readonly nodeCategory: 'kubernetes-explorer-node';
     getChildren(kubectl: Kubectl, host: Host): vscode.ProviderResult<ClusterExplorerNode[]>;
     getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem>;
-    getPathApi(namespace: string): string;
+    getPathApi(namespace: string): Promise<string>;
 }
 
 export interface ClusterExplorerContextNode extends ClusterExplorerNodeBase {

--- a/src/components/clusterexplorer/node.ts
+++ b/src/components/clusterexplorer/node.ts
@@ -11,7 +11,7 @@ export interface ClusterExplorerNodeBase {
     readonly nodeCategory: 'kubernetes-explorer-node';
     getChildren(kubectl: Kubectl, host: Host): vscode.ProviderResult<ClusterExplorerNode[]>;
     getTreeItem(): vscode.TreeItem | Thenable<vscode.TreeItem>;
-    getPathApi(namespace: string): Promise<string>;
+    apiURI(kubectl: Kubectl, namespace: string): Promise<string | undefined>;
 }
 
 export interface ClusterExplorerContextNode extends ClusterExplorerNodeBase {

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -6,7 +6,7 @@ const EXTENSION_CONFIG_KEY = "vs-kubernetes";
 const KUBECONFIG_PATH_KEY = "vs-kubernetes.kubeconfig";
 const KNOWN_KUBECONFIGS_KEY = "vs-kubernetes.knownKubeconfigs";
 const KUBECTL_VERSIONING_KEY = "vs-kubernetes.kubectlVersioning";
-const RWATCH_KUBECONFIGS_KEY = "vs-kubernetes.resource-to-watch";
+const RESOURCES_TO_WATCH_KEY = "vs-kubernetes.resource-to-watch";
 
 export enum KubectlVersioning {
     UserProvided = 1,
@@ -235,7 +235,7 @@ export function getPythonDebugPort(): number | undefined {
 // Functions for working with the list of resources to be watched
 
 export function getResourcesToBeWatched(): string[] {
-    const krwConfig = vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)[RWATCH_KUBECONFIGS_KEY];
+    const krwConfig = vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)[RESOURCES_TO_WATCH_KEY];
     if (!krwConfig || !krwConfig.length) {
         return [];
     }

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -6,7 +6,7 @@ const EXTENSION_CONFIG_KEY = "vs-kubernetes";
 const KUBECONFIG_PATH_KEY = "vs-kubernetes.kubeconfig";
 const KNOWN_KUBECONFIGS_KEY = "vs-kubernetes.knownKubeconfigs";
 const KUBECTL_VERSIONING_KEY = "vs-kubernetes.kubectlVersioning";
-const RESOURCES_TO_WATCH_KEY = "vs-kubernetes.resource-to-watch";
+const RESOURCES_TO_WATCH_KEY = "vs-kubernetes.resources-to-watch";
 
 export enum KubectlVersioning {
     UserProvided = 1,

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -6,6 +6,7 @@ const EXTENSION_CONFIG_KEY = "vs-kubernetes";
 const KUBECONFIG_PATH_KEY = "vs-kubernetes.kubeconfig";
 const KNOWN_KUBECONFIGS_KEY = "vs-kubernetes.knownKubeconfigs";
 const KUBECTL_VERSIONING_KEY = "vs-kubernetes.kubectlVersioning";
+const RWATCH_KUBECONFIGS_KEY = "vs-kubernetes.resource-to-watch";
 
 export enum KubectlVersioning {
     UserProvided = 1,
@@ -229,4 +230,14 @@ export function getPythonRemoteRoot(): string {
 // remote debugging port for Python. Usually 5678
 export function getPythonDebugPort(): number | undefined {
     return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.python-debug-port'];
+}
+
+// Functions for working with the list of resources to be watched
+
+export function getResourcesToBeWatched(): string[] {
+    const krwConfig = vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)[RWATCH_KUBECONFIGS_KEY];
+    if (!krwConfig || !krwConfig.length) {
+        return [];
+    }
+    return krwConfig as string[];
 }

--- a/src/components/kubectl/watch.ts
+++ b/src/components/kubectl/watch.ts
@@ -25,7 +25,6 @@ export class WatchManager {
         const kc = await loadKubeconfig();
         const kcWatch = new kubernetes.Watch(kc);
         const doneCallback = (err: any) => {
-                                            // tslint:disable-next-line:no-console
                                             // Error: read ECONNRESET
                                             // at TLSWrap.onStreamRead (internal/stream_base_commons.js:183:27)
                                             if (err &&

--- a/src/components/kubectl/watch.ts
+++ b/src/components/kubectl/watch.ts
@@ -1,0 +1,43 @@
+import { loadKubeconfig } from '../../explainer';
+import * as kubernetes from '@kubernetes/client-node';
+import { Request } from 'request';
+
+export class WatchManager {
+    private static instance: WatchManager;
+    private watchers: Map<string, Request>;
+
+    private constructor() {
+        this.watchers = new Map<string, Request>();
+    }
+
+    public static getInstance() {
+        if (!this.instance) {
+            this.instance = new WatchManager();
+        }
+
+        return this.instance;
+    }
+
+    public async addWatch(name: string, apiUri: string, params: any, callback: (phase: string, obj: any) => void): Promise<void> {
+        const kc = await loadKubeconfig();
+        const kcWatch = new kubernetes.Watch(kc);
+        const watcher = kcWatch.watch(apiUri,
+                                      params,
+                                      callback,
+                                      // done callback is called if the watch terminates normally
+                                      (err) => {
+                                          // tslint:disable-next-line:no-console
+                                          //err.code === "ECONNRESET";
+                                          console.log(err);
+                                      });
+        this.watchers.set(name, watcher);
+    }
+
+    public removeWatch(name: string) {
+        const watcher = this.watchers.get(name);
+        if (watcher) {
+            watcher.abort();
+        }
+        this.watchers.delete(name);
+    }
+}

--- a/src/components/kubectl/watch.ts
+++ b/src/components/kubectl/watch.ts
@@ -18,8 +18,8 @@ export class WatchManager {
         return this.instance;
     }
 
-    public async addWatch(name: string, apiUri: string, params: any, callback: (phase: string, obj: any) => void): Promise<void> {
-        if (this.watchers.has(name)) {
+    public async addWatch(id: string, apiUri: string, params: any, callback: (phase: string, obj: any) => void): Promise<void> {
+        if (this.watchers.has(id)) {
             return;
         }
         const kc = await loadKubeconfig();
@@ -29,8 +29,8 @@ export class WatchManager {
                                             // at TLSWrap.onStreamRead (internal/stream_base_commons.js:183:27)
                                             if (err &&
                                                 (err as Error).name === "ECONNRESET") {
-                                                    this.removeWatch(name);
-                                                    this.addWatch(name, apiUri, params, callback);
+                                                    this.removeWatch(id);
+                                                    this.addWatch(id, apiUri, params, callback);
                                             }
                                             console.log(err);
                                             };
@@ -39,17 +39,25 @@ export class WatchManager {
                                                callback,
                                                doneCallback
                                                );
-        this.watchers.set(name, watcher);
+        this.watchers.set(id, watcher);
     }
 
-    public removeWatch(name: string) {
-        if (!this.watchers.has(name)) {
+    public removeWatch(id: string) {
+        if (!this.watchers.has(id)) {
             return;
         }
-        const watcher = this.watchers.get(name);
+        const watcher = this.watchers.get(id);
         if (watcher) {
             watcher.abort();
         }
-        this.watchers.delete(name);
+        this.watchers.delete(id);
+    }
+
+    public clear() {
+        if (this.watchers && this.watchers.size > 0) {
+            this.watchers.forEach((_value, key, _map) => {
+                this.removeWatch(key);
+            });
+        }
     }
 }

--- a/src/components/kubectl/watch.ts
+++ b/src/components/kubectl/watch.ts
@@ -58,11 +58,11 @@ export class WatchManager {
             this.watchers.forEach((_value, key, _map) => {
                 this.removeWatch(key);
             });
+            this.watchers.clear();
         }
-        this.watchers.clear();
     }
 
-    public isWatched(id: string) {
+    public existsWatch(id: string) {
         return id && this.watchers.has(id);
     }
 }

--- a/src/components/kubectl/watch.ts
+++ b/src/components/kubectl/watch.ts
@@ -19,21 +19,34 @@ export class WatchManager {
     }
 
     public async addWatch(name: string, apiUri: string, params: any, callback: (phase: string, obj: any) => void): Promise<void> {
+        if (this.watchers.has(name)) {
+            return;
+        }
         const kc = await loadKubeconfig();
         const kcWatch = new kubernetes.Watch(kc);
-        const watcher = kcWatch.watch(apiUri,
-                                      params,
-                                      callback,
-                                      // done callback is called if the watch terminates normally
-                                      (err) => {
-                                          // tslint:disable-next-line:no-console
-                                          //err.code === "ECONNRESET";
-                                          console.log(err);
-                                      });
+        const doneCallback = (err: any) => {
+                                            // tslint:disable-next-line:no-console
+                                            // Error: read ECONNRESET
+                                            // at TLSWrap.onStreamRead (internal/stream_base_commons.js:183:27)
+                                            if (err &&
+                                                (err as Error).name === "ECONNRESET") {
+                                                    this.removeWatch(name);
+                                                    this.addWatch(name, apiUri, params, callback);
+                                            }
+                                            console.log(err);
+                                            };
+        const watcher: Request = kcWatch.watch(apiUri,
+                                               params,
+                                               callback,
+                                               doneCallback
+                                               );
         this.watchers.set(name, watcher);
     }
 
     public removeWatch(name: string) {
+        if (!this.watchers.has(name)) {
+            return;
+        }
         const watcher = this.watchers.get(name);
         if (watcher) {
             watcher.abort();

--- a/src/explainer.ts
+++ b/src/explainer.ts
@@ -3,34 +3,9 @@
 import request = require('request');
 import * as kubernetes from '@kubernetes/client-node';
 import * as pluralize from 'pluralize';
-import * as shelljs from 'shelljs';
 
 import { formatComplex, formatOne, Typed, formatType } from "./schema-formatting";
-import { getKubeconfigPath } from './components/kubectl/kubeconfig';
-
-export async function loadKubeconfig(): Promise<kubernetes.KubeConfig> {
-    const kubeconfig = new kubernetes.KubeConfig();
-    const kubeconfigPath = getKubeconfigPath();
-
-    if (kubeconfigPath.pathType === 'host') {
-        kubeconfig.loadFromFile(kubeconfigPath.hostPath);
-    } else if (kubeconfigPath.pathType === 'wsl') {
-        const result = shelljs.exec(`wsl.exe sh -c "cat ${kubeconfigPath.wslPath}"`, { silent: true }) as shelljs.ExecOutputReturnValue;
-        if (!result) {
-            throw new Error(`Impossible to retrieve the kubeconfig content from WSL at path '${kubeconfigPath.wslPath}'. No result from the shelljs.exe call.`);
-        }
-
-        if (result.code !== 0) {
-            throw new Error(`Impossible to retrieve the kubeconfig content from WSL at path '${kubeconfigPath.wslPath}. Error code: ${result.code}. Error output: ${result.stderr.trim()}`);
-        }
-
-        kubeconfig.loadFromString(result.stdout.trim());
-    } else {
-        throw new Error(`Kubeconfig path type is not recognized.`);
-    }
-
-    return kubeconfig;
-}
+import { loadKubeconfig } from './components/kubectl/kubeconfig';
 
 export interface SwaggerModel {
     readonly definitions: any[];

--- a/src/explainer.ts
+++ b/src/explainer.ts
@@ -8,7 +8,7 @@ import * as shelljs from 'shelljs';
 import { formatComplex, formatOne, Typed, formatType } from "./schema-formatting";
 import { getKubeconfigPath } from './components/kubectl/kubeconfig';
 
-async function loadKubeconfig(): Promise<kubernetes.KubeConfig> {
+export async function loadKubeconfig(): Promise<kubernetes.KubeConfig> {
     const kubeconfig = new kubernetes.KubeConfig();
     const kubeconfigPath = getKubeconfigPath();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -199,7 +199,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         registerCommand('extension.vsKubernetesUseNamespace', (explorerNode: ClusterExplorerNode) => { useNamespaceKubernetes(kubectl, explorerNode); } ),
         registerCommand('extension.vsKubernetesDashboard', () => { dashboardKubernetes(kubectl); }),
         registerCommand('extension.vsKubernetesAddWatcher', (explorerNode: ClusterExplorerNode) => { addWatch(treeProvider, explorerNode); }),
-        registerCommand('extension.vsKubernetesDeleteWatcher', (explorerNode: ClusterExplorerNode) => { deleteWatch(explorerNode); }),
+        registerCommand('extension.vsKubernetesDeleteWatcher', (explorerNode: ClusterExplorerNode) => { deleteWatch(treeProvider, explorerNode); }),
         registerCommand('extension.vsMinikubeStop', () => minikube.stop()),
         registerCommand('extension.vsMinikubeStart', () => minikube.start({} as MinikubeOptions)),
         registerCommand('extension.vsMinikubeStatus', async () => {
@@ -793,22 +793,16 @@ function getKubernetes(explorerNode?: any) {
     }
 }
 
-async function addWatch(tree: explorer.KubernetesExplorer, explorerNode?: ClusterExplorerNode) {
+function addWatch(tree: explorer.KubernetesExplorer, explorerNode?: ClusterExplorerNode) {
     if (explorerNode) {
-        tree.addWatcher(explorerNode);
+        tree.watch(explorerNode);
     }
 }
 
-async function deleteWatch(explorerNode?: ClusterExplorerNode) {
+function deleteWatch(tree: explorer.KubernetesExplorer, explorerNode?: ClusterExplorerNode) {
     if (explorerNode) {
-        let label = '';
-        if ("kind" in explorerNode) {
-            label = explorerNode.kind.abbreviation;
-        }
-        if ("kindName" in explorerNode) {
-            label = explorerNode.kindName;
-        }
-        WatchManager.getInstance().removeWatch(label);
+        const id = tree.getWatchId(explorerNode);
+        WatchManager.getInstance().removeWatch(id);
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -199,7 +199,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         registerCommand('extension.vsKubernetesUseNamespace', (explorerNode: ClusterExplorerNode) => { useNamespaceKubernetes(kubectl, explorerNode); } ),
         registerCommand('extension.vsKubernetesDashboard', () => { dashboardKubernetes(kubectl); }),
         registerCommand('extension.vsKubernetesAddWatcher', (explorerNode: ClusterExplorerNode) => { addWatch(treeProvider, explorerNode); }),
-        registerCommand('extension.vsKubernetesDeleteWatcher', (explorerNode: ClusterExplorerNode) => { deleteWatch(treeProvider, explorerNode); }),
+        registerCommand('extension.vsKubernetesDeleteWatcher', (explorerNode: ClusterExplorerNode) => { deleteWatch(explorerNode); }),
         registerCommand('extension.vsMinikubeStop', () => minikube.stop()),
         registerCommand('extension.vsMinikubeStart', () => minikube.start({} as MinikubeOptions)),
         registerCommand('extension.vsMinikubeStatus', async () => {
@@ -799,12 +799,16 @@ async function addWatch(tree: explorer.KubernetesExplorer, explorerNode?: Cluste
     }
 }
 
-async function deleteWatch(tree: explorer.KubernetesExplorer, explorerNode?: ClusterExplorerNode) {
+async function deleteWatch(explorerNode?: ClusterExplorerNode) {
     if (explorerNode) {
-        const nodeItem = await tree.getTreeItem(explorerNode);
-        if (nodeItem.label) {
-            WatchManager.getInstance().removeWatch(nodeItem.label);
+        let label = '';
+        if ("kind" in explorerNode) {
+            label = explorerNode.kind.abbreviation;
         }
+        if ("kindName" in explorerNode) {
+            label = explorerNode.kindName;
+        }
+        WatchManager.getInstance().removeWatch(label);
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -795,10 +795,7 @@ function getKubernetes(explorerNode?: any) {
 
 async function addWatch(tree: explorer.KubernetesExplorer, explorerNode?: ClusterExplorerNode) {
     if (explorerNode) {
-        const nodeItem = await tree.getTreeItem(explorerNode);
-        if (nodeItem.label) {
-            tree.addWatcher(nodeItem.label, explorerNode);
-        }
+        tree.addWatcher(explorerNode);
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2278,3 +2278,22 @@ function kubernetesFindCloudProviders() {
     const searchUrl = 'https://marketplace.visualstudio.com/search?term=kubernetes-extension-cloud-provider&target=VSCode&category=All%20categories&sortBy=Relevance';
     browser.open(searchUrl);
 }
+
+export async function getResourceVersion(resource: string): Promise<string> {
+    const documentation = await kubectl.asLines(` explain ${resource}`);
+    if (failed(documentation)) {
+        return '';
+    }
+
+    const rgx = new RegExp('(?<=VERSION:\\s*)(\\S)+.*');
+    let version = '';
+    for (const line of documentation.result) {
+        const match = line.match(rgx);
+        if (match) {
+            version = match[0];
+            break;
+        }
+    }
+
+    return version;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -802,7 +802,9 @@ function addWatch(tree: explorer.KubernetesExplorer, explorerNode?: ClusterExplo
 function deleteWatch(tree: explorer.KubernetesExplorer, explorerNode?: ClusterExplorerNode) {
     if (explorerNode) {
         const id = tree.getWatchId(explorerNode);
-        WatchManager.getInstance().removeWatch(id);
+        if (id) {
+            WatchManager.getInstance().removeWatch(id);
+        }
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -801,10 +801,7 @@ function addWatch(tree: explorer.KubernetesExplorer, explorerNode?: ClusterExplo
 
 function deleteWatch(tree: explorer.KubernetesExplorer, explorerNode?: ClusterExplorerNode) {
     if (explorerNode) {
-        const id = tree.getWatchId(explorerNode);
-        if (id) {
-            WatchManager.getInstance().removeWatch(id);
-        }
+        tree.stopWatching(explorerNode);
     }
 }
 
@@ -1935,7 +1932,7 @@ async function useContextKubernetes(explorerNode: ClusterExplorerNode) {
         telemetry.invalidateClusterType(targetContext);
         activeContextTracker.setActive(targetContext);
         refreshExplorer();
-        WatchManager.getInstance().clear();
+        WatchManager.instance().clear();
     } else {
         vscode.window.showErrorMessage(`Failed to set '${targetContext}' as current cluster: ${shellResult ? shellResult.stderr : "Unable to run kubectl"}`);
     }
@@ -2279,23 +2276,4 @@ async function kubeconfigFromTreeNode(target?: CloudExplorerTreeNode): Promise<s
 function kubernetesFindCloudProviders() {
     const searchUrl = 'https://marketplace.visualstudio.com/search?term=kubernetes-extension-cloud-provider&target=VSCode&category=All%20categories&sortBy=Relevance';
     browser.open(searchUrl);
-}
-
-export async function getResourceVersion(resource: string): Promise<string> {
-    const documentation = await kubectl.asLines(` explain ${resource}`);
-    if (failed(documentation)) {
-        return '';
-    }
-
-    const rgx = new RegExp('(?<=VERSION:\\s*)(\\S)+.*');
-    let version = '';
-    for (const line of documentation.result) {
-        const match = line.match(rgx);
-        if (match) {
-            version = match[0];
-            break;
-        }
-    }
-
-    return version;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1939,6 +1939,7 @@ async function useContextKubernetes(explorerNode: ClusterExplorerNode) {
         telemetry.invalidateClusterType(targetContext);
         activeContextTracker.setActive(targetContext);
         refreshExplorer();
+        WatchManager.getInstance().clear();
     } else {
         vscode.window.showErrorMessage(`Failed to set '${targetContext}' as current cluster: ${shellResult ? shellResult.stderr : "Unable to run kubectl"}`);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -296,7 +296,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         portForwardStatusBarItem,
 
         // Telemetry
-        registerTelemetry(context)
+        registerTelemetry(context),
+
+        treeProvider.initialize()
     ];
 
     telemetry.invalidateClusterType(undefined, kubectl);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -198,8 +198,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         registerCommand('extension.vsKubernetesDeleteContext', deleteContextKubernetes),
         registerCommand('extension.vsKubernetesUseNamespace', (explorerNode: ClusterExplorerNode) => { useNamespaceKubernetes(kubectl, explorerNode); } ),
         registerCommand('extension.vsKubernetesDashboard', () => { dashboardKubernetes(kubectl); }),
-        registerCommand('extension.vsKubernetesAddWatcher', (explorerNode: ClusterExplorerNode) => { addWatch(explorerNode, treeProvider); }),
-        registerCommand('extension.vsKubernetesDeleteWatcher', (explorerNode: ClusterExplorerNode) => { deleteWatch(explorerNode, treeProvider); }),
+        registerCommand('extension.vsKubernetesAddWatcher', (explorerNode: ClusterExplorerNode) => { addWatch(treeProvider, explorerNode); }),
+        registerCommand('extension.vsKubernetesDeleteWatcher', (explorerNode: ClusterExplorerNode) => { deleteWatch(treeProvider, explorerNode); }),
         registerCommand('extension.vsMinikubeStop', () => minikube.stop()),
         registerCommand('extension.vsMinikubeStart', () => minikube.start({} as MinikubeOptions)),
         registerCommand('extension.vsMinikubeStatus', async () => {
@@ -791,7 +791,7 @@ function getKubernetes(explorerNode?: any) {
     }
 }
 
-async function addWatch(explorerNode: ClusterExplorerNode, tree: explorer.KubernetesExplorer) {
+async function addWatch(tree: explorer.KubernetesExplorer, explorerNode?: ClusterExplorerNode) {
     if (explorerNode) {
         const nodeItem = await tree.getTreeItem(explorerNode);
         if (nodeItem.label) {
@@ -800,7 +800,7 @@ async function addWatch(explorerNode: ClusterExplorerNode, tree: explorer.Kubern
     }
 }
 
-async function deleteWatch(explorerNode: ClusterExplorerNode, tree: explorer.KubernetesExplorer) {
+async function deleteWatch(tree: explorer.KubernetesExplorer, explorerNode?: ClusterExplorerNode) {
     if (explorerNode) {
         const nodeItem = await tree.getTreeItem(explorerNode);
         if (nodeItem.label) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -198,8 +198,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         registerCommand('extension.vsKubernetesDeleteContext', deleteContextKubernetes),
         registerCommand('extension.vsKubernetesUseNamespace', (explorerNode: ClusterExplorerNode) => { useNamespaceKubernetes(kubectl, explorerNode); } ),
         registerCommand('extension.vsKubernetesDashboard', () => { dashboardKubernetes(kubectl); }),
-        registerCommand('extension.vsKubernetesAddWatcher', (explorerNode: ClusterExplorerNode) => { addWatch(treeProvider, explorerNode); }),
-        registerCommand('extension.vsKubernetesDeleteWatcher', (explorerNode: ClusterExplorerNode) => { deleteWatch(treeProvider, explorerNode); }),
+        registerCommand('extension.vsKubernetesAddWatch', (explorerNode: ClusterExplorerNode) => { addWatch(treeProvider, explorerNode); }),
+        registerCommand('extension.vsKubernetesDeleteWatch', (explorerNode: ClusterExplorerNode) => { deleteWatch(treeProvider, explorerNode); }),
         registerCommand('extension.vsMinikubeStop', () => minikube.stop()),
         registerCommand('extension.vsMinikubeStart', () => minikube.start({} as MinikubeOptions)),
         registerCommand('extension.vsMinikubeStatus', async () => {

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -435,3 +435,20 @@ export async function namespaceResources(kubectl: Kubectl, ns: string): Promise<
     const resources = getresult.stdout.split('\n').map((s) => s.trim()).filter((s) => s.length > 0);
     return { succeeded: true, result: resources };
 }
+
+export async function getResourceVersion(kubectl: Kubectl, resource: string): Promise<string | undefined> {
+    const documentation = await kubectl.asLines(` explain ${resource}`);
+    if (failed(documentation)) {
+        return undefined;
+    }
+
+    const rgx = new RegExp('(?<=VERSION:\\s*)(\\S)+.*');
+    for (const line of documentation.result) {
+        const match = line.match(rgx);
+        if (match) {
+            return match[0];
+        }
+    }
+
+    return undefined;
+}

--- a/src/kuberesources.ts
+++ b/src/kuberesources.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { Dictionary } from './utils/dictionary';
 
 export class ResourceKind implements vscode.QuickPickItem {
-    constructor(readonly displayName: string, readonly pluralDisplayName: string, readonly manifestKind: string, readonly abbreviation: string) {
+    constructor(readonly displayName: string, readonly pluralDisplayName: string, readonly manifestKind: string, readonly abbreviation: string, readonly apiName: string) {
     }
 
     get label() { return this.displayName; }
@@ -10,25 +10,25 @@ export class ResourceKind implements vscode.QuickPickItem {
 }
 
 export const allKinds: Dictionary<ResourceKind> = {
-    endpoint: new ResourceKind("Endpoint", "Endpoints", "Endpoint", "endpoints"),
-    namespace: new ResourceKind("Namespace", "Namespaces", "Namespace", "namespace"),
-    node: new ResourceKind("Node", "Nodes", "Node", "node"),
-    deployment: new ResourceKind("Deployment", "Deployments", "Deployment", "deployment"),
-    daemonSet: new ResourceKind("DaemonSet", "DaemonSets", "DaemonSet", "daemonset"),
-    replicaSet: new ResourceKind("ReplicaSet", "ReplicaSets", "ReplicaSet", "rs"),
-    replicationController: new ResourceKind("Replication Controller", "Replication Controllers", "ReplicationController", "rc"),
-    job: new ResourceKind("Job", "Jobs", "Job", "job"),
-    cronjob: new ResourceKind("CronJob", "CronJobs", "CronJob", "cronjob"),
-    pod: new ResourceKind("Pod", "Pods", "Pod", "pod"),
-    crd: new ResourceKind("Custom Resource", "Custom Resources", "CustomResourceDefinition", "crd"),
-    service: new ResourceKind("Service", "Services", "Service", "service"),
-    configMap: new ResourceKind("ConfigMap", "Config Maps", "ConfigMap", "configmap"),
-    secret: new ResourceKind("Secret", "Secrets", "Secret", "secret"),
-    ingress: new ResourceKind("Ingress", "Ingress", "Ingress", "ingress"),
-    persistentVolume: new ResourceKind("Persistent Volume", "Persistent Volumes", "PersistentVolume", "pv"),
-    persistentVolumeClaim: new ResourceKind("Persistent Volume Claim", "Persistent Volume Claims", "PersistentVolumeClaim", "pvc"),
-    storageClass: new ResourceKind("Storage Class", "Storage Classes", "StorageClass", "sc"),
-    statefulSet: new ResourceKind("StatefulSet", "StatefulSets", "StatefulSet", "statefulset"),
+    endpoint: new ResourceKind("Endpoint", "Endpoints", "Endpoint", "endpoints", "endpoints"),
+    namespace: new ResourceKind("Namespace", "Namespaces", "Namespace", "namespace" , "namespaces"),
+    node: new ResourceKind("Node", "Nodes", "Node", "node", "nodes"),
+    deployment: new ResourceKind("Deployment", "Deployments", "Deployment", "deployment", "deployments"),
+    daemonSet: new ResourceKind("DaemonSet", "DaemonSets", "DaemonSet", "daemonset", "daemonsets"),
+    replicaSet: new ResourceKind("ReplicaSet", "ReplicaSets", "ReplicaSet", "rs", "replicasets"),
+    replicationController: new ResourceKind("Replication Controller", "Replication Controllers", "ReplicationController", "rc", "replicationcontrollers"),
+    job: new ResourceKind("Job", "Jobs", "Job", "job", "jobs"),
+    cronjob: new ResourceKind("CronJob", "CronJobs", "CronJob", "cronjob", "cronjobs"),
+    pod: new ResourceKind("Pod", "Pods", "Pod", "pod", "pods"),
+    crd: new ResourceKind("Custom Resource", "Custom Resources", "CustomResourceDefinition", "crd", "customresources"),
+    service: new ResourceKind("Service", "Services", "Service", "service", "services"),
+    configMap: new ResourceKind("ConfigMap", "Config Maps", "ConfigMap", "configmap", "configmaps"),
+    secret: new ResourceKind("Secret", "Secrets", "Secret", "secret", "secrets"),
+    ingress: new ResourceKind("Ingress", "Ingress", "Ingress", "ingress", "ingress"),
+    persistentVolume: new ResourceKind("Persistent Volume", "Persistent Volumes", "PersistentVolume", "pv", "persistentvolumes"),
+    persistentVolumeClaim: new ResourceKind("Persistent Volume Claim", "Persistent Volume Claims", "PersistentVolumeClaim", "pvc", "persistentvolumeclaims"),
+    storageClass: new ResourceKind("Storage Class", "Storage Classes", "StorageClass", "sc", "storageclasses"),
+    statefulSet: new ResourceKind("StatefulSet", "StatefulSets", "StatefulSet", "statefulset", "statefulsets")
 };
 
 export const commonKinds = [

--- a/src/kuberesources.ts
+++ b/src/kuberesources.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { Dictionary } from './utils/dictionary';
 
 export class ResourceKind implements vscode.QuickPickItem {
-    constructor(readonly displayName: string, readonly pluralDisplayName: string, readonly manifestKind: string, readonly abbreviation: string, readonly apiName: string) {
+    constructor(readonly displayName: string, readonly pluralDisplayName: string, readonly manifestKind: string, readonly abbreviation: string, readonly apiName?: string) {
     }
 
     get label() { return this.displayName; }


### PR DESCRIPTION
This is a POC based on https://github.com/Azure/vscode-kubernetes-tools/issues/647

This PR allows the extension to update Kubernetes Clusters View content automatically when something on cluster changes. There are 2 ways to set up a watch on resources: by using the action in the context menu or by declaring the kind of resources to watch in the settings (vs-kubernetes.resource-to-watch).

![k8sctx](https://user-images.githubusercontent.com/49404737/72886773-b5f63400-3d0a-11ea-914f-1b4824810edb.png)

Currently the watch function is supported by `folder.resource` and `resource` nodes.

The watch is managed in a way that it is active only if the node of the resources we want to watch is expanded. Once the treeitem is in a collapsed state the watch is removed. This way we prevent to call the refresh tree method for resources user isn't looking at.

The refresh is made on single node to avoid refreshing the whole tree and it works like a queue which is emptied after a while. This way if many resources change in a short amount of time we don't refresh the tree uselessly many times. (i.e a watch on pods is active. If 3-4 pods are created in almost the same moment, we refresh the pods node once).

In the gif below you can see how the `pods` and `deployments` are updated without clicking on the refresh btn

![k8s1-gif](https://user-images.githubusercontent.com/49404737/72886335-e6899e00-3d09-11ea-9daf-3bc3d80e8331.gif)
