### PR TITLE
Restrictive installer permission for kubectl.

### DIFF
--- a/src/components/installer/installer.ts
+++ b/src/components/installer/installer.ts
@@ -40,7 +40,7 @@ export async function installKubectl(shell: Shell): Promise<Errorable<null>> {
     }
 
     if (shell.isUnix()) {
-        fs.chmodSync(downloadFile, '0777');
+        fs.chmodSync(downloadFile, '0755');
     }
 
     await addPathToConfig(toolPathOSKey(platform, tool), downloadFile);


### PR DESCRIPTION
* Restrictive installer permission for kubectl. 

Probably more conformance to something like this: https://github.com/Azure/vscode-kubernetes-tools/blob/master/src/components/installer/installer.ts#L137 

 Thanks, and cc: @itowlson and @squillace for eyeballing and thoughts. 🙏 💡