### PR TITLE
Remove chart.yaml and requirements.yaml from languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1166,8 +1166,6 @@
                     "helm"
                 ],
                 "filenamePatterns": [
-                    "Chart.yaml",
-                    "requirements.yaml",
                     "**/templates/*.yaml",
                     "**/templates/*.yml",
                     "**/templates/*.tpl",


### PR DESCRIPTION
These aren’t Helm templates. They are regular yaml files.