### PR TITLE
Automate release process (#728)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build & Publish
 on: [workflow_dispatch]
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,55 @@
+name: CI
+on: [workflow_dispatch]
+
+jobs:
+  build:
+    name: release
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14
+    # Run install dependencies
+    - name: Install dependencies
+      run: npm install
+    # Run tests
+    - name: Build 
+      run: npm run compile
+    - name: Get current package version
+      id: package_version
+      uses: martinbeentjes/npm-get-version-action@v1.1.0
+    - name: Check version is mentioned in Changelog
+      uses: mindsers/changelog-reader-action@v2.0.0
+      with:
+        version: ${{ steps.package_version.outputs.current-version }}
+        path: 'CHANGELOG.md'
+    - name: Create a Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+      with:
+        tag_name : ${{ steps.package_version.outputs.current-version}}
+        release_name: ${{ steps.package_version.outputs.current-version}}
+        body: Publish ${{ steps.package_version.outputs.current-version}}
+    - name: Create vsix and publish to marketplace
+      id: create_vsix
+      uses: HaaLeo/publish-vscode-extension@v0
+      with:
+        pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+        registryUrl: https://marketplace.visualstudio.com
+    - name: Attach vsix to release
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ steps.create_vsix.outputs.vsixPath}}
+        asset_name: ${{ steps.create_vsix.outputs.vsixPath}}
+        asset_content_type: application/vsix
+    
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,8 @@ extension as a foundation or as a helper.
 
 * [Extensibility overview](extending/README.md)
 * [Adding a new cloud or cluster type to the Add Existing Cluster and Create Cluster commands](extending/clusterprovider.md)
+
+## Maintenance
+
+* [How to release](maintenance/README.md)
+

--- a/docs/maintenance/README.md
+++ b/docs/maintenance/README.md
@@ -1,0 +1,24 @@
+## How to Release
+
+To make a new release and publish it to the marketplace you have to follow the following steps.
+
+1. Create a branch `publish-x.y.z`
+2. Update `package.json` with the new version 
+3. Add a section to `CHANGELOG.md` with the header `## [x.y.z]` (N.B: make sure to write the new version in square brackets as the `changelog-reader` action only works if the `CHANGELOG.md` file follows the [Keep a Changelog standard](https://github.com/olivierlacan/keep-a-changelog))
+4. Create a new PR, get approval and merge
+5. Run the `Build & Publish` workflow manually from the GH Actions tab
+
+### Build & Publish 
+
+The `Build & Publish` workflow allows to create a new release, package it in a VSIX file and publish to the VSCode marketplace with a single click.
+
+The only requirement needed to run the workflow is to have a secret named `VS_MARKETPLACE_TOKEN` containing the Personal Access Token of the publisher. You can find more infos about how to create a publisher/token in the [official documentation](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#create-a-publisher)
+
+Once everything is set up and you followed all first 4 steps in the previous section, you are ready to trigger the `Build & Publish` workflow.
+This is what it actually does:
+
+1. Install all dependencies and build the project
+2. Check if the `CHANGELOG.md` contains a section related to the new version
+3. Create a new release
+4. Create the VSIX file and publish it to the marketplace
+5. Attach the VSIX file to the new release


### PR DESCRIPTION
This is related to https://github.com/Azure/vscode-kubernetes-tools/issues/728

The workflow has to be triggered manually and it does almost all the job needed to publish the extension to the marketplace.

- Build the extension
- Check that version used in the `package.json` file is mentioned in `changelog.md`
- Create a new release (if another one with the same version exists, it fails)
- Publish it to the marketplace

The only secret required is the marketplace token.

The only edit we need to make inside the project is about the changelog, a version should be written like `## [x.x.x]` because the action follows this convention.

By having this workflow in place we can also make a release when Ivan is busy on other projects. We just need to agree when a new release can be made.

Only thing missing is the testing process, not sure if we want to write some unit/integration tests or there was some reason to not adding them.

Any idea how this can be improved? @itowlson @squillace @gorkem 
