### PR TITLE
Added a hack to make kubectl works if installed with snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Minikube tools to be installed and available on your PATH.
        * `vs-kubernetes.outputFormat` - The output format that you prefer to view Kubernetes manifests in. One of "yaml" or "json". Defaults to "yaml".
        * `vs-kubernetes.resources-to-watch` - List of resources to be watched. To identify a resource the extension uses the label displayed in the cluster explorer. E.g. ["Pods", "Services", "Namespaces"]. 
        * `logsDisplay` - Where and how to display Kubernetes logs.  One of `webview` (display in a filterable HTML view) and `terminal` (run the command in the VS Code terminal)
+       * `vscode-kubernetes.enable-snap-flag` - Enables compatibility with instances of VS Code that were installed using snap.
    * `vsdocker.imageUser` - Image prefix for the container images e.g. 'docker.io/brendanburns'
    * `checkForMinikubeUpgrade` - On extension startup, notify if a minikube upgrade is available. Defaults to true.
    * `disable-lint` - Disable all linting of Kubernetes files
@@ -260,6 +261,7 @@ Here are the various linters, you can enable or disable them individually using 
 
   * `Kubernetes: Debug` command currently works only with Node.js, Java, Python and .NET applications
   * For deeply nested Helm charts, template previews are generated against highest (umbrella) chart values (though for `Helm: Template` calls you can pick your chart)
+  * When installing VS Code and/or kubectl through `snap` on a Linux system, you may face some permissions error which will prevent this extension to work correctly. As a workaround you can set up the `vs-kubernetes.enable-snap-flag` setting to `true` in your user or workspace settings. 
 
 ## Release notes
 

--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
                         },
                         "vs-kubernetes.enable-snap-flag": {
                             "type": "boolean",
-                            "description": "If true will enable the flag to run kubectl commands using kubectl installed by snap."
+                            "description": "Enables compatibility with instances of VS Code that were installed using snap."
                         }
                     },
                     "default": {

--- a/package.json
+++ b/package.json
@@ -263,6 +263,10 @@
                         "vs-kubernetes.resources-to-watch": {
                             "type": "array",
                             "description": "List of resources to be watched."
+                        },
+                        "vs-kubernetes.enable-snap-flag": {
+                            "type": "boolean",
+                            "description": "If true will enable the flag to run kubectl commands using kubectl installed by snap."
                         }
                     },
                     "default": {

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -247,3 +247,8 @@ export function getResourcesToBeWatched(): string[] {
     }
     return krwConfig as string[];
 }
+
+// if true will enable the flag to run kubectl commands using kubectl installed by snap
+export function getEnableSnapFlag(): boolean {
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.enable-snap-flag'];
+}


### PR DESCRIPTION
Finally i was able to replicate the error users have by installing stuff with snap. #770 #522 
Did i find a fix? Apparently yes. Did i find out the reason why it doesn't work? No, absolutely not lol. 

This is what i got if i try to execute the command without the hack
![error snap](https://user-images.githubusercontent.com/49404737/85010003-9c450580-b15f-11ea-902d-61c863c97fcb.png)

In Unix systems this solution should always work (i guess in Windows it fails as there is no `cat` cmd) but i added an extra setting so snap users can enable this because i am not sure if i'm forgetting something. This way the extension will keep working as before for others.