### PR TITLE
Adding support for syntax highlighting for Helm Inspect Values

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "onCommand:extension.helmDepUp",
         "onCommand:extension.helmInspectChart",
         "onCommand:extension.helmInspectValues",
+        "onCommand:extension.helmGetValues",
         "onCommand:extension.helmGet",
         "onCommand:extension.helmPackage",
         "onCommand:extension.helmFetch",
@@ -673,6 +674,11 @@
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem =~ /vsKubernetes\\.((chart)|(chartversion))/i"
                 },
                 {
+                    "command": "extension.helmGetValues",
+                    "group": "0@3",
+                    "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem =~ /vsKubernetes\\.((chart)|(chartversion))/i"
+                },
+                {
                     "command": "extension.helmRollback",
                     "group": "3@1",
                     "when": "view == extension.vsKubernetesExplorer && viewItem =~ /vsKubernetes\\.helmhistory/i"
@@ -1085,6 +1091,12 @@
                 "command": "extension.helmInspectValues",
                 "title": "Inspect Values",
                 "description": "Inspect a Helm Chart",
+                "category": "Helm"
+            },
+            {
+                "command": "extension.helmGetValues",
+                "title": "Generate values.yaml",
+                "description": "Generate values.yaml from the chart",
                 "category": "Helm"
             },
             {

--- a/package.json
+++ b/package.json
@@ -75,8 +75,7 @@
         "onCommand:extension.helmInsertReq",
         "onCommand:extension.helmDepUp",
         "onCommand:extension.helmInspectChart",
-        "onCommand:extension.helmInspectValues",
-        "onCommand:extension.helmGenerateValues",
+        "onCommand:extension.helmFetchValues",
         "onCommand:extension.helmGet",
         "onCommand:extension.helmPackage",
         "onCommand:extension.helmFetch",
@@ -426,11 +425,6 @@
                 },
                 {
                     "when": "",
-                    "command": "extension.helmInspectValues",
-                    "group": "2_helm@98"
-                },
-                {
-                    "when": "",
                     "command": "extension.helmConvertToTemplate",
                     "group": "2_helm@98"
                 }
@@ -669,12 +663,7 @@
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem =~ /vsKubernetes\\.((chart)|(chartversion))/i"
                 },
                 {
-                    "command": "extension.helmInspectValues",
-                    "group": "0@2",
-                    "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem =~ /vsKubernetes\\.((chart)|(chartversion))/i"
-                },
-                {
-                    "command": "extension.helmGenerateValues",
+                    "command": "extension.helmFetchValues",
                     "group": "0@3",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem =~ /vsKubernetes\\.((chart)|(chartversion))/i"
                 },
@@ -764,14 +753,6 @@
                 {
                     "command": "extension.helmGet",
                     "when": "view == extension.vsKubernetesExplorer"
-                },
-                {
-                    "command": "extension.helmInspectValues",
-                    "when": "filesExplorerFocus"
-                },
-                {
-                    "command": "extension.helmInspectValues",
-                    "when": "view === extension.vsKubernetesHelmRepoExplorer"
                 },
                 {
                     "command": "extension.helmInspectChart",
@@ -1088,15 +1069,9 @@
                 "category": "Helm"
             },
             {
-                "command": "extension.helmInspectValues",
-                "title": "Inspect Values",
-                "description": "Inspect a Helm Chart",
-                "category": "Helm"
-            },
-            {
-                "command": "extension.helmGenerateValues",
-                "title": "Generate values.yaml",
-                "description": "Generate values.yaml from the chart",
+                "command": "extension.helmFetchValues",
+                "title": "Fetch values",
+                "description": "Fetches values.yaml from the chart",
                 "category": "Helm"
             },
             {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "onCommand:extension.helmDepUp",
         "onCommand:extension.helmInspectChart",
         "onCommand:extension.helmInspectValues",
-        "onCommand:extension.helmGenerateValues",
+        "onCommand:extension.helmGetValues",
         "onCommand:extension.helmGet",
         "onCommand:extension.helmPackage",
         "onCommand:extension.helmFetch",
@@ -674,7 +674,7 @@
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem =~ /vsKubernetes\\.((chart)|(chartversion))/i"
                 },
                 {
-                    "command": "extension.helmGenerateValues",
+                    "command": "extension.helmGetValues",
                     "group": "0@3",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem =~ /vsKubernetes\\.((chart)|(chartversion))/i"
                 },
