### PR TITLE
Fixes the tooltip of the helm-template-function 'has'

### DIFF
--- a/src/helm.funcmap.ts
+++ b/src/helm.funcmap.ts
@@ -192,7 +192,7 @@ export class FuncMap {
             this.f("reverse", "reverse $list", "reverse $list item order"),
             this.f("uniq", "uniq $list", "remove duplicates from list"),
             this.f("without", "without $list $item ...", "return $list with $item(s) removed"),
-            this.f("has", "has $list $item", "return true if $item is in $list"),
+            this.f("has", "has $item $list", "return true if $item is in $list"),
             // Dictionaries
             this.f("dict", "dict $key $val $key2 $val2 ...", "create dictionary with $key/$val pairs"),
             this.f("set", "set $dict $key $val", "set $key=$val in $dict (mutates dict)"),


### PR DESCRIPTION
The tooltip of the helm-template function [has](https://helm.sh/docs/chart_template_guide/function_list/#has-musthas) had the parameters $item and $list in the wrong order.