### PR TITLE
Install Dependencies should use OS-specific config keys to record paths

### DIFF
--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -107,7 +107,13 @@ function getPathSetting(host: Host, shell: Shell, baseKey: string): string | und
     return osOverridePath || host.getConfiguration(EXTENSION_CONFIG_KEY)[baseKey];
 }
 
-export function toolPathBaseKey(tool: string): string {
+export function toolPathOSKey(os: Platform, tool: string): string {
+    const baseKey = toolPathBaseKey(tool);
+    const osSpecificKey = osOverrideKey(os, baseKey);
+    return osSpecificKey;
+}
+
+function toolPathBaseKey(tool: string): string {
     return `vs-kubernetes.${tool}-path`;
 }
 


### PR DESCRIPTION
Fixes #689.  See also #543.

TODO: There is still an issue where if `kubectl-versioning` is `infer` it assumes that `kubectl` will be available when needed, and so thinks it doesn't need to install it.  This is a false assumption, because we need a `kubectl` to work out the server version in order to download the right `kubectl`.  Raised this as #690.