@@ -1094,7 +1094,7 @@
                 "category": "Helm"
             },
             {
-                "command": "extension.helmGenerateValues",
+                "command": "extension.helmGetValues",
                 "title": "Generate values.yaml",
                 "description": "Generate values.yaml from the chart",
                 "category": "Helm"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "onCommand:extension.helmDepUp",
         "onCommand:extension.helmInspectChart",
         "onCommand:extension.helmInspectValues",
-        "onCommand:extension.helmGetValues",
+        "onCommand:extension.helmGenerateValues",
         "onCommand:extension.helmGet",
         "onCommand:extension.helmPackage",
         "onCommand:extension.helmFetch",
@@ -674,7 +674,7 @@
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem =~ /vsKubernetes\\.((chart)|(chartversion))/i"
                 },
                 {
-                    "command": "extension.helmGetValues",
+                    "command": "extension.helmGenerateValues",
                     "group": "0@3",
                     "when": "view == extension.vsKubernetesHelmRepoExplorer && viewItem =~ /vsKubernetes\\.((chart)|(chartversion))/i"
                 },
@@ -1094,7 +1094,7 @@
                 "category": "Helm"
             },
             {
-                "command": "extension.helmGetValues",
+                "command": "extension.helmGenerateValues",
                 "title": "Generate values.yaml",
                 "description": "Generate values.yaml from the chart",
                 "category": "Helm"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -234,7 +234,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         registerCommand('extension.helmTemplatePreview', helmexec.helmTemplatePreview),
         registerCommand('extension.helmLint', helmexec.helmLint),
         registerCommand('extension.helmInspectValues', helmexec.helmInspectValues),
-        registerCommand('extension.helmGenerateValues', helmexec.helmGenerateValues),
+        registerCommand('extension.helmGetValues', helmexec.helmGetValues),
         registerCommand('extension.helmInspectChart', helmexec.helmInspectChart),
         registerCommand('extension.helmDryRun', helmexec.helmDryRun),
         registerCommand('extension.helmDepUp', helmexec.helmDepUp),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -233,8 +233,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         registerCommand('extension.helmTemplate', helmexec.helmTemplate),
         registerCommand('extension.helmTemplatePreview', helmexec.helmTemplatePreview),
         registerCommand('extension.helmLint', helmexec.helmLint),
-        registerCommand('extension.helmInspectValues', helmexec.helmInspectValues),
-        registerCommand('extension.helmGenerateValues', helmexec.helmGenerateValues),
+        registerCommand('extension.helmFetchValues', helmexec.helmFetchValues),
         registerCommand('extension.helmInspectChart', helmexec.helmInspectChart),
         registerCommand('extension.helmDryRun', helmexec.helmDryRun),
         registerCommand('extension.helmDepUp', helmexec.helmDepUp),
@@ -263,9 +262,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
 
         // HTML renderers
         vscode.workspace.registerTextDocumentContentProvider(helm.PREVIEW_SCHEME, previewProvider),
-        vscode.workspace.registerTextDocumentContentProvider(helm.INSPECT_VALUES_SCHEME, inspectProvider),
         vscode.workspace.registerTextDocumentContentProvider(helm.INSPECT_CHART_SCHEME, inspectProvider),
-        vscode.workspace.registerTextDocumentContentProvider(helm.GET_VALUES_SCHEME, helmValuesProvider),
+        vscode.workspace.registerTextDocumentContentProvider(helm.FETCH_VALUES_SCHEME, helmValuesProvider),
         vscode.workspace.registerTextDocumentContentProvider(helm.DEPENDENCIES_SCHEME, dependenciesProvider),
 
         // Completion providers

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,7 +38,7 @@ import * as helmexec from './helm.exec';
 import * as helmauthoring from './helm.authoring';
 import { HelmRequirementsCodeLensProvider } from './helm.requirementsCodeLens';
 import { HelmTemplateHoverProvider } from './helm.hoverProvider';
-import { HelmTemplatePreviewDocumentProvider, HelmInspectDocumentProvider, HelmDependencyDocumentProvider } from './helm.documentProvider';
+import { HelmTemplatePreviewDocumentProvider, HelmInspectDocumentProvider, HelmDependencyDocumentProvider, HelmValuesDocumentProvider } from './helm.documentProvider';
 import { HelmTemplateCompletionProvider } from './helm.completionProvider';
 import { Reporter } from './telemetry';
 import * as telemetry from './telemetry-helper';
@@ -142,6 +142,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
     const resourceLinkProvider = new KubernetesResourceLinkProvider();
     const previewProvider = new HelmTemplatePreviewDocumentProvider();
     const inspectProvider = new HelmInspectDocumentProvider();
+    const helmValuesProvider = new HelmValuesDocumentProvider();
     const dependenciesProvider = new HelmDependencyDocumentProvider();
     const helmSymbolProvider = new HelmDocumentSymbolProvider();
     const completionProvider = new HelmTemplateCompletionProvider();
@@ -233,6 +234,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         registerCommand('extension.helmTemplatePreview', helmexec.helmTemplatePreview),
         registerCommand('extension.helmLint', helmexec.helmLint),
         registerCommand('extension.helmInspectValues', helmexec.helmInspectValues),
+        registerCommand('extension.helmGetValues', helmexec.helmGetValues),
         registerCommand('extension.helmInspectChart', helmexec.helmInspectChart),
         registerCommand('extension.helmDryRun', helmexec.helmDryRun),
         registerCommand('extension.helmDepUp', helmexec.helmDepUp),
@@ -263,6 +265,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         vscode.workspace.registerTextDocumentContentProvider(helm.PREVIEW_SCHEME, previewProvider),
         vscode.workspace.registerTextDocumentContentProvider(helm.INSPECT_VALUES_SCHEME, inspectProvider),
         vscode.workspace.registerTextDocumentContentProvider(helm.INSPECT_CHART_SCHEME, inspectProvider),
+        vscode.workspace.registerTextDocumentContentProvider(helm.GET_VALUES_SCHEME, helmValuesProvider),
         vscode.workspace.registerTextDocumentContentProvider(helm.DEPENDENCIES_SCHEME, dependenciesProvider),
 
         // Completion providers

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -234,7 +234,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<APIBro
         registerCommand('extension.helmTemplatePreview', helmexec.helmTemplatePreview),
         registerCommand('extension.helmLint', helmexec.helmLint),
         registerCommand('extension.helmInspectValues', helmexec.helmInspectValues),
-        registerCommand('extension.helmGetValues', helmexec.helmGetValues),
+        registerCommand('extension.helmGenerateValues', helmexec.helmGenerateValues),
         registerCommand('extension.helmInspectChart', helmexec.helmInspectChart),
         registerCommand('extension.helmDryRun', helmexec.helmDryRun),
         registerCommand('extension.helmDepUp', helmexec.helmDepUp),

--- a/src/helm.documentProvider.ts
+++ b/src/helm.documentProvider.ts
@@ -1,15 +1,15 @@
-import { escape as htmlEscape } from 'lodash';
-import * as filepath from 'path';
+import * as vscode from "vscode";
+import * as filepath from "path";
+import * as exec from "./helm.exec";
+import * as YAML from "yamljs";
+import * as fs from "./wsl-fs";
+import { escape as htmlEscape } from "lodash";
 import * as querystring from "querystring";
-import * as vscode from 'vscode';
-import * as YAML from 'yamljs';
-import { failed } from './errorable';
-import * as helm from './helm';
-import * as exec from './helm.exec';
-import * as logger from './logger';
-import * as shell from './shell';
-import * as fs from './wsl-fs';
 
+import * as helm from "./helm";
+import * as logger from "./logger";
+import { failed } from "./errorable";
+import * as shell from "./shell";
 
 interface HelmDocumentResult {
     readonly title: string;

--- a/src/helm.documentProvider.ts
+++ b/src/helm.documentProvider.ts
@@ -89,7 +89,7 @@ export class HelmInspectDocumentProvider implements vscode.TextDocumentContentPr
                 const id = uri.path.substring(1);
                 const query = querystring.parse(uri.query);
                 const version = query.version as string;
-                const generateFile = (query.generateFile as string) ? true : false;
+                const generateFile = query.generateFile  ? true : false;
                 if (!shell.isSafe(id)) {
                     vscode.window.showWarningMessage(`Unexpected characters in chart name ${id}. Use Helm CLI to inspect this chart.`);
                     return;
@@ -135,7 +135,8 @@ export class HelmValuesDocumentProvider implements vscode.TextDocumentContentPro
             ) {
                 const query = querystring.parse(uri.query);
                 const id = query.chart as string;
-                const version = query.version as string;
+                const version = query.version ? `${query.version}` : "";
+                const versionArg = version ? `--version ${version}` : "";
                 if (!shell.isSafe(id)) {
                     vscode.window.showWarningMessage(`Unexpected characters in chart name ${id}. Use Helm CLI to inspect this chart.`);
                     return;
@@ -144,7 +145,6 @@ export class HelmValuesDocumentProvider implements vscode.TextDocumentContentPro
                     vscode.window.showWarningMessage(`Unexpected characters in chart version ${version}. Use Helm CLI to inspect this chart.`);
                     return;
                 }
-                const versionArg = version ? `--version ${version}` : "";
                 exec.helmExec(`inspect values ${id} ${versionArg}`, filePrinter);
             }
         });

