### PR TITLE
Get aks dashbaord port number and url scheme from metadata

### DIFF
--- a/src/kuberesources.objectmodel.ts
+++ b/src/kuberesources.objectmodel.ts
@@ -24,9 +24,20 @@ export interface DataResource extends KubernetesResource {
 export interface Namespace extends KubernetesResource {
 }
 
+export interface LivenessProbeHttpGet {
+    readonly path: string;
+    readonly port: number;
+    readonly scheme: string;
+}
+
+export interface LivenessProbe {
+    readonly httpGet: LivenessProbeHttpGet;
+}
+
 export interface Container {
     readonly name: string;
     readonly image: string;
+    readonly livenessProbe?: LivenessProbe;
 }
 
 export interface Pod extends KubernetesResource {


### PR DESCRIPTION
After the Kubernetes is upgraded on aks, the port of dashboard is changed and https is enabled. The port is hard-coded in the extension so it creates incorrect proxy connection when execute the command "Kubernetes: Open Dashboard".

This PR change the logic from hard-coded to retrieve the port number and url scheme from pod metadata.