### PR TITLE
add webpack __dirname rule

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,9 @@ const config = {
           use: ['file-loader']
       }
     ]
+  },
+  node: {
+    __dirname: false
   }
 };
 module.exports = config;


### PR DESCRIPTION
it resolves #897 

@itowlson found this https://webpack.js.org/configuration/node/#node__dirname . Now the `__dirname` is resolved to `/` and it probably fails because it doesn't have permission to write the proxy file there. By adding this rule `__dirname` should be resolved  like before. Try it whenever you can.