### PR TITLE
Fixes linter issue with multi object file

### DIFF
--- a/src/yaml-support/jsonalike-symbol-provider.ts
+++ b/src/yaml-support/jsonalike-symbol-provider.ts
@@ -9,9 +9,12 @@ export class JsonALikeYamlDocumentSymbolProvider implements vscode.DocumentSymbo
 
     async provideDocumentSymbolsImpl(document: vscode.TextDocument, _token: vscode.CancellationToken): Promise<vscode.SymbolInformation[]> {
         const fakeText = document.getText().replace(/{{[^}]*}}/g, (s) => encodeWithTemplateMarkers(s));
-        const root = yp.safeLoad(fakeText);
+        const nodes: yp.YAMLNode[] = [];
+        yp.safeLoadAll(fakeText, (node) => nodes.push(node));
         const syms: vscode.SymbolInformation[] = [];
-        walk(root, '', document, document.uri, syms);
+        nodes.forEach((node) => {
+            walk(node, '', document, document.uri, syms);
+        });
         return syms;
     }
 }


### PR DESCRIPTION
it fixes #359 

The fix is similar to https://github.com/Azure/vscode-kubernetes-tools/pull/360. We forgot to switch from `safeLoad` to `safeLoadAll` here as well. By using `safeLoad` only the first resource was taken in consideration.
