### PR TITLE
VS Code engine and types were out of sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "1.2.4",
     "publisher": "ms-kubernetes-tools",
     "engines": {
-        "vscode": "^1.31.0"
+        "vscode": "^1.52.0"
     },
     "license": "MIT",
     "categories": [


### PR DESCRIPTION
I upgraded the VS Code types as part of the smoke test PR, but this put them out of sync with the VS Code engine declaration, which caused issues in packaging which weren't caught in the PR cycle.  This puts things back in sync.  And now everything will just work first time.