### PR TITLE
Publish 1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [1.2.3]
+
+* We now pack the extension to improve load times.  _This was quite an invasive change -
+  please let us know if you run into any funnies._
+* Added example of setings JSON for disabling linters
+* Fixed a missing contribution credit in 1.2.2
+* Fixed typo in debugger documentation
+
+Thanks to Jason Behnke and Willem Odendaal.
+
 ## 1.2.2
 
 * It now (finally!) works with Snap

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-kubernetes-tools",
     "displayName": "Kubernetes",
     "description": "Develop, deploy and debug Kubernetes applications",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "publisher": "ms-kubernetes-tools",
     "engines": {
         "vscode": "^1.31.0"


### PR DESCRIPTION
This is basically the bundling change, plus a couple of nonfunctional changes (documentation fixes).  I'm suggesting we publish this as its own release despite the lack of new features, because that way we can easily detect the impact of this change in isolation, and roll back without withdrawing features if it turns out to be a disaster!