### PR TITLE
Remove values.yaml association with helm-template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1199,7 +1199,6 @@
                     "helm"
                 ],
                 "filenamePatterns": [
-                    "values.yaml",
                     "Chart.yaml",
                     "requirements.yaml",
                     "**/templates/*.yaml",


### PR DESCRIPTION
values.yaml is for user-specified values rather than a Helm chart specification. Associating with helm-template causes issues when using JSON schema validation, as noted in #146, redhat-developer/vscode-yaml#196, and others.