### PR TITLE
Fix snippet syntax warning

### DIFF
--- a/rawsnippets/range-list.tpl
+++ b/rawsnippets/range-list.tpl
@@ -1,3 +1,3 @@
-{{- range \$i, \$val := ${1:$list} }}
+{{- range \$i, \$val := ${1:list} }}
   ${2}
 {{ end -}}

--- a/rawsnippets/range-map.tpl
+++ b/rawsnippets/range-map.tpl
@@ -1,3 +1,3 @@
-{{- range \$key, \$val := ${1:$dict} }}
+{{- range \$key, \$val := ${1:dict} }}
   ${2}
 {{ end -}}

--- a/rawsnippets/range-until.tpl
+++ b/rawsnippets/range-until.tpl
@@ -1,3 +1,3 @@
-{{- range \$i := until ${1:$number} }}
+{{- range \$i := until ${1:number} }}
   ${2}
 {{ end -}}

--- a/snippets/helm.json
+++ b/snippets/helm.json
@@ -189,7 +189,7 @@
   "range-list": {
     "prefix": "rangeList",
     "body": [
-      "{{- range \\$i, \\$val := ${1:$list} }}",
+      "{{- range \\$i, \\$val := ${1:list} }}",
       "  ${2}",
       "{{ end -}}"
     ],
@@ -198,7 +198,7 @@
   "range-map": {
     "prefix": "rangeDict",
     "body": [
-      "{{- range \\$key, \\$val := ${1:$dict} }}",
+      "{{- range \\$key, \\$val := ${1:dict} }}",
       "  ${2}",
       "{{ end -}}"
     ],
@@ -207,7 +207,7 @@
   "range-until": {
     "prefix": "rangeUntil",
     "body": [
-      "{{- range \\$i := until ${1:$number} }}",
+      "{{- range \\$i := until ${1:number} }}",
       "  ${2}",
       "{{ end -}}"
     ],


### PR DESCRIPTION
We had a minor syntax error (text getting treated as variable references) in some of our Helm template snippets, which had been fixed in the generated `snippets/helm.json` but had not been fixed in the templates from which the JSON was generated.  This meant that when someone did things right and regenerated the JSON, which they did in #676, the error reappeared.

This PR fixes the error at source, so that future regenerations should not cause this to recur.