### PR TITLE
Revert v1 and v1.1 APIs to their contracts

### DIFF
--- a/src/api/contract/cluster-explorer/v1.ts
+++ b/src/api/contract/cluster-explorer/v1.ts
@@ -73,10 +73,6 @@ export namespace ClusterExplorerV1 {
         readonly nodeType: 'helm.release';
         readonly name: string;
     }
-    export interface ClusterExplorerHelmHistoryNode {
-        readonly nodeType: 'helm.history';
-        readonly name: string;
-    }
 
     export interface ClusterExplorerExtensionNode {
         readonly nodeType: 'extension';
@@ -91,7 +87,6 @@ export namespace ClusterExplorerV1 {
         ClusterExplorerConfigDataItemNode |
         ClusterExplorerErrorNode |
         ClusterExplorerHelmReleaseNode |
-        ClusterExplorerHelmHistoryNode |
         ClusterExplorerExtensionNode;
 
     export interface ResourceKind {

--- a/src/api/contract/cluster-explorer/v1_1.ts
+++ b/src/api/contract/cluster-explorer/v1_1.ts
@@ -76,11 +76,6 @@ export namespace ClusterExplorerV1_1 {
         readonly name: string;
     }
 
-    export interface ClusterExplorerHelmHistoryNode {
-        readonly nodeType: 'helm.history';
-        readonly name: string;
-    }
-
     export interface ClusterExplorerExtensionNode {
         readonly nodeType: 'extension';
     }
@@ -94,7 +89,6 @@ export namespace ClusterExplorerV1_1 {
         ClusterExplorerConfigDataItemNode |
         ClusterExplorerErrorNode |
         ClusterExplorerHelmReleaseNode |
-        ClusterExplorerHelmHistoryNode |
         ClusterExplorerExtensionNode;
 
     export interface ResourceKind {

--- a/src/api/implementation/cluster-explorer/common.ts
+++ b/src/api/implementation/cluster-explorer/common.ts
@@ -92,7 +92,6 @@ function adaptKubernetesExplorerNode(node: ClusterExplorerNode): ClusterExplorer
         case 'helm.release':
             return { nodeType: 'helm.release', name: node.releaseName };
         case 'helm.history':
-            return { nodeType: 'helm.history', name: node.releaseName };
         case 'extension':
             return { nodeType: 'extension' };
     }


### PR DESCRIPTION
When Helm release history was added the the cluster explorer, the v1 and v1,1 API contract files were edited to surface this node type, putting them out of sync with the previously existing contract.  This was unintentional and an error: existing API contracts never change, and the files should always reflect those pre-existing contracts.

This PR reverts the Cluster Explorer API contract files to their conditions before the edit, and restores them to being in sync with the previously existing contracts.

As a future enhancement, we should consider keeping golden versions of the API contracts in the tests folder, and verifying that the files in `src/api/contracts` have not changed from there, with a message conveying that the golden versions must not be changed and a new API version must be created instead.  Or we could compare them against golden versions in GitHub identified by path and tag.  Thoughts?