### PR TITLE
add status bar items for viewing/changing current context and namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ Minikube tools to be installed and available on your PATH.
        * `vs-kubernetes.resources-to-watch` - List of resources to be watched. To identify a resource the extension uses the label displayed in the cluster explorer. E.g. ["Pods", "Services", "Namespaces"]. 
        * `logsDisplay` - Where and how to display Kubernetes logs.  One of `webview` (display in a filterable HTML view) and `terminal` (run the command in the VS Code terminal)
        * `vscode-kubernetes.enable-snap-flag` - Enables compatibility with instances of VS Code that were installed using snap.
+       * `vs-kubernetes.disable-context-info-status-bar` - Disable displaying your current Kubernetes context in VS Code's status bar. When active, it can be used to switch context from the status bar.
+       * `vs-kubernetes.disable-namespace-info-status-bar` - Disable displaying your current Kubernetes namespace in VS Code's status bar. When active, it can be used to switch namespace from the status bar.
    * `vsdocker.imageUser` - Image prefix for the container images e.g. 'docker.io/brendanburns'
    * `checkForMinikubeUpgrade` - On extension startup, notify if a minikube upgrade is available. Defaults to true.
    * `disable-lint` - Disable all linting of Kubernetes files

--- a/package.json
+++ b/package.json
@@ -267,6 +267,14 @@
                         "vs-kubernetes.enable-snap-flag": {
                             "type": "boolean",
                             "description": "Enables compatibility with instances of VS Code that were installed using snap."
+                        },
+                        "vs-kubernetes.disable-context-info-status-bar": {
+                            "type": "boolean",
+                            "description": "Disable displaying your current Kubernetes context in VS Code's status bar."
+                        },
+                        "vs-kubernetes.disable-namespace-info-status-bar": {
+                            "type": "boolean",
+                            "description": "Disable displaying your current Kubernetes namespace in VS Code's status bar."
                         }
                     },
                     "default": {

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -252,3 +252,13 @@ export function getResourcesToBeWatched(): string[] {
 export function getEnableSnapFlag(): boolean {
     return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.enable-snap-flag'];
 }
+
+// if true will disable displaying the context from the status bar
+export function isContextStatusBarDisabled(): boolean {
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.disable-context-info-status-bar'];
+}
+
+// if true will disable displaying the namespace from the status bar
+export function isNamespaceStatusBarDisabled(): boolean {
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.disable-namespace-info-status-bar'];
+}

--- a/src/components/kubectl/namespace.ts
+++ b/src/components/kubectl/namespace.ts
@@ -28,7 +28,7 @@ export async function useNamespaceKubernetes(kubectl: Kubectl, explorerNode: Clu
     );
 
     if (kindName) {
-        switchToNamespace(kubectl, currentNS, kindName)
+        switchToNamespace(kubectl, currentNS, kindName);
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -401,14 +401,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
     activeContextTracker.activeChanged(async (context) => {
         const currentContext = await getCurrentContext(kubectl, { silent: true });
         if (!currentContext) { return; }
-        updateStatusBarItem(activeContextStatusBarItem, context!, `${currentContext.contextName}\nCluster: ${currentContext.clusterName}`, true);
+        updateStatusBarItem(activeContextStatusBarItem, context!, `${currentContext.contextName}\nCluster: ${currentContext.clusterName}`, !config.isContextStatusBarDisabled());
     });
 
     kubectlUtils.onDidChangeNamespaceEmitter.event((namespace) => {
-        updateStatusBarItem(activeNamespaceStatusBarItem, namespace, 'Current active namespace', true);
+        updateStatusBarItem(activeNamespaceStatusBarItem, namespace, 'Current active namespace', !config.isNamespaceStatusBarDisabled());
     });
     const currentNS = await kubectlUtils.currentNamespace(kubectl);
-    updateStatusBarItem(activeNamespaceStatusBarItem, currentNS, 'Current active namespace', true);
+    updateStatusBarItem(activeNamespaceStatusBarItem, currentNS, 'Current active namespace', !config.isNamespaceStatusBarDisabled());
 
     await registerYamlSchemaSupport(activeContextTracker, kubectl);
 

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -290,6 +290,8 @@ export async function currentNamespaceArg(kubectl: Kubectl): Promise<string> {
     return `--namespace ${ns}`;
 }
 
+export const onDidChangeNamespaceEmitter = new vscode.EventEmitter<string>();
+
 export async function switchNamespace(kubectl: Kubectl, namespace: string): Promise<boolean> {
     const er = await kubectl.invokeCommand("config current-context");
     if (ExecResult.failed(er)) {
@@ -309,6 +311,7 @@ export async function switchNamespace(kubectl: Kubectl, namespace: string): Prom
         }
         return false;
     }
+    onDidChangeNamespaceEmitter.fire(namespace);
     return true;
 }
 


### PR DESCRIPTION
it resolves #777 

This PR adds two items to the status bar: one which displays the current context and another one which displays the current namespace. (in the example below minikube is the context, tektontest the namespace)
![image](https://user-images.githubusercontent.com/49404737/90408049-9a3bec00-e0a7-11ea-9b5b-96679bf47d13.png)

By clicking on the context, the user can switch it (a quickpick shows up with a list of possible contexts).... the same for the namespace item.
Users can hide one or both items by using the optional settings in the extension.
