### PR TITLE
Fetch custom crd schemas from active cluster

### DIFF
--- a/src/components/swagger/swagger.ts
+++ b/src/components/swagger/swagger.ts
@@ -3,6 +3,7 @@ import { Errorable, failed } from "../../errorable";
 import { Kubectl } from "../../kubectl";
 import { proxy } from "../kubectl/proxy";
 import { fs } from '../../fs';
+import { ExecResult } from '../../binutilplusplus';
 
 export type Swagger = any;
 
@@ -33,4 +34,42 @@ export async function getClusterSwagger(kubectl: Kubectl): Promise<Errorable<Swa
     } finally {
         proxySession.dispose();
     }
+}
+
+export async function getCrdSchemas(kubectl: Kubectl): Promise<{[key: string]: object | undefined} | undefined> {
+    const er = await kubectl.invokeCommand(`get crd -o jsonpath="{range .items[*].spec}[{.group}, {.names.plural}, {.names.singular}, {range .versions[?(.schema.openAPIV3Schema.properties)]}{.name}{\\" \\"}{end}]{end}"`);
+
+    if (ExecResult.failed(er)) {
+        kubectl.reportFailure(er, { whatFailed: 'Failed to get crds' });
+        return;
+    }
+    try {
+        const crdSchemasMapping: { [key: string]: object } = {};
+        const crdInfos = er.stdout.substring(1).split('[');
+        for (const crdInfo of crdInfos) {
+            const crdInfoAsArray = crdInfo.split(',');
+            const group = crdInfoAsArray[0].trim();
+            const plural = crdInfoAsArray[1].trim();
+            const singular = crdInfoAsArray[2].trim();
+            const versions = crdInfoAsArray[3].trim() !== '' ? crdInfoAsArray[3].trim().split(' ') : [];
+            if (versions.length > 0) {
+                const crdSchemas = await getSchemas(kubectl, `${plural}.${group}`);
+                for (const version of versions) {
+                    const versionObject = crdSchemas.spec.versions.filter((v: { name: string }) => v.name === version);
+                    crdSchemasMapping[`${group}/${version}@${singular}`] = versionObject.length > 0 ? versionObject[0].schema.openAPIV3Schema.properties : undefined;
+                }
+            }
+        }
+        return crdSchemasMapping;
+    } catch (e) { }
+    return;
+}
+
+async function getSchemas(kubectl: Kubectl, crd: string) {
+    const json = await kubectl.asJson<any>(`get crd ${crd} -o json`);
+    if (failed(json)) {
+        return;
+    }
+    return json.result;
+
 }

--- a/src/kubectlUtils.ts
+++ b/src/kubectlUtils.ts
@@ -406,11 +406,13 @@ function isTransientPodState(status: string): boolean {
  * @param resourceId the resource id.
  * @return the result as a json object, or undefined if errors happen.
  */
-export async function getResourceAsJson<T extends KubernetesResource | KubernetesCollection<KubernetesResource>>(kubectl: Kubectl, resourceId: string, resourceNamespace?: string): Promise<T | undefined> {
+export async function getResourceAsJson<T extends KubernetesResource | KubernetesCollection<KubernetesResource>>(kubectl: Kubectl, resourceId: string, resourceNamespace?: string, silent?: boolean): Promise<T | undefined> {
     const nsarg = resourceNamespace ? `--namespace ${resourceNamespace}` : '';
     const shellResult = await kubectl.asJson<T>(`get ${resourceId} ${nsarg} -o json`);
     if (failed(shellResult)) {
-        vscode.window.showErrorMessage(shellResult.error[0]);
+        if (!silent) {
+            vscode.window.showErrorMessage(shellResult.error[0]);
+        }
         return undefined;
     }
     return shellResult.result;


### PR DESCRIPTION
This resolves #917 

Until now the plugin only downloaded the swagger json from the active cluster which contains minimal schemas for custom crds. An example is the camel-k operator as mentioned in #917. The minimal schema for the kameletbinding type is 
```
{
  "id": "camel.apache.org/v1alpha1@KameletBinding",
  "apiVersion": "camel.apache.org/v1alpha1",
  "kind": "KameletBinding",
  "type": "object",
  "name": "org.apache.camel.v1alpha1.KameletBinding"
}
```
while the crd on the cluster contains the actual schema 
```
"versions": [
            {
                "additionalPrinterColumns": [
                    {
                        "description": "The Kamelet Binding phase",
                        "jsonPath": ".status.phase",
                        "name": "Phase",
                        "type": "string"
                    }
                ],
                "name": "v1alpha1",
                "schema": {
                    "openAPIV3Schema": {
                        "description": "KameletBinding is the Schema for the kamelets binding API",
                        "properties": {
                            "apiVersion": {
                                "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
                                "type": "string"
                            },
                            "kind": {
                                "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
                                "type": "string"
                            },
                            "metadata": {
                                "type": "object"
                            },
                            "spec": {
                                "description": "KameletBindingSpec --",
                                "properties": {
                                    "integration": {
                                        "description": "Integration is an optional integration used to specify custom parameters",
                                        "properties": {
                                            "configuration": {
                                                "items": {
                                                    "description": "ConfigurationSpec --",
                                                    "properties": {
                                                        "type": {
                                                            "type": "string"
                                                        },
                                                        "value": {
                                                            "type": "string"
                                                        }
                                                    },
                                                    "required": [
                                                        "type",
...........
...........
```

So users didn't have autocompletion or schema validation at all.
This patch adds the logic to download and use all schemas (when available) for all crds and their multiple versions. 
Below a short demonstration of the cool autocompletion we obtain for the camel-k operator

![kamelet](https://user-images.githubusercontent.com/49404737/115116096-2c2e2880-9f98-11eb-95e7-e12de7241b29.gif)

@apupier it would be awesome if you could test it and tell me if it works as expected. Keep in mind that when the plugin starts it fetch everything and then feed the YAML plugin with the schemas so if you have your `kamelet` file already opened when the k8s extensions activates you won't see anything. So close it and reopen it.
