### PR TITLE
Add collapse all button

### DIFF
--- a/src/components/clusterexplorer/explorer.ts
+++ b/src/components/clusterexplorer/explorer.ts
@@ -100,7 +100,8 @@ export class KubernetesExplorer implements vscode.TreeDataProvider<ClusterExplor
 
     initialize() {
         const viewer = vscode.window.createTreeView('extension.vsKubernetesExplorer', {
-            treeDataProvider: this
+            treeDataProvider: this,
+            showCollapseAll: true
         });
         return vscode.Disposable.from(
 			viewer,


### PR DESCRIPTION
It resolves #764 

In the issue there is also a request to add an "expand all" button. By looking at the vscode api documentation it looks like we can only expand to 3 levels. It should be enough for this extension but i wonder if we want that behavior. Do we really want to expand all tree? Or it is enough to just expand the first/second level (e.g to see all possible group resources such as pods/deployments/jobs... and the user then decide which one to expand)? I think it's better to create a new issue and discuss how it should behave.

