### PR TITLE
Binaries installed with wrong permissions should be fixed

### DIFF
--- a/src/components/installer/fixwriteablebinaries.ts
+++ b/src/components/installer/fixwriteablebinaries.ts
@@ -1,0 +1,83 @@
+// We had an issue where we were installing binaries with excessively permissive
+// permissions.  We no longer do this, but older installations may have existing
+// files lying around.  This module checks for such files and fixes their permissions.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { promisify } from 'util';
+
+import { Shell } from "../../shell";
+import { Dictionary } from '../../utils/dictionary';
+import { baseInstallFolder } from "./installationlayout";
+
+const MITIGATIONS_FILE = 'mitigations.json';
+
+export async function fixOldInstalledBinaryPermissions(shell: Shell): Promise<void> {
+    if (!shell.isUnix()) {
+        return;
+    }
+    if (isMitigated(shell)) {
+        return;
+    }
+
+    try {
+        await fixAllBinaryPermissions(baseInstallFolder(shell));
+        recordMitigated(shell);
+    } catch (e) {
+        // don't bubble this up to the top level
+        console.warn(`Error trying to update permissions to installed binaries: ${e}`);
+    }
+
+}
+
+const chmod = promisify(fs.chmod);
+const readdir = promisify(fs.readdir);
+const stat = promisify(fs.stat);
+
+async function fixAllBinaryPermissions(folder: string): Promise<void> {
+    const entries = (await readdir(folder)).map((e) => path.join(folder, e));
+    for (const entry of entries) {
+        const info = await stat(entry);
+        if (info.isDirectory()) {
+            await fixAllBinaryPermissions(entry);
+        } else if (info.isFile()) {
+            if ((info.mode & 0o777) === 0o777) {
+                await chmod(entry, 0o755);
+            }
+        }
+    }
+}
+
+function readMitigations(shell: Shell): Dictionary<any> {
+    const mitigationsFile = path.join(baseInstallFolder(shell), MITIGATIONS_FILE);
+    if (!fs.existsSync(mitigationsFile)) {
+        return {};
+    }
+    const mitigationsJSON = fs.readFileSync(mitigationsFile, { encoding: 'utf8' });
+    try {
+        return JSON.parse(mitigationsJSON);
+    } catch {
+        return {};
+    }
+}
+
+function writeMitigations(shell: Shell, value: Dictionary<any>): void {
+    const mitigationsFile = path.join(baseInstallFolder(shell), MITIGATIONS_FILE);
+    try {
+        fs.writeFileSync(mitigationsFile, JSON.stringify(value, undefined, 2));
+    } catch (e) {
+        // swallow errors - just means we will recheck next startup
+        console.log(`Failed to record mitigation: ${e}`);
+    }
+}
+
+function isMitigated(shell: Shell): boolean {
+    const mitigations = readMitigations(shell);
+    return !!mitigations && !!mitigations['permissions'];
+}
+
+function recordMitigated(shell: Shell): void {
+    const mitigations = readMitigations(shell);
+    mitigations['permissions'] = true;
+    writeMitigations(shell, mitigations);
+}

--- a/src/components/installer/installationlayout.ts
+++ b/src/components/installer/installationlayout.ts
@@ -1,4 +1,14 @@
-import { Platform } from "../../shell";
+import * as path from 'path';
+
+import { Platform, Shell } from "../../shell";
+
+export function baseInstallFolder(shell: Shell): string {
+    return path.join(shell.home(), `.vs-kubernetes/tools`);
+}
+
+export function getInstallFolder(shell: Shell, tool: string): string {
+    return path.join(baseInstallFolder(shell), tool);
+}
 
 export function platformUrlString(platform: Platform, supported?: Platform[]): string | null {
     if (supported && supported.indexOf(platform) < 0) {

--- a/src/components/installer/installer.ts
+++ b/src/components/installer/installer.ts
@@ -10,7 +10,7 @@ import * as tar from 'tar';
 import { Shell, Platform } from '../../shell';
 import { Errorable, failed, succeeded } from '../../errorable';
 import { addPathToConfig, toolPathOSKey, getUseWsl } from '../config/config';
-import { platformUrlString, formatBin, platformArch } from './installationlayout';
+import { getInstallFolder, platformUrlString, formatBin, platformArch } from './installationlayout';
 import { IncomingMessage } from 'http';
 
 enum ArchiveKind {
@@ -151,10 +151,6 @@ async function installToolFromArchive(tool: string, urlTemplate: string, shell: 
     const url = urlTemplate.replace('{os_placeholder}', os).replace('{arch}', arch);
     const configKey = toolPathOSKey(shell.platform(), tool);
     return installFromArchive(url, installFolder, executable, configKey, shell, archiveKind);
-}
-
-function getInstallFolder(shell: Shell, tool: string): string {
-    return path.join(shell.home(), `.vs-kubernetes/tools/${tool}`);
 }
 
 async function installFromArchive(sourceUrl: string, destinationFolder: string, executablePath: string, configKey: string, shell: Shell, archiveKind: ArchiveKind): Promise<Errorable<null>> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,6 +86,7 @@ import { ExecResult } from './binutilplusplus';
 import { getCurrentContext } from './kubectlUtils';
 import { LocalTunnelDebugger } from './components/localtunneldebugger/localtunneldebugger';
 import { setAssetContext } from './assets';
+import { fixOldInstalledBinaryPermissions } from './components/installer/fixwriteablebinaries';
 
 let explainActive = false;
 let swaggerSpecPromise: Promise<explainer.SwaggerModel | undefined> | null = null;
@@ -131,6 +132,8 @@ export const HELM_TPL_MODE: vscode.DocumentFilter = { language: "helm", scheme: 
 // your extension is activated the very first time the command is executed
 export async function activate(context: vscode.ExtensionContext): Promise<APIBroker> {
     setAssetContext(context);
+
+    await fixOldInstalledBinaryPermissions(shell);
 
     kubectl.ensurePresent({ warningIfNotPresent: 'Kubectl not found. Many features of the Kubernetes extension will not work.' });
 


### PR DESCRIPTION
We had an issue where binaries we installed were too broadly writeable.  That is now fixed, but users who allowed old versions of the extension to do an install will be left with poorly configured files.

This fix checks the extension's tool installation directory at startup and fixes any executable files to be user-writeable only.  To avoid performing this check on every startup, it records if there has been a successful pass and skips the directory walk if so.