### PR TITLE
Centralise Cluster Explorer API implementation

### DIFF
--- a/src/api/implementation/cluster-explorer/common.ts
+++ b/src/api/implementation/cluster-explorer/common.ts
@@ -1,0 +1,167 @@
+/* eslint-disable camelcase */
+
+import * as vscode from 'vscode';
+// import { KubernetesExplorer, KUBERNETES_EXPLORER_NODE_CATEGORY } from "../../../components/clusterexplorer/explorer";
+import { ExplorerExtender /* , ExplorerUICustomizer */ } from "../../../components/clusterexplorer/explorer.extension";
+import { /* CustomGroupingFolderNodeSource, CustomResourceFolderNodeSource, */ NodeSourceImpl } from "../../../components/clusterexplorer/extension.nodesources";
+import { ClusterExplorerCustomNode, ClusterExplorerNode, ClusterExplorerResourceNode } from "../../../components/clusterexplorer/node";
+import { Host } from "../../../host";
+import { Kubectl } from "../../../kubectl";
+// import { ResourceKind } from '../../../kuberesources';
+
+import { ClusterExplorerV1 } from '../../contract/cluster-explorer/v1';
+import { ClusterExplorerV1_1 } from '../../contract/cluster-explorer/v1_1';
+
+export interface NodeContributor {
+    contributesChildren(parent: ClusterExplorerV1.ClusterExplorerNode | ClusterExplorerV1_1.ClusterExplorerNode | undefined): boolean;
+    getChildren(parent: ClusterExplorerV1.ClusterExplorerNode | ClusterExplorerV1_1.ClusterExplorerNode | undefined): Promise<Node[]>;
+}
+
+export interface Node {
+    getChildren(): Promise<Node[]>;
+    getTreeItem(): vscode.TreeItem;
+}
+
+export interface NodeSource {
+    at(parentFolder: string | undefined): NodeContributor;
+    if(condition: () => boolean | Thenable<boolean>): NodeSource;
+    nodes(): Promise<Node[]>;
+}
+
+export class NodeContributorAdapter implements ExplorerExtender<ClusterExplorerNode> {
+    constructor(private readonly impl: ClusterExplorerV1_1.NodeContributor) {}
+    contributesChildren(parent?: ClusterExplorerNode | undefined): boolean {
+        const parentNode = parent ? adaptKubernetesExplorerNode(parent) : undefined;
+        return this.impl.contributesChildren(parentNode);
+    }
+    async getChildren(parent?: ClusterExplorerNode | undefined): Promise<ClusterExplorerNode[]> {
+        const parentNode = parent ? adaptKubernetesExplorerNode(parent) : undefined;
+        const children = await this.impl.getChildren(parentNode);
+        return children.map(internalNodeOf);
+    }
+}
+
+export function adaptKubernetesExplorerNode(node: ClusterExplorerNode): ClusterExplorerV1.ClusterExplorerNode & ClusterExplorerV1_1.ClusterExplorerNode {
+    switch (node.nodeType) {
+        case 'error':
+            return { nodeType: 'error' };
+        case 'context':
+            return node.kubectlContext.active ?
+                { nodeType: 'context', name: node.contextName } :
+                { nodeType: 'context.inactive', name: node.contextName };
+        case 'folder.grouping':
+            return { nodeType: 'folder.grouping' };
+        case 'folder.resource':
+            return { nodeType: 'folder.resource', resourceKind: node.kind };
+        case 'resource':
+            return adaptKubernetesExplorerResourceNode(node);
+        case 'configitem':
+            return { nodeType: 'configitem', name: node.key };
+        case 'helm.release':
+            return { nodeType: 'helm.release', name: node.releaseName };
+        case 'helm.history':
+            return { nodeType: 'helm.history', name: node.releaseName };
+        case 'extension':
+            return { nodeType: 'extension' };
+    }
+}
+
+function adaptKubernetesExplorerResourceNode(node: ClusterExplorerResourceNode): ClusterExplorerV1.ClusterExplorerResourceNode & ClusterExplorerV1_1.ClusterExplorerResourceNode {
+    return {
+        nodeType: 'resource',
+        metadata: node.metadata,
+        name: node.name,
+        resourceKind: node.kind,
+        namespace: node.namespace
+    };
+}
+
+const BUILT_IN_CONTRIBUTOR_KIND_TAG = 'nativeextender-4a4bc473-a8c6-4b1e-973f-22327f99cea8';
+const BUILT_IN_NODE_KIND_TAG = 'nativek8sobject-5be3c876-3683-44cd-a400-7763d2c4302a';
+const BUILT_IN_NODE_SOURCE_KIND_TAG = 'nativenodesource-aa0c30a9-bf1d-444a-a147-7823edcc7c04';
+
+export interface BuiltInNodeContributor {
+    readonly [BUILT_IN_CONTRIBUTOR_KIND_TAG]: true;
+    readonly impl: ExplorerExtender<ClusterExplorerNode>;
+}
+
+export interface BuiltInNodeSource {
+    readonly [BUILT_IN_NODE_SOURCE_KIND_TAG]: true;
+    readonly impl: NodeSourceImpl;
+}
+
+export interface BuiltInNode {
+    readonly [BUILT_IN_NODE_KIND_TAG]: true;
+    readonly impl: ClusterExplorerNode;
+}
+
+export class ContributedNode implements ClusterExplorerCustomNode {
+    readonly nodeCategory = 'kubernetes-explorer-node';
+    readonly nodeType = 'extension';
+    readonly id = 'dummy';
+
+    constructor(private readonly impl: Node) { }
+
+    async getChildren(_kubectl: Kubectl, _host: Host): Promise<ClusterExplorerNode[]> {
+        return (await this.impl.getChildren()).map((n) => internalNodeOf(n));
+    }
+    getTreeItem(): vscode.TreeItem {
+        return this.impl.getTreeItem();
+    }
+    async apiURI(_kubectl: Kubectl, _namespace: string): Promise<string | undefined> {
+        return undefined;
+    }
+}
+
+export function apiNodeSourceOf(nodeSet: NodeSourceImpl): NodeSource & BuiltInNodeSource {
+    return {
+        at(parent: string | undefined) { const ee = nodeSet.at(parent); return apiNodeContributorOf(ee); },
+        if(condition: () => boolean | Thenable<boolean>) { return apiNodeSourceOf(nodeSet.if(condition)); },
+        async nodes() { return (await nodeSet.nodes()).map(apiNodeOf); },
+        [BUILT_IN_NODE_SOURCE_KIND_TAG]: true,
+        impl: nodeSet
+    };
+}
+
+export function apiNodeContributorOf(ee: ExplorerExtender<ClusterExplorerNode>): NodeContributor & BuiltInNodeContributor {
+    return {
+        contributesChildren(_parent) { return false; },
+        async getChildren(_parent) { return []; },
+        [BUILT_IN_CONTRIBUTOR_KIND_TAG]: true,
+        impl: ee
+    };
+}
+
+export function apiNodeOf(node: ClusterExplorerNode): Node & BuiltInNode {
+    return {
+        async getChildren() { throw new Error('apiNodeOf->getChildren: not expected to be called directly'); },
+        getTreeItem() { throw new Error('apiNodeOf->getTreeItem: not expected to be called directly'); },
+        [BUILT_IN_NODE_KIND_TAG]: true,
+        impl: node
+    };
+}
+
+export function internalNodeSourceOf(nodeSet: ClusterExplorerV1_1.NodeSource): NodeSourceImpl {
+    if ((<any>nodeSet)[BUILT_IN_NODE_SOURCE_KIND_TAG]) {
+        return (nodeSet as unknown as BuiltInNodeSource).impl;
+    }
+    return {
+        at(parent: string | undefined) { return internalNodeContributorOf(nodeSet.at(parent)); },
+        if(condition: () => boolean | Thenable<boolean>) { return internalNodeSourceOf(nodeSet).if(condition); },
+        async nodes() { return (await nodeSet.nodes()).map(internalNodeOf); }
+    };
+}
+
+export function internalNodeContributorOf(nodeContributor: ClusterExplorerV1_1.NodeContributor): ExplorerExtender<ClusterExplorerNode> {
+    if ((<any>nodeContributor)[BUILT_IN_CONTRIBUTOR_KIND_TAG] === true) {
+        return (nodeContributor as unknown as BuiltInNodeContributor).impl;
+    }
+    return new NodeContributorAdapter(nodeContributor);
+}
+
+export function internalNodeOf(node: ClusterExplorerV1_1.Node): ClusterExplorerNode {
+    if ((<any>node)[BUILT_IN_NODE_KIND_TAG]) {
+        return (node as unknown as BuiltInNode).impl;
+    }
+    return new ContributedNode(node);
+}

