### PR TITLE
Delete namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -467,7 +467,7 @@
                 {
                     "command": "extension.vsKubernetesDelete",
                     "group": "2@2",
-                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource(?!\\.namespace).*/i"
+                    "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.resource.*/i"
                 },
                 {
                     "command": "extension.vsKubernetesDescribe",

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -225,10 +225,7 @@ async function checkPossibleIncompatibility(context: Context): Promise<void> {
 }
 
 async function invokeAsyncWithProgress(context: Context, command: string, progressMessage: string): Promise<ShellResult | undefined> {
-    return context.host.withProgress(async (p) => {
-        p.report({ message: progressMessage });
-        return await invokeAsync(context, command);
-    });
+    return context.host.longRunning(progressMessage, () => invokeAsync(context, command));
 }
 
 async function spawnAsChild(context: Context, command: string[]): Promise<ChildProcess | undefined> {


### PR DESCRIPTION
Fixes #696.

This will always give the standard resource confirmation, but if the namespace contains other resources, or is the `default` namespace, then it requests additional confirmation.  Also if the user deletes the current namespace then we try to switch back to the `default` namespace so as not to be left with no valid active namespace in the kubeconfig.

cc @bradygaster