### PR TITLE
Ignore tool paths at workspace level

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,10 +100,11 @@
     "contributes": {
         "configuration": {
             "type": "object",
-            "title": "Kubernetes configuration",
+            "title": "Kubernetes",
             "properties": {
                 "vs-kubernetes": {
                     "type": "object",
+                    "title": "Additional settings",
                     "description": "Kubernetes configuration",
                     "properties": {
                         "vs-kubernetes.namespace": {
@@ -112,51 +113,51 @@
                         },
                         "vs-kubernetes.kubectl-path": {
                             "type": "string",
-                            "description": "File path to a kubectl binary."
+                            "description": "[deprecated - use top level property] File path to a kubectl binary."
                         },
                         "vs-kubernetes.helm-path": {
                             "type": "string",
-                            "description": "File path to a helm binary."
+                            "description": "[deprecated - use top level property] File path to a helm binary."
                         },
                         "vs-kubernetes.minikube-path": {
                             "type": "string",
-                            "description": "File path to a minikube binary."
+                            "description": "[deprecated - use top level property] File path to a minikube binary."
                         },
                         "vs-kubernetes.kubectl-path.windows": {
                             "type": "string",
-                            "description": "File path to a kubectl binary."
+                            "description": "[deprecated - use top level property] File path to a kubectl binary."
                         },
                         "vs-kubernetes.helm-path.windows": {
                             "type": "string",
-                            "description": "File path to a helm binary."
+                            "description": "[deprecated - use top level property] File path to a helm binary."
                         },
                         "vs-kubernetes.minikube-path.windows": {
                             "type": "string",
-                            "description": "File path to a minikube binary."
+                            "description": "[deprecated - use top level property] File path to a minikube binary."
                         },
                         "vs-kubernetes.kubectl-path.mac": {
                             "type": "string",
-                            "description": "File path to a kubectl binary."
+                            "description": "[deprecated - use top level property] File path to a kubectl binary."
                         },
                         "vs-kubernetes.helm-path.mac": {
                             "type": "string",
-                            "description": "File path to a helm binary."
+                            "description": "[deprecated - use top level property] File path to a helm binary."
                         },
                         "vs-kubernetes.minikube-path.mac": {
                             "type": "string",
-                            "description": "File path to a minikube binary."
+                            "description": "[deprecated - use top level property] File path to a minikube binary."
                         },
                         "vs-kubernetes.kubectl-path.linux": {
                             "type": "string",
-                            "description": "File path to a kubectl binary."
+                            "description": "[deprecated - use top level property] File path to a kubectl binary."
                         },
                         "vs-kubernetes.helm-path.linux": {
                             "type": "string",
-                            "description": "File path to a helm binary."
+                            "description": "[deprecated - use top level property] File path to a helm binary."
                         },
                         "vs-kubernetes.minikube-path.linux": {
                             "type": "string",
-                            "description": "File path to a minikube binary."
+                            "description": "[deprecated - use top level property] File path to a minikube binary."
                         },
                         "vs-kubernetes.kubectlVersioning": {
                             "type": "string",
@@ -286,6 +287,78 @@
                     "type": "string",
                     "default": null,
                     "description": "Image prefix for docker images ie 'docker.io/brendanburns'"
+                },
+                "vscode-kubernetes.kubectl-path": {
+                    "type": "string",
+                    "scope": "machine",
+                    "title": "Path to kubectl",
+                    "description": "File path to a kubectl binary. (You can override this on a per-OS basis if required)."
+                },
+                "vscode-kubernetes.helm-path": {
+                    "type": "string",
+                    "scope": "machine",
+                    "title": "Helm path",
+                    "description": "File path to a helm binary. (You can override this on a per-OS basis if required)."
+                },
+                "vscode-kubernetes.minikube-path": {
+                    "type": "string",
+                    "scope": "machine",
+                    "title": "Minikube path",
+                    "description": "File path to a minikube binary. (You can override this on a per-OS basis if required)."
+                },
+                "vscode-kubernetes.kubectl-path.windows": {
+                    "type": "string",
+                    "scope": "machine",
+                    "title": "Path to kubectl (Windows)",
+                    "description": "File path to a kubectl binary."
+                },
+                "vscode-kubernetes.helm-path.windows": {
+                    "type": "string",
+                    "scope": "machine",
+                    "title": "Helm path (Windows)",
+                    "description": "File path to a helm binary."
+                },
+                "vscode-kubernetes.minikube-path.windows": {
+                    "type": "string",
+                    "scope": "machine",
+                    "title": "Minikube path (Windows)",
+                    "description": "File path to a minikube binary."
+                },
+                "vscode-kubernetes.kubectl-path.mac": {
+                    "type": "string",
+                    "scope": "machine",
+                    "title": "Path to kubectl (Mac)",
+                    "description": "File path to a kubectl binary."
+                },
+                "vscode-kubernetes.helm-path.mac": {
+                    "type": "string",
+                    "scope": "machine",
+                    "title": "Helm path (Mac)",
+                    "description": "File path to a helm binary."
+                },
+                "vscode-kubernetes.minikube-path.mac": {
+                    "type": "string",
+                    "scope": "machine",
+                    "title": "Minikube path (Mac)",
+                    "description": "File path to a minikube binary."
+                },
+                "vscode-kubernetes.kubectl-path.linux": {
+                    "type": "string",
+                    "scope": "machine",
+                    "title": "Path to kubectl (Linux)",
+                    "description": "File path to a kubectl binary."
+                },
+                "vscode-kubernetes.helm-path.linux": {
+                    "type": "string",
+                    "scope": "machine",
+                    "title": "Helm path (Linux)",
+                    "description": "File path to a helm binary."
+                },
+                "vscode-kubernetes.minikube-path.linux": {
+                    "type": "string",
+                    "scope": "machine",
+                    "title": "Minikube path (Linux)",
+                    "description": "File path to a minikube binary."
                 }
             }
         },

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -105,11 +105,11 @@ export function getToolPath(_host: Host, shell: Shell, tool: string): string | u
 
     const baseBackCompatKey = toolPathBackCompatBaseKey(tool);
     const osBackCompatKey = osOverrideKey(os, baseBackCompatKey);
-    const backCompatSettings = config.inspect<Dictionary<any>>(EXTENSION_CONFIG_KEY);
-    const wsFolderValues = backCompatSettings?.workspaceFolderValue || {};
-    const wsValues = backCompatSettings?.workspaceValue || {};
-    const userValues = backCompatSettings?.globalValue || {};
-    const defaultValues = backCompatSettings?.defaultValue || {};
+    const backCompatSettings = config.inspect<Dictionary<any>>(EXTENSION_CONFIG_KEY) || Dictionary.of<any>();
+    const wsFolderValues = backCompatSettings.workspaceFolderValue || {};
+    const wsValues = backCompatSettings.workspaceValue || {};
+    const userValues = backCompatSettings.globalValue || {};
+    const defaultValues = backCompatSettings.defaultValue || {};
 
     const localBackCompatSetting =
         wsFolderValues[osBackCompatKey] ||

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { Host } from '../../host';
 import { Shell, Platform } from '../../shell';
+import { Dictionary } from '../../utils/dictionary';
 
 const EXTENSION_CONFIG_KEY = "vs-kubernetes";
 const KUBECONFIG_PATH_KEY = "vs-kubernetes.kubeconfig";
@@ -97,25 +98,54 @@ export function getActiveKubeconfig(): string {
 
 // Functions for working with tool paths
 
-export function getToolPath(host: Host, shell: Shell, tool: string): string | undefined {
-    const baseKey = toolPathBaseKey(tool);
-    return getPathSetting(host, shell, baseKey);
-}
-
-function getPathSetting(host: Host, shell: Shell, baseKey: string): string | undefined {
+export function getToolPath(_host: Host, shell: Shell, tool: string): string | undefined {
     const os = shell.platform();
-    const osOverridePath = host.getConfiguration(EXTENSION_CONFIG_KEY)[osOverrideKey(os, baseKey)];
-    return osOverridePath || host.getConfiguration(EXTENSION_CONFIG_KEY)[baseKey];
+
+    const config = vscode.workspace.getConfiguration();
+
+    const baseBackCompatKey = toolPathBackCompatBaseKey(tool);
+    const osBackCompatKey = osOverrideKey(os, baseBackCompatKey);
+    const backCompatSettings = config.inspect<Dictionary<any>>(EXTENSION_CONFIG_KEY);
+    const wsFolderValues = backCompatSettings?.workspaceFolderValue || {};
+    const wsValues = backCompatSettings?.workspaceValue || {};
+    const userValues = backCompatSettings?.globalValue || {};
+    const defaultValues = backCompatSettings?.defaultValue || {};
+
+    const localBackCompatSetting =
+        wsFolderValues[osBackCompatKey] ||
+        wsFolderValues[baseBackCompatKey] ||
+        wsValues[osBackCompatKey] ||
+        wsValues[baseBackCompatKey];
+
+    if (localBackCompatSetting) {
+        console.warn(`Ignoring workspace-level setting ${baseBackCompatKey}; paths are not allowed at workspace level`);
+    }
+
+    const globalBackCompatSetting =
+        userValues[osBackCompatKey] ||
+        userValues[baseBackCompatKey] ||
+        defaultValues[osBackCompatKey] ||
+        defaultValues[baseBackCompatKey];
+
+    const baseKey = toolPathNewBaseKey(tool);
+    const osKey = osOverrideKey(os, baseKey);
+    const topLevelToolPath = config.get<string>(osKey) || config.get<string>(baseKey);
+
+    return topLevelToolPath || globalBackCompatSetting;
 }
 
 export function toolPathOSKey(os: Platform, tool: string): string {
-    const baseKey = toolPathBaseKey(tool);
+    const baseKey = toolPathNewBaseKey(tool);
     const osSpecificKey = osOverrideKey(os, baseKey);
     return osSpecificKey;
 }
 
-function toolPathBaseKey(tool: string): string {
+function toolPathBackCompatBaseKey(tool: string): string {
     return `vs-kubernetes.${tool}-path`;
+}
+
+function toolPathNewBaseKey(tool: string): string {
+    return `vscode-kubernetes.${tool}-path`;
 }
 
 function osOverrideKey(os: Platform, baseKey: string): string {


### PR DESCRIPTION
It is undesirable for workspace-level configuration to specify tool paths, because those tool paths are unlikely to be portable across different clones of the workspace.

Fortunately, VS Code allows you to mark configuration settings as `machine` or `user` so that they are picked up only from global settings and ignored at the workspace level.

Unfortunately. we long ago bundled all our settings into one settings object.  And VS Code would only let us mark that _object_ as `machine` or `user`.  We can't mark individual properties of the object.

So this PR declares some new top-level properties for tool paths, which are marked as `machine`.  The old object properties are accepted for compatibility, but only at global level; workspace level settings are now explicitly ignored.

(As a bonus, this means that tool paths can now be edited in the VS Code settings editor rather than just JSON, so that's nice.)

NOTE: the new settings are prefixed `vscode-kubernetes` instead of `vs-kubernetes`.  This is because the existing object is called `vs-kubernetes` and VS Code's reading of dotted notation seems to mean that looking up `vs-kubernetes.foo` results in it looking for `foo` in the object and not considering the top-level dotted property.  At least it seemed not to work for me and changing the prefix did work.