--- a/src/api/implementation/cluster-explorer/v1.ts
+++ b/src/api/implementation/cluster-explorer/v1.ts
@@ -1,8 +1,12 @@
-import { KubernetesExplorer, KUBERNETES_EXPLORER_NODE_CATEGORY } from "../../../components/clusterexplorer/explorer";
-import { ClusterExplorerNode } from "../../../components/clusterexplorer/node";
+import { KubernetesExplorer } from "../../../components/clusterexplorer/explorer";
 import { ClusterExplorerV1 } from "../../contract/cluster-explorer/v1";
 
-import { adaptKubernetesExplorerNode, adaptToExplorerUICustomizer, internalNodeContributorOf, resourceFolderContributor, groupingFolderContributor } from './common';
+import {
+    resolveCommandTarget,
+    adaptToExplorerUICustomizer,
+    internalNodeContributorOf,
+    allNodeSources
+} from './common';
 
 export function impl(explorer: KubernetesExplorer): ClusterExplorerV1 {
     return new ClusterExplorerV1Impl(explorer);
@@ -12,15 +16,7 @@ class ClusterExplorerV1Impl implements ClusterExplorerV1 {
     constructor(private readonly explorer: KubernetesExplorer) {}
 
     resolveCommandTarget(target?: any): ClusterExplorerV1.ClusterExplorerNode | undefined {
-        if (!target) {
-            return undefined;
-        }
-        if (target.nodeCategory === KUBERNETES_EXPLORER_NODE_CATEGORY) {
-            const implNode = target as ClusterExplorerNode;
-            const apiNode = adaptKubernetesExplorerNode(implNode);
-            return apiNode;
-        }
-        return undefined;
+        return resolveCommandTarget(target);
     }
 
     registerNodeContributor(nodeContributor: ClusterExplorerV1.NodeContributor): void {
@@ -34,10 +30,7 @@ class ClusterExplorerV1Impl implements ClusterExplorerV1 {
     }
 
     get nodeSources(): ClusterExplorerV1.NodeSources {
-        return {
-            resourceFolder: resourceFolderContributor,
-            groupingFolder: groupingFolderContributor
-        };
+        return allNodeSources();
     }
 
     refresh(): void {

--- a/src/api/implementation/cluster-explorer/v1.ts
+++ b/src/api/implementation/cluster-explorer/v1.ts
@@ -1,13 +1,12 @@
 import * as vscode from 'vscode';
 import { KubernetesExplorer, KUBERNETES_EXPLORER_NODE_CATEGORY } from "../../../components/clusterexplorer/explorer";
-import { ExplorerExtender, ExplorerUICustomizer } from "../../../components/clusterexplorer/explorer.extension";
-import { CustomGroupingFolderNodeSource, CustomResourceFolderNodeSource, NodeSourceImpl } from "../../../components/clusterexplorer/extension.nodesources";
-import { ClusterExplorerCustomNode, ClusterExplorerNode, ClusterExplorerResourceNode } from "../../../components/clusterexplorer/node";
-import { Host } from "../../../host";
-import { Kubectl } from "../../../kubectl";
+import { ExplorerUICustomizer } from "../../../components/clusterexplorer/explorer.extension";
+import { CustomGroupingFolderNodeSource, CustomResourceFolderNodeSource } from "../../../components/clusterexplorer/extension.nodesources";
+import { ClusterExplorerNode } from "../../../components/clusterexplorer/node";
 import { ResourceKind } from '../../../kuberesources';
 import { ClusterExplorerV1 } from "../../contract/cluster-explorer/v1";
 
+import { adaptKubernetesExplorerNode, apiNodeSourceOf, internalNodeContributorOf, internalNodeSourceOf } from './common';
 
 export function impl(explorer: KubernetesExplorer): ClusterExplorerV1 {
     return new ClusterExplorerV1Impl(explorer);
@@ -54,19 +53,6 @@ function adaptToExplorerUICustomizer(nodeUICustomizer: ClusterExplorerV1.NodeUIC
     return new NodeUICustomizerAdapter(nodeUICustomizer);
 }
 
-class NodeContributorAdapter implements ExplorerExtender<ClusterExplorerNode> {
-    constructor(private readonly impl: ClusterExplorerV1.NodeContributor) {}
-    contributesChildren(parent?: ClusterExplorerNode | undefined): boolean {
-        const parentNode = parent ? adaptKubernetesExplorerNode(parent) : undefined;
-        return this.impl.contributesChildren(parentNode);
-    }
-    async getChildren(parent?: ClusterExplorerNode | undefined): Promise<ClusterExplorerNode[]> {
-        const parentNode = parent ? adaptKubernetesExplorerNode(parent) : undefined;
-        const children = await this.impl.getChildren(parentNode);
-        return children.map(internalNodeOf);
-    }
-}
-
 class NodeUICustomizerAdapter implements ExplorerUICustomizer<ClusterExplorerNode> {
     constructor(private readonly impl: ClusterExplorerV1.NodeUICustomizer) {}
     customize(element: ClusterExplorerNode, treeItem: vscode.TreeItem): true | Thenable<true> {
@@ -83,59 +69,6 @@ async function waitFor(waiter: Thenable<void>): Promise<true> {
     return true;
 }
 
-function adaptKubernetesExplorerNode(node: ClusterExplorerNode): ClusterExplorerV1.ClusterExplorerNode {
-    switch (node.nodeType) {
-        case 'error':
-            return { nodeType: 'error' };
-        case 'context':
-            return node.kubectlContext.active ?
-                { nodeType: 'context', name: node.contextName } :
-                { nodeType: 'context.inactive', name: node.contextName };
-        case 'folder.grouping':
-            return { nodeType: 'folder.grouping' };
-        case 'folder.resource':
-            return { nodeType: 'folder.resource', resourceKind: node.kind };
-        case 'resource':
-            return adaptKubernetesExplorerResourceNode(node);
-        case 'configitem':
-            return { nodeType: 'configitem', name: node.key };
-        case 'helm.release':
-            return { nodeType: 'helm.release', name: node.releaseName };
-        case 'helm.history':
-            return { nodeType: 'helm.history', name: node.releaseName };
-        case 'extension':
-            return { nodeType: 'extension' };
-    }
-}
-
-function adaptKubernetesExplorerResourceNode(node: ClusterExplorerResourceNode): ClusterExplorerV1.ClusterExplorerResourceNode {
-    return {
-        nodeType: 'resource',
-        metadata: node.metadata,
-        name: node.name,
-        resourceKind: node.kind,
-        namespace: node.namespace
-    };
-}
-
-export class ContributedNode implements ClusterExplorerCustomNode {
-    readonly nodeCategory = 'kubernetes-explorer-node';
-    readonly nodeType = 'extension';
-    readonly id = 'dummy';
-
-    constructor(private readonly impl: ClusterExplorerV1.Node) { }
-
-    async getChildren(_kubectl: Kubectl, _host: Host): Promise<ClusterExplorerNode[]> {
-        return (await this.impl.getChildren()).map((n) => internalNodeOf(n));
-    }
-    getTreeItem(): vscode.TreeItem {
-        return this.impl.getTreeItem();
-    }
-    async apiURI(_kubectl: Kubectl, _namespace: string): Promise<string | undefined> {
-        return undefined;
-    }
-}
-
 function resourceFolderContributor(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string): ClusterExplorerV1.NodeSource {
     const nodeSource = new CustomResourceFolderNodeSource(new ResourceKind(displayName, pluralDisplayName, manifestKind, abbreviation));
     return apiNodeSourceOf(nodeSource);
@@ -144,76 +77,4 @@ function resourceFolderContributor(displayName: string, pluralDisplayName: strin
 function groupingFolderContributor(displayName: string, contextValue: string | undefined, ...children: ClusterExplorerV1.NodeSource[]): ClusterExplorerV1.NodeSource {
     const nodeSource = new CustomGroupingFolderNodeSource(displayName, contextValue, children.map(internalNodeSourceOf));
     return apiNodeSourceOf(nodeSource);
-}
-
-const BUILT_IN_CONTRIBUTOR_KIND_TAG = 'nativeextender-4a4bc473-a8c6-4b1e-973f-22327f99cea8';
-const BUILT_IN_NODE_KIND_TAG = 'nativek8sobject-5be3c876-3683-44cd-a400-7763d2c4302a';
-const BUILT_IN_NODE_SOURCE_KIND_TAG = 'nativenodesource-aa0c30a9-bf1d-444a-a147-7823edcc7c04';
-
-interface BuiltInNodeContributor {
-    readonly [BUILT_IN_CONTRIBUTOR_KIND_TAG]: true;
-    readonly impl: ExplorerExtender<ClusterExplorerNode>;
-}
-
-interface BuiltInNodeSource {
-    readonly [BUILT_IN_NODE_SOURCE_KIND_TAG]: true;
-    readonly impl: NodeSourceImpl;
-}
-
-interface BuiltInNode {
-    readonly [BUILT_IN_NODE_KIND_TAG]: true;
-    readonly impl: ClusterExplorerNode;
-}
-
-function apiNodeSourceOf(nodeSet: NodeSourceImpl): ClusterExplorerV1.NodeSource & BuiltInNodeSource {
-    return {
-        at(parent: string | undefined) { const ee = nodeSet.at(parent); return apiNodeContributorOf(ee); },
-        if(condition: () => boolean | Thenable<boolean>) { return apiNodeSourceOf(nodeSet.if(condition)); },
-        async nodes() { return (await nodeSet.nodes()).map(apiNodeOf); },
-        [BUILT_IN_NODE_SOURCE_KIND_TAG]: true,
-        impl: nodeSet
-    };
-}
-
-function internalNodeSourceOf(nodeSet: ClusterExplorerV1.NodeSource): NodeSourceImpl {
-    if ((<any>nodeSet)[BUILT_IN_NODE_SOURCE_KIND_TAG]) {
-        return (nodeSet as unknown as BuiltInNodeSource).impl;
-    }
-    return {
-        at(parent: string | undefined) { return internalNodeContributorOf(nodeSet.at(parent)); },
-        if(condition: () => boolean | Thenable<boolean>) { return internalNodeSourceOf(nodeSet).if(condition); },
-        async nodes() { return (await nodeSet.nodes()).map(internalNodeOf); }
-    };
-}
-
-function internalNodeContributorOf(nodeContributor: ClusterExplorerV1.NodeContributor): ExplorerExtender<ClusterExplorerNode> {
-    if ((<any>nodeContributor)[BUILT_IN_CONTRIBUTOR_KIND_TAG] === true) {
-        return (nodeContributor as unknown as BuiltInNodeContributor).impl;
-    }
-    return new NodeContributorAdapter(nodeContributor);
-}
-
-function apiNodeContributorOf(ee: ExplorerExtender<ClusterExplorerNode>): ClusterExplorerV1.NodeContributor & BuiltInNodeContributor {
-    return {
-        contributesChildren(_parent) { return false; },
-        async getChildren(_parent) { return []; },
-        [BUILT_IN_CONTRIBUTOR_KIND_TAG]: true,
-        impl: ee
-    };
-}
-
-export function internalNodeOf(node: ClusterExplorerV1.Node): ClusterExplorerNode {
-    if ((<any>node)[BUILT_IN_NODE_KIND_TAG]) {
-        return (node as unknown as BuiltInNode).impl;
-    }
-    return new ContributedNode(node);
-}
-
-function apiNodeOf(node: ClusterExplorerNode): ClusterExplorerV1.Node & BuiltInNode {
-    return {
-        async getChildren() { throw new Error('apiNodeOf->getChildren: not expected to be called directly'); },
-        getTreeItem() { throw new Error('apiNodeOf->getTreeItem: not expected to be called directly'); },
-        [BUILT_IN_NODE_KIND_TAG]: true,
-        impl: node
-    };
 }

--- a/src/api/implementation/cluster-explorer/v1_1.ts
+++ b/src/api/implementation/cluster-explorer/v1_1.ts
@@ -1,10 +1,14 @@
 /* eslint-disable camelcase */
 
-import { KubernetesExplorer, KUBERNETES_EXPLORER_NODE_CATEGORY } from "../../../components/clusterexplorer/explorer";
-import { ClusterExplorerNode } from "../../../components/clusterexplorer/node";
+import { KubernetesExplorer } from "../../../components/clusterexplorer/explorer";
 import { ClusterExplorerV1_1 } from '../../contract/cluster-explorer/v1_1';
 
-import { adaptKubernetesExplorerNode, adaptToExplorerUICustomizer, internalNodeContributorOf, resourceFolderContributor, groupingFolderContributor } from './common';
+import {
+    resolveCommandTarget,
+    adaptToExplorerUICustomizer,
+    internalNodeContributorOf,
+    allNodeSources
+} from './common';
 
 export function impl(explorer: KubernetesExplorer): ClusterExplorerV1_1 {
     return new ClusterExplorerV1_1Impl(explorer);
@@ -14,15 +18,7 @@ class ClusterExplorerV1_1Impl implements ClusterExplorerV1_1 {
     constructor(private readonly explorer: KubernetesExplorer) {}
 
     resolveCommandTarget(target?: any): ClusterExplorerV1_1.ClusterExplorerNode | undefined {
-        if (!target) {
-            return undefined;
-        }
-        if (target.nodeCategory === KUBERNETES_EXPLORER_NODE_CATEGORY) {
-            const implNode = target as ClusterExplorerNode;
-            const apiNode = adaptKubernetesExplorerNode(implNode);
-            return apiNode;
-        }
-        return undefined;
+       return resolveCommandTarget(target);
     }
 
     registerNodeContributor(nodeContributor: ClusterExplorerV1_1.NodeContributor): void {
@@ -36,10 +32,7 @@ class ClusterExplorerV1_1Impl implements ClusterExplorerV1_1 {
     }
 
     get nodeSources(): ClusterExplorerV1_1.NodeSources {
-        return {
-            resourceFolder: resourceFolderContributor,
-            groupingFolder: groupingFolderContributor
-        };
+        return allNodeSources();
     }
 
     refresh(): void {

--- a/src/api/implementation/cluster-explorer/v1_1.ts
+++ b/src/api/implementation/cluster-explorer/v1_1.ts
@@ -2,14 +2,13 @@
 
 import * as vscode from 'vscode';
 import { KubernetesExplorer, KUBERNETES_EXPLORER_NODE_CATEGORY } from "../../../components/clusterexplorer/explorer";
-import { ExplorerExtender, ExplorerUICustomizer } from "../../../components/clusterexplorer/explorer.extension";
-import { CustomGroupingFolderNodeSource, CustomResourceFolderNodeSource, NodeSourceImpl } from "../../../components/clusterexplorer/extension.nodesources";
-import { ClusterExplorerCustomNode, ClusterExplorerNode, ClusterExplorerResourceNode } from "../../../components/clusterexplorer/node";
-import { Host } from "../../../host";
-import { Kubectl } from "../../../kubectl";
+import { ExplorerUICustomizer } from "../../../components/clusterexplorer/explorer.extension";
+import { CustomGroupingFolderNodeSource, CustomResourceFolderNodeSource } from "../../../components/clusterexplorer/extension.nodesources";
+import { ClusterExplorerNode } from "../../../components/clusterexplorer/node";
 import { ResourceKind } from '../../../kuberesources';
 import { ClusterExplorerV1_1 } from '../../contract/cluster-explorer/v1_1';
 
+import { adaptKubernetesExplorerNode, apiNodeSourceOf, internalNodeContributorOf, internalNodeSourceOf } from './common';
 
 export function impl(explorer: KubernetesExplorer): ClusterExplorerV1_1 {
     return new ClusterExplorerV1_1Impl(explorer);
@@ -56,19 +55,6 @@ function adaptToExplorerUICustomizer(nodeUICustomizer: ClusterExplorerV1_1.NodeU
     return new NodeUICustomizerAdapter(nodeUICustomizer);
 }
 
-class NodeContributorAdapter implements ExplorerExtender<ClusterExplorerNode> {
-    constructor(private readonly impl: ClusterExplorerV1_1.NodeContributor) {}
-    contributesChildren(parent?: ClusterExplorerNode | undefined): boolean {
-        const parentNode = parent ? adaptKubernetesExplorerNode(parent) : undefined;
-        return this.impl.contributesChildren(parentNode);
-    }
-    async getChildren(parent?: ClusterExplorerNode | undefined): Promise<ClusterExplorerNode[]> {
-        const parentNode = parent ? adaptKubernetesExplorerNode(parent) : undefined;
-        const children = await this.impl.getChildren(parentNode);
-        return children.map(internalNodeOf);
-    }
-}
-
 class NodeUICustomizerAdapter implements ExplorerUICustomizer<ClusterExplorerNode> {
     constructor(private readonly impl: ClusterExplorerV1_1.NodeUICustomizer) {}
     customize(element: ClusterExplorerNode, treeItem: vscode.TreeItem): true | Thenable<true> {
@@ -85,59 +71,6 @@ async function waitFor(waiter: Thenable<void>): Promise<true> {
     return true;
 }
 
-function adaptKubernetesExplorerNode(node: ClusterExplorerNode): ClusterExplorerV1_1.ClusterExplorerNode {
-    switch (node.nodeType) {
-        case 'error':
-            return { nodeType: 'error' };
-        case 'context':
-            return node.kubectlContext.active ?
-                { nodeType: 'context', name: node.contextName } :
-                { nodeType: 'context.inactive', name: node.contextName };
-        case 'folder.grouping':
-            return { nodeType: 'folder.grouping' };
-        case 'folder.resource':
-            return { nodeType: 'folder.resource', resourceKind: node.kind };
-        case 'resource':
-            return adaptKubernetesExplorerResourceNode(node);
-        case 'configitem':
-            return { nodeType: 'configitem', name: node.key };
-        case 'helm.release':
-            return { nodeType: 'helm.release', name: node.releaseName };
-        case 'helm.history':
-            return { nodeType: 'helm.history', name: node.releaseName };
-        case 'extension':
-            return { nodeType: 'extension' };
-    }
-}
-
-function adaptKubernetesExplorerResourceNode(node: ClusterExplorerResourceNode): ClusterExplorerV1_1.ClusterExplorerResourceNode {
-    return {
-        nodeType: 'resource',
-        metadata: node.metadata,
-        name: node.name,
-        resourceKind: node.kind,
-        namespace: node.namespace
-    };
-}
-
-export class ContributedNode implements ClusterExplorerCustomNode {
-    readonly nodeCategory = 'kubernetes-explorer-node';
-    readonly nodeType = 'extension';
-    readonly id = 'dummy';
-
-    constructor(private readonly impl: ClusterExplorerV1_1.Node) { }
-
-    async getChildren(_kubectl: Kubectl, _host: Host): Promise<ClusterExplorerNode[]> {
-        return (await this.impl.getChildren()).map((n) => internalNodeOf(n));
-    }
-    getTreeItem(): vscode.TreeItem {
-        return this.impl.getTreeItem();
-    }
-    async apiURI(_kubectl: Kubectl, _namespace: string): Promise<string | undefined> {
-        return undefined;
-    }
-}
-
 function resourceFolderContributor(displayName: string, pluralDisplayName: string, manifestKind: string, abbreviation: string, apiName?: string): ClusterExplorerV1_1.NodeSource {
     const nodeSource = new CustomResourceFolderNodeSource(new ResourceKind(displayName, pluralDisplayName, manifestKind, abbreviation, apiName));
     return apiNodeSourceOf(nodeSource);
@@ -146,76 +79,4 @@ function resourceFolderContributor(displayName: string, pluralDisplayName: strin
 function groupingFolderContributor(displayName: string, contextValue: string | undefined, ...children: ClusterExplorerV1_1.NodeSource[]): ClusterExplorerV1_1.NodeSource {
     const nodeSource = new CustomGroupingFolderNodeSource(displayName, contextValue, children.map(internalNodeSourceOf));
     return apiNodeSourceOf(nodeSource);
-}
-
-const BUILT_IN_CONTRIBUTOR_KIND_TAG = 'nativeextender-4a4bc473-a8c6-4b1e-973f-22327f99cea8';
-const BUILT_IN_NODE_KIND_TAG = 'nativek8sobject-5be3c876-3683-44cd-a400-7763d2c4302a';
-const BUILT_IN_NODE_SOURCE_KIND_TAG = 'nativenodesource-aa0c30a9-bf1d-444a-a147-7823edcc7c04';
-
-interface BuiltInNodeContributor {
-    readonly [BUILT_IN_CONTRIBUTOR_KIND_TAG]: true;
-    readonly impl: ExplorerExtender<ClusterExplorerNode>;
-}
-
-interface BuiltInNodeSource {
-    readonly [BUILT_IN_NODE_SOURCE_KIND_TAG]: true;
-    readonly impl: NodeSourceImpl;
-}
-
-interface BuiltInNode {
-    readonly [BUILT_IN_NODE_KIND_TAG]: true;
-    readonly impl: ClusterExplorerNode;
-}
-
-function apiNodeSourceOf(nodeSet: NodeSourceImpl): ClusterExplorerV1_1.NodeSource & BuiltInNodeSource {
-    return {
-        at(parent: string | undefined) { const ee = nodeSet.at(parent); return apiNodeContributorOf(ee); },
-        if(condition: () => boolean | Thenable<boolean>) { return apiNodeSourceOf(nodeSet.if(condition)); },
-        async nodes() { return (await nodeSet.nodes()).map(apiNodeOf); },
-        [BUILT_IN_NODE_SOURCE_KIND_TAG]: true,
-        impl: nodeSet
-    };
-}
-
-function internalNodeSourceOf(nodeSet: ClusterExplorerV1_1.NodeSource): NodeSourceImpl {
-    if ((<any>nodeSet)[BUILT_IN_NODE_SOURCE_KIND_TAG]) {
-        return (nodeSet as unknown as BuiltInNodeSource).impl;
-    }
-    return {
-        at(parent: string | undefined) { return internalNodeContributorOf(nodeSet.at(parent)); },
-        if(condition: () => boolean | Thenable<boolean>) { return internalNodeSourceOf(nodeSet).if(condition); },
-        async nodes() { return (await nodeSet.nodes()).map(internalNodeOf); }
-    };
-}
-
-function internalNodeContributorOf(nodeContributor: ClusterExplorerV1_1.NodeContributor): ExplorerExtender<ClusterExplorerNode> {
-    if ((<any>nodeContributor)[BUILT_IN_CONTRIBUTOR_KIND_TAG] === true) {
-        return (nodeContributor as unknown as BuiltInNodeContributor).impl;
-    }
-    return new NodeContributorAdapter(nodeContributor);
-}
-
-function apiNodeContributorOf(ee: ExplorerExtender<ClusterExplorerNode>): ClusterExplorerV1_1.NodeContributor & BuiltInNodeContributor {
-    return {
-        contributesChildren(_parent) { return false; },
-        async getChildren(_parent) { return []; },
-        [BUILT_IN_CONTRIBUTOR_KIND_TAG]: true,
-        impl: ee
-    };
-}
-
-export function internalNodeOf(node: ClusterExplorerV1_1.Node): ClusterExplorerNode {
-    if ((<any>node)[BUILT_IN_NODE_KIND_TAG]) {
-        return (node as unknown as BuiltInNode).impl;
-    }
-    return new ContributedNode(node);
-}
-
-function apiNodeOf(node: ClusterExplorerNode): ClusterExplorerV1_1.Node & BuiltInNode {
-    return {
-        async getChildren() { throw new Error('apiNodeOf->getChildren: not expected to be called directly'); },
-        getTreeItem() { throw new Error('apiNodeOf->getTreeItem: not expected to be called directly'); },
-        [BUILT_IN_NODE_KIND_TAG]: true,
-        impl: node
-    };
 }


### PR DESCRIPTION
There is a lot of shared behaviour in the Cluster Explorer V1 and V1.1 API implementations (reflecting their significant overlap in the API surface).  We have a new API version coming down the line for a new tree layout, and I am hoping to add some new node sources before too long, which would be another API version.  So it would be good to centralise so that we can more easily review only what has changed rather than reviewing implementations files that are marked entirely as new code.