--- a/src/helm.documentProvider.ts
+++ b/src/helm.documentProvider.ts
@@ -126,7 +126,7 @@ export class HelmValuesDocumentProvider implements vscode.TextDocumentContentPro
         return new Promise<string>((resolve, reject) => {
             if (
                 uri.authority === helm.INSPECT_REPO_AUTHORITY &&
-                uri.scheme === helm.GET_VALUES_SCHEME
+                uri.scheme === helm.FETCH_VALUES_SCHEME
             ) {
                 const query = querystring.parse(uri.query);
                 const id = query.chart as string;

--- a/src/helm.documentProvider.ts
+++ b/src/helm.documentProvider.ts
@@ -1,15 +1,15 @@
-import * as vscode from "vscode";
-import * as filepath from "path";
-import * as exec from "./helm.exec";
-import * as YAML from "yamljs";
-import * as fs from "./wsl-fs";
-import { escape as htmlEscape } from "lodash";
-import * as querystring from "querystring";
+import * as vscode from 'vscode';
+import * as filepath from 'path';
+import * as exec from './helm.exec';
+import * as YAML from 'yamljs';
+import * as fs from './wsl-fs';
+import { escape as htmlEscape } from 'lodash';
+import * as querystring from 'querystring';
 
-import * as helm from "./helm";
-import * as logger from "./logger";
-import { failed } from "./errorable";
-import * as shell from "./shell";
+import * as helm from './helm';
+import * as logger from './logger';
+import { failed } from './errorable';
+import * as shell from './shell';
 
 interface HelmDocumentResult {
     readonly title: string;

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -220,19 +220,11 @@ export function helmLint() {
     });
 }
 
-export function helmInspectValues(arg: any) {
-    helmInspect(arg, {
-        noTargetMessage: "Helm Inspect Values is for packaged charts and directories. Launch the command from a file or directory in the file explorer. or a chart or version in the Helm Repos explorer.",
-        inspectionScheme: helm.INSPECT_VALUES_SCHEME,
-        generateFile: false
-    });
-}
-
-export function helmGenerateValues(arg: any) {
+export function helmFetchValues(arg: any) {
     helmInspect(arg, {
         noTargetMessage:
             "Helm generate values.yaml is for packaged charts and directories. Launch the command from a file or directory in the file explorer. or a chart or version in the Helm Repos explorer.",
-        inspectionScheme: helm.GET_VALUES_SCHEME,
+        inspectionScheme: helm.FETCH_VALUES_SCHEME,
         generateFile: true,
     });
 }

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -22,7 +22,7 @@ import { HELM_RESOURCE_AUTHORITY, K8S_RESOURCE_SCHEME } from './kuberesources.vi
 import { helm as logger } from './logger';
 import { parseLineOutput } from './outputUtils';
 import { ExecCallback, shell as sh, ShellResult } from './shell';
-import { getFile as openHelmValuesFile, preview } from "./utils/preview";
+import { getFile, preview } from "./utils/preview";
 import * as fs from './wsl-fs';
 import * as shell from './shell';
 
@@ -228,7 +228,7 @@ export function helmInspectValues(arg: any) {
     });
 }
 
-export function helmGenerateValues(arg: any) {
+export function helmGetValues(arg: any) {
     helmInspect(arg, {
         noTargetMessage:
             "Helm generate values.yaml is for packaged charts and directories. Launch the command from a file or directory in the file explorer. or a chart or version in the Helm Repos explorer.",
@@ -262,10 +262,13 @@ function helmInspect(arg: any, s: InspectionStrategy) {
 
     if (helmrepoexplorer.isHelmRepoChart(arg) || helmrepoexplorer.isHelmRepoChartVersion(arg)) {
         const id = arg.id;
-        const versionQuery = helmrepoexplorer.isHelmRepoChartVersion(arg) ? `?version=${arg.version}` : "";
-        const uri = vscode.Uri.parse(`${s.inspectionScheme}://${helm.INSPECT_REPO_AUTHORITY}/values.yaml?chart=${id}${versionQuery}`);
+        let versionQuery = helmrepoexplorer.isHelmRepoChartVersion(arg) ? `?version=${arg.version}` : "";
+        const generateFile = s.generateFile ? `&generateFile=values.yaml` : "";
+        let uri = vscode.Uri.parse(`${s.inspectionScheme}://${helm.INSPECT_REPO_AUTHORITY}/${id}${versionQuery}${generateFile}`);
         if (s.generateFile) {
-            openHelmValuesFile(uri);
+            versionQuery = helmrepoexplorer.isHelmRepoChartVersion(arg) ? `&version=${arg.version}` : "";
+            uri = vscode.Uri.parse(`${s.inspectionScheme}://${helm.INSPECT_REPO_AUTHORITY}/values.yaml?chart=${id}${versionQuery}`);
+            getFile(uri);
         } else {
             preview(uri, vscode.ViewColumn.Two, "Inspect");
         }

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -22,7 +22,7 @@ import { HELM_RESOURCE_AUTHORITY, K8S_RESOURCE_SCHEME } from './kuberesources.vi
 import { helm as logger } from './logger';
 import { parseLineOutput } from './outputUtils';
 import { ExecCallback, shell as sh, ShellResult } from './shell';
-import { getFile, preview } from "./utils/preview";
+import { openHelmGeneratedValuesFile, preview } from "./utils/preview";
 import * as fs from './wsl-fs';
 import * as shell from './shell';
 
@@ -263,12 +263,17 @@ function helmInspect(arg: any, s: InspectionStrategy) {
     if (helmrepoexplorer.isHelmRepoChart(arg) || helmrepoexplorer.isHelmRepoChartVersion(arg)) {
         const id = arg.id;
         let versionQuery = helmrepoexplorer.isHelmRepoChartVersion(arg) ? `?version=${arg.version}` : "";
-        const generateFile = s.generateFile ? `&generateFile=values.yaml` : "";
-        let uri = vscode.Uri.parse(`${s.inspectionScheme}://${helm.INSPECT_REPO_AUTHORITY}/${id}${versionQuery}${generateFile}`);
+        let uri = vscode.Uri.parse(`${s.inspectionScheme}://${helm.INSPECT_REPO_AUTHORITY}/${id}${versionQuery}`);
         if (s.generateFile) {
             versionQuery = helmrepoexplorer.isHelmRepoChartVersion(arg) ? `&version=${arg.version}` : "";
-            uri = vscode.Uri.parse(`${s.inspectionScheme}://${helm.INSPECT_REPO_AUTHORITY}/values.yaml?chart=${id}${versionQuery}`);
-            getFile(uri);
+            let valuesFileName = `${id}-values.yaml`;
+            if (versionQuery !== "") {
+                valuesFileName = `${id}-${versionQuery.replace('&version=', "")}-values.yaml`;
+            }
+            uri = vscode.Uri.parse(
+                `${s.inspectionScheme}://${helm.INSPECT_REPO_AUTHORITY}/${valuesFileName}?chart=${id}${versionQuery}`
+            );
+            openHelmGeneratedValuesFile(uri);
         } else {
             preview(uri, vscode.ViewColumn.Two, "Inspect");
         }

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -228,7 +228,7 @@ export function helmInspectValues(arg: any) {
     });
 }
 
-export function helmGetValues(arg: any) {
+export function helmGenerateValues(arg: any) {
     helmInspect(arg, {
         noTargetMessage:
             "Helm generate values.yaml is for packaged charts and directories. Launch the command from a file or directory in the file explorer. or a chart or version in the Helm Repos explorer.",

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -231,7 +231,7 @@ export function helmInspectValues(arg: any) {
 export function helmGetValues(arg: any) {
     helmInspect(arg, {
         noTargetMessage:
-            "Helm Inspect Values is for packaged charts and directories. Launch the command from a file or directory in the file explorer. or a chart or version in the Helm Repos explorer.",
+            "Helm generate values.yaml is for packaged charts and directories. Launch the command from a file or directory in the file explorer. or a chart or version in the Helm Repos explorer.",
         inspectionScheme: helm.GET_VALUES_SCHEME,
         generateFile: true,
     });

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -22,7 +22,7 @@ import { HELM_RESOURCE_AUTHORITY, K8S_RESOURCE_SCHEME } from './kuberesources.vi
 import { helm as logger } from './logger';
 import { parseLineOutput } from './outputUtils';
 import { ExecCallback, shell as sh, ShellResult } from './shell';
-import { getFile, preview } from "./utils/preview";
+import { getFile as openHelmValuesFile, preview } from "./utils/preview";
 import * as fs from './wsl-fs';
 import * as shell from './shell';
 
@@ -228,7 +228,7 @@ export function helmInspectValues(arg: any) {
     });
 }
 
-export function helmGetValues(arg: any) {
+export function helmGenerateValues(arg: any) {
     helmInspect(arg, {
         noTargetMessage:
             "Helm generate values.yaml is for packaged charts and directories. Launch the command from a file or directory in the file explorer. or a chart or version in the Helm Repos explorer.",
@@ -262,13 +262,10 @@ function helmInspect(arg: any, s: InspectionStrategy) {
 
     if (helmrepoexplorer.isHelmRepoChart(arg) || helmrepoexplorer.isHelmRepoChartVersion(arg)) {
         const id = arg.id;
-        let versionQuery = helmrepoexplorer.isHelmRepoChartVersion(arg) ? `?version=${arg.version}` : "";
-        const generateFile = s.generateFile ? `&generateFile=values.yaml` : "";
-        let uri = vscode.Uri.parse(`${s.inspectionScheme}://${helm.INSPECT_REPO_AUTHORITY}/${id}${versionQuery}${generateFile}`);
+        const versionQuery = helmrepoexplorer.isHelmRepoChartVersion(arg) ? `?version=${arg.version}` : "";
+        const uri = vscode.Uri.parse(`${s.inspectionScheme}://${helm.INSPECT_REPO_AUTHORITY}/values.yaml?chart=${id}${versionQuery}`);
         if (s.generateFile) {
-            versionQuery = helmrepoexplorer.isHelmRepoChartVersion(arg) ? `&version=${arg.version}` : "";
-            uri = vscode.Uri.parse(`${s.inspectionScheme}://${helm.INSPECT_REPO_AUTHORITY}/values.yaml?chart=${id}${versionQuery}`);
-            getFile(uri);
+            openHelmValuesFile(uri);
         } else {
             preview(uri, vscode.ViewColumn.Two, "Inspect");
         }

--- a/src/helm.exec.ts
+++ b/src/helm.exec.ts
@@ -22,7 +22,7 @@ import { HELM_RESOURCE_AUTHORITY, K8S_RESOURCE_SCHEME } from './kuberesources.vi
 import { helm as logger } from './logger';
 import { parseLineOutput } from './outputUtils';
 import { ExecCallback, shell as sh, ShellResult } from './shell';
-import { openHelmGeneratedValuesFile, preview } from "./utils/preview";
+import { openHelmGeneratedValuesFile, preview } from './utils/preview';
 import * as fs from './wsl-fs';
 import * as shell from './shell';
 
@@ -262,19 +262,19 @@ function helmInspect(arg: any, s: InspectionStrategy) {
 
     if (helmrepoexplorer.isHelmRepoChart(arg) || helmrepoexplorer.isHelmRepoChartVersion(arg)) {
         const id = arg.id;
-        let versionQuery = helmrepoexplorer.isHelmRepoChartVersion(arg) ? `?version=${arg.version}` : "";
-        let uri = vscode.Uri.parse(`${s.inspectionScheme}://${helm.INSPECT_REPO_AUTHORITY}/${id}${versionQuery}`);
         if (s.generateFile) {
-            versionQuery = helmrepoexplorer.isHelmRepoChartVersion(arg) ? `&version=${arg.version}` : "";
+            const versionQuery = helmrepoexplorer.isHelmRepoChartVersion(arg) ? `&version=${arg.version}` : "";
             let valuesFileName = `${id}-values.yaml`;
             if (versionQuery !== "") {
                 valuesFileName = `${id}-${versionQuery.replace('&version=', "")}-values.yaml`;
             }
-            uri = vscode.Uri.parse(
+            const uri = vscode.Uri.parse(
                 `${s.inspectionScheme}://${helm.INSPECT_REPO_AUTHORITY}/${valuesFileName}?chart=${id}${versionQuery}`
             );
             openHelmGeneratedValuesFile(uri);
         } else {
+             const versionQuery = helmrepoexplorer.isHelmRepoChartVersion(arg) ? `?version=${arg.version}` : "";
+             const uri = vscode.Uri.parse(`${s.inspectionScheme}://${helm.INSPECT_REPO_AUTHORITY}/${id}${versionQuery}`);
             preview(uri, vscode.ViewColumn.Two, "Inspect");
         }
     } else {

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -6,6 +6,7 @@ export const INSPECT_REPO_AUTHORITY = 'repo-chart';
 export const INSPECT_FILE_AUTHORITY = 'chart-file';
 export const DEPENDENCIES_SCHEME = 'helm-dependencies';
 export const DEPENDENCIES_REPO_AUTHORITY = 'repo-chart';
+export const GET_VALUES_SCHEME = "helm-get-values";
 export const HELM_OUTPUT_COLUMN_SEPARATOR = /\t+/g;
 
 let previewShown = false;

--- a/src/helm.ts
+++ b/src/helm.ts
@@ -6,7 +6,7 @@ export const INSPECT_REPO_AUTHORITY = 'repo-chart';
 export const INSPECT_FILE_AUTHORITY = 'chart-file';
 export const DEPENDENCIES_SCHEME = 'helm-dependencies';
 export const DEPENDENCIES_REPO_AUTHORITY = 'repo-chart';
-export const GET_VALUES_SCHEME = "helm-get-values";
+export const FETCH_VALUES_SCHEME = "helm-get-values";
 export const HELM_OUTPUT_COLUMN_SEPARATOR = /\t+/g;
 
 let previewShown = false;

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -17,6 +17,9 @@ async function getHTML(uri: vscode.Uri): Promise<string> {
 
 export async function openHelmGeneratedValuesFile(uri: vscode.Uri): Promise<void> {
     return vscode.workspace.openTextDocument(uri).then((document) => {
-        vscode.window.showTextDocument(document);
-    });
+            if (document) {
+                vscode.window.showTextDocument(document);
+            }
+        },
+        (err) => vscode.window.showErrorMessage(`Error loading document: ${err}`));
 }

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -15,7 +15,7 @@ async function getHTML(uri: vscode.Uri): Promise<string> {
     return doc.getText();
 }
 
-export async function getFile(uri: vscode.Uri): Promise<void> {
+export async function openHelmGeneratedValuesFile(uri: vscode.Uri): Promise<void> {
     return vscode.workspace.openTextDocument(uri).then((document) => {
         vscode.window.showTextDocument(document);
     });

--- a/src/utils/preview.ts
+++ b/src/utils/preview.ts
@@ -14,3 +14,9 @@ async function getHTML(uri: vscode.Uri): Promise<string> {
     const doc = await vscode.workspace.openTextDocument(uri);
     return doc.getText();
 }
+
+export async function getFile(uri: vscode.Uri): Promise<void> {
+    return vscode.workspace.openTextDocument(uri).then((document) => {
+        vscode.window.showTextDocument(document);
+    });
+}


### PR DESCRIPTION
This PR follows the enhancement request #891 and implements a new command `Generate values.yaml` for Helm Repo Explorer which generates a `values.yaml` file for the Helm chart. 

![image](https://user-images.githubusercontent.com/311217/110229056-6695a780-7ebb-11eb-89ed-c39625ca175f.png)


The primary use case for this `values.yaml` file is syntax highlighting and generation of editable `values.yaml` file which can enable customization of Helm chart installation.

Since this functionality is closely related to Helm Inspect Values I have implemented this as an extension of the same. Happy to provide alternate implementation if necessary. 