### PR TITLE
Read the install locations from User and default configuration to decide whether the dependencies are installed or not

### DIFF
--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -129,7 +129,11 @@ export function getToolPath(_host: Host, shell: Shell, tool: string): string | u
 
     const baseKey = toolPathNewBaseKey(tool);
     const osKey = osOverrideKey(os, baseKey);
-    const topLevelToolPath = config.get<string>(osKey) || config.get<string>(baseKey);
+    const topLevelToolPath = 
+        userValues[osKey] ||
+        defaultValues[osKey] ||
+        userValues[baseKey] ||
+        defaultValues[baseKey];
 
     return topLevelToolPath || globalBackCompatSetting;
 }


### PR DESCRIPTION
**Description:**
This PR fixes the issue where the dependencies(kubectl, helm, minikube) are not being downloaded in remote-containers automatically. Currently in #543, manual workaround are specified to unblock the users but this PR would remove the need to have a manual workarounds.
**How it is being fixed:**
Once the install dependencies button is clicked, on a fresh machine the binaries are being downloaded to /home/username/.vs-kubernetes/tools/< toolname >/< toolBinary >. After the download is completed (for example in installKubectl ), the path of the tool is updated in the config values at Global, Workspace & WorkspaceFolder level using `addPathToConfig`.
Previously the values are being retrieved from the custom config values.