### PR TITLE
If autoversioning doesn't have a kubectl to bootstrap from, find one and use it

### DIFF
--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -107,7 +107,13 @@ function getPathSetting(host: Host, shell: Shell, baseKey: string): string | und
     return osOverridePath || host.getConfiguration(EXTENSION_CONFIG_KEY)[baseKey];
 }
 
-export function toolPathBaseKey(tool: string): string {
+export function toolPathOSKey(os: Platform, tool: string): string {
+    const baseKey = toolPathBaseKey(tool);
+    const osSpecificKey = osOverrideKey(os, baseKey);
+    return osSpecificKey;
+}
+
+function toolPathBaseKey(tool: string): string {
     return `vs-kubernetes.${tool}-path`;
 }
 

--- a/src/components/kubectl/autoversion.ts
+++ b/src/components/kubectl/autoversion.ts
@@ -5,14 +5,15 @@ import * as download from '../download/download';
 import { Shell, shell } from "../../shell";
 import { Dictionary } from '../../utils/dictionary';
 import { fs } from '../../fs';
-import { Kubectl } from '../../kubectl';
+import { Kubectl, CheckPresentMessageMode, createOnBinary as kubectlCreateOnBinary } from '../../kubectl';
 import { getCurrentContext } from '../../kubectlUtils';
 import { succeeded } from '../../errorable';
 import { FileBacked } from '../../utils/filebacked';
-import { getActiveKubeconfig } from '../config/config';
+import { getActiveKubeconfig, getToolPath } from '../config/config';
 import { Host } from '../../host';
 import { mkdirpAsync } from '../../utils/mkdirp';
 import { platformUrlString, formatBin } from '../installer/installationlayout';
+import * as installer from '../installer/installer';
 
 const AUTO_VERSION_CACHE_FILE = getCachePath(shell);  // TODO: awkward that we're using a hardwired shell here but parameterising it elsewhere
 const AUTO_VERSION_CACHE = new FileBacked<ClusterVersionCache>(fs, AUTO_VERSION_CACHE_FILE, defaultClusterVersionCache);
@@ -26,11 +27,17 @@ export async function ensureSuitableKubectl(kubectl: Kubectl, shell: Shell, host
     if (!(await fs.existsAsync(getBasePath(shell)))) {
         await mkdirpAsync(getBasePath(shell));
     }
-    const context = await getCurrentContext(kubectl);
+
+    const bootstrapperKubectl = await ensureBootstrapperKubectl(kubectl, shell, host);
+    if (!bootstrapperKubectl) {
+        return undefined;
+    }
+
+    const context = await getCurrentContext(bootstrapperKubectl);
     if (!context) {
         return undefined;
     }
-    const serverVersion = await getServerVersion(kubectl, context.contextName);
+    const serverVersion = await getServerVersion(bootstrapperKubectl, context.contextName);
     if (!serverVersion) {
         return undefined;
     }
@@ -135,4 +142,48 @@ async function getServerVersion(kubectl: Kubectl, context: string): Promise<stri
 
 function defaultClusterVersionCache(): ClusterVersionCache {
     return { derivedFromKubeconfig: undefined, versions: {} };
+}
+
+async function ensureBootstrapperKubectl(naiveKubectl: Kubectl, shell: Shell, host: Host): Promise<Kubectl | undefined> {
+    if (await naiveKubectl.checkPresent(CheckPresentMessageMode.Silent)) {
+        return naiveKubectl;
+    }
+
+    // There's no kubectl where we were hoping to find one. Is there one in
+    // the autoversion directory?
+    const existingKubectls = getExistingAutoversionKubectls(shell);
+    if (existingKubectls.length > 0) {
+        const existingKubectl = existingKubectls[0];
+        return kubectlCreateOnBinary(host, fs, shell, existingKubectl);
+    }
+
+    // Looks like we're going to have to download one
+    const installationResult = await host.longRunning({ title: 'Downloading default version of kubectl' }, () =>
+        installer.installKubectl(shell)
+    );
+    if (!installationResult.succeeded) {
+        return undefined;
+    }
+
+    const installedToolPath = getToolPath(host, shell, 'kubectl');
+    if (!installedToolPath) {
+        return undefined;
+    }
+
+    return kubectlCreateOnBinary(host, fs, shell, installedToolPath);
+}
+
+// TODO: would be nice to make this async
+function getExistingAutoversionKubectls(shell: Shell): string[] {
+    const baseFolder = getBasePath(shell);
+    const downloadedFolders = fs.dirSync(baseFolder)
+                                .map((p) => path.join(baseFolder, p))
+                                .filter((p) => fs.statSync(p).isDirectory);
+    const binName = formatBin('kubectl', shell.platform());
+    if (!binName) {
+        return [];
+    }
+    const kubectls = downloadedFolders.map((f) => path.join(f, binName)).filter((p) => fs.existsSync(p));
+    return kubectls;
+
 }

--- a/src/components/kubectl/autoversion.ts
+++ b/src/components/kubectl/autoversion.ts
@@ -17,6 +17,7 @@ import * as installer from '../installer/installer';
 
 const AUTO_VERSION_CACHE_FILE = getCachePath(shell);  // TODO: awkward that we're using a hardwired shell here but parameterising it elsewhere
 const AUTO_VERSION_CACHE = new FileBacked<ClusterVersionCache>(fs, AUTO_VERSION_CACHE_FILE, defaultClusterVersionCache);
+const OPERATION_ID_DOWNLOAD_KC_FOR_BOOTSTRAP = 'autoversion:download_kubectl_for_bootstrap';
 
 interface ClusterVersionCache {
     readonly derivedFromKubeconfig: string | undefined;
@@ -158,7 +159,7 @@ async function ensureBootstrapperKubectl(naiveKubectl: Kubectl, shell: Shell, ho
     }
 
     // Looks like we're going to have to download one
-    const installationResult = await host.longRunning({ title: 'Downloading default version of kubectl' }, () =>
+    const installationResult = await host.longRunning({ title: 'Downloading default version of kubectl', operationKey: OPERATION_ID_DOWNLOAD_KC_FOR_BOOTSTRAP }, () =>
         installer.installKubectl(shell)
     );
     if (!installationResult.succeeded) {

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -135,6 +135,11 @@ function createAutoVersioned(host: Host, fs: FS, shell: Shell, installDependenci
     return new KubectlImpl(host, fs, shell, installDependenciesCallback, pathfinder, false);
 }
 
+export function createOnBinary(host: Host, fs: FS, shell: Shell, bin: string): Kubectl {
+    const pathfinder = async () => bin;
+    return new KubectlImpl(host, fs, shell, () => {}, pathfinder, false);
+}
+
 export enum CheckPresentMessageMode {
     Command,
     Activation,


### PR DESCRIPTION
At the moment, auto version (`kubectlVersioning: infer`) requires some (any!) version of `kubectl` in the PATH or settings, in order to query the server for its version and fetch the _actual_ kubectl for that cluster.  This is silly.  If we are going to magically get kubectl behind the scenes then let's make it work completely transparently.  With this PR, you can start the extension with NO KUBECTL AT ALL and it will go find one by SORCERY and you will be up and running as soon as your network can oblige.

The actual strategy it uses to find a 'bootstrapper' k8s is:
* If there's one around in the normal way (set in config or on PATH), use that.
* Otherwise, see if there are any autoversion directories containing `kubectl` binaries.  If there are, use one of those - it doesn't matter which because we only use it to run `kubectl version`.
* If none of those exist either, download it from latest stable.
* And if that fails, well, tough, no kubectl for you today, though it will probably try again soon enough with aggravating tenacity.

Fixes #690.