### PR TITLE
Improve performance log viewer

### DIFF
--- a/log-colors-rules.json
+++ b/log-colors-rules.json
@@ -1,5 +1,9 @@
 [
     {
+        "regex": "\"[^\"]*\"|(?<![\\w])'[^']*'|\\[(warning|warn|wrn|wn|w)\\]|(?<=^[\\s\\d\\p]*)\\bW\\b|\\b(WARNING|WARN|Warn|WW)\\b",
+        "color": "ol"
+    },
+    {
         "regex": "\\b(HINT|INFO|INFORMATION|Info|NOTICE|II)\\b|\\[(information|info|inf|in|i)\\]|(?<=^[\\s\\d\\p]*)\\bI\\b",
         "color": "gl"
     },
@@ -10,11 +14,7 @@
     {
         "regex": "\\b(DEBUG|Debug)\\b|\\[(debug|dbug|dbg|de|d)\\]|(?<=^[\\s\\d\\p]*)\\bD\\b|\\b([0-9a-fA-F]{40}|[0-9a-fA-F]{10}|[0-9a-fA-F]{7})\\b|\\b[0-9a-fA-F]{8}[-]?([0-9a-fA-F]{4}[-]?){3}[0-9a-fA-F]{12}\\b|\\b([0-9]+|true|false|null)\\b|\\b[a-z]+://\\S+\\b/?",
         "color": "b"
-    },
-    {
-        "regex": "\\[(warning|warn|wrn|wn|w)\\]|(?<=^[\\s\\d\\p]*)\\bW\\b|\\b(WARNING|WARN|Warn|WW)\\b|\"[^\"]*\"|(?<![\\w])'[^']*'",
-        "color": "ol"
-    },
+    },    
     {
         "regex": "\\[(error|eror|err|er|e|fatal|fatl|ftl|fa|f)\\]|(?<=^[\\s\\d\\p]*)\\bE\\b|\\b(ALERT|CRITICAL|EMERGENCY|ERROR|FAILURE|FAIL|Fatal|FATAL|Error|EE)\\b",
         "color": "r"

--- a/log-colors-rules.json
+++ b/log-colors-rules.json
@@ -1,107 +1,27 @@
 [
     {
-        "regex": "\\b(HINT|INFO|INFORMATION|Info|NOTICE|II)\\b",
-        "color": "#b5cea8"
+        "regex": "\\b(HINT|INFO|INFORMATION|Info|NOTICE|II)\\b|\\[(information|info|inf|in|i)\\]|(?<=^[\\s\\d\\p]*)\\bI\\b",
+        "color": "gl"
     },
     {
-        "regex": "\\[(information|info|inf|in|i)\\]",
-        "color": "#b5cea8"
+        "regex": "\\b(Trace)\\b:|\\[(verbose|verb|vrb|vb|v)\\]|(?<=^[\\s\\d\\p]*)\\bV\\b|\\b\\d{4}-\\d{2}-\\d{2}(T|\\b)|(?<=(^|\\s))\\d{2}[^\\w\\s]\\d{2}[^\\w\\s]\\d{4}\\b|\\d{1,2}:\\d{2}(:\\d{2}([.,]\\d{1,})?)?(Z| ?[+-]\\d{1,2}:\\d{2})?\\b",
+        "color": "g"
     },
     {
-        "regex": "(?<=^[\\s\\d\\p]*)\\bI\\b",
-        "color": "#b5cea8"
+        "regex": "\\b(DEBUG|Debug)\\b|\\[(debug|dbug|dbg|de|d)\\]|(?<=^[\\s\\d\\p]*)\\bD\\b|\\b([0-9a-fA-F]{40}|[0-9a-fA-F]{10}|[0-9a-fA-F]{7})\\b|\\b[0-9a-fA-F]{8}[-]?([0-9a-fA-F]{4}[-]?){3}[0-9a-fA-F]{12}\\b|\\b([0-9]+|true|false|null)\\b|\\b[a-z]+://\\S+\\b/?",
+        "color": "b"
     },
     {
-        "regex": "\\b(Trace)\\b:",
-        "color": "#6a9955"
+        "regex": "\\[(warning|warn|wrn|wn|w)\\]|(?<=^[\\s\\d\\p]*)\\bW\\b|\\b(WARNING|WARN|Warn|WW)\\b|\"[^\"]*\"|(?<![\\w])'[^']*'",
+        "color": "ol"
     },
     {
-        "regex": "\\[(verbose|verb|vrb|vb|v)\\]",
-        "color": "#6a9955"
-    },
-    {
-        "regex": "\\[(verbose|verb|vrb|vb|v)\\]",
-        "color": "#6a9955"
-    },
-    {
-        "regex": "(?<=^[\\s\\d\\p]*)\\bV\\b",
-        "color": "#6a9955"
-    },
-    {
-        "regex": "\\b(DEBUG|Debug)\\b",
-        "color": "#569cd6"
-    },
-    {
-        "regex": "\\[(debug|dbug|dbg|de|d)\\]",
-        "color": "#569cd6"
-    },
-    {
-        "regex": "(?<=^[\\s\\d\\p]*)\\bD\\b",
-        "color": "#569cd6"
-    },
-    {
-        "regex": "\\b(WARNING|WARN|Warn|WW)\\b",
-        "color": "#ce9178"
-    },
-    {
-        "regex": "\\[(warning|warn|wrn|wn|w)\\]",
-        "color": "#ce9178"
-    },
-    {
-        "regex": "(?<=^[\\s\\d\\p]*)\\bW\\b",
-        "color": "#ce9178"
-    },
-    {
-        "regex": "\\b(ALERT|CRITICAL|EMERGENCY|ERROR|FAILURE|FAIL|Fatal|FATAL|Error|EE)\\b",
-        "color": "#c50313"
-    },
-    {
-        "regex": "\\[(error|eror|err|er|e|fatal|fatl|ftl|fa|f)\\]",
-        "color": "#c50313"
-    },
-    {
-        "regex": "(?<=^[\\s\\d\\p]*)\\bE\\b",
-        "color": "#c50313"
-    },
-    {
-        "regex": "\\b\\d{4}-\\d{2}-\\d{2}(T|\\b)",
-        "color": "#6a9955"
-    },
-    {
-        "regex": "(?<=(^|\\s))\\d{2}[^\\w\\s]\\d{2}[^\\w\\s]\\d{4}\\b",
-        "color": "#6a9955"
-    },
-    {
-        "regex": "\\d{1,2}:\\d{2}(:\\d{2}([.,]\\d{1,})?)?(Z| ?[+-]\\d{1,2}:\\d{2})?\\b",
-        "color": "#6a9955"
-    },
-    {
-        "regex": "\\b([0-9a-fA-F]{40}|[0-9a-fA-F]{10}|[0-9a-fA-F]{7})\\b",
-        "color": "#569cd6"
-    },
-    {
-        "regex": "\\b[0-9a-fA-F]{8}[-]?([0-9a-fA-F]{4}[-]?){3}[0-9a-fA-F]{12}\\b",
-        "color": "#569cd6"
-    },
-    {
-        "regex": "\\b([0-9]+|true|false|null)\\b",
-        "color": "#569cd6"
-    },
-    {
-        "regex": "\"[^\"]*\"",
-        "color": "#ce9178"
-    },
-    {
-        "regex": "(?<![\\w])'[^']*'",
-        "color": "#ce9178"
+        "regex": "\\[(error|eror|err|er|e|fatal|fatl|ftl|fa|f)\\]|(?<=^[\\s\\d\\p]*)\\bE\\b|\\b(ALERT|CRITICAL|EMERGENCY|ERROR|FAILURE|FAIL|Fatal|FATAL|Error|EE)\\b",
+        "color": "r"
     },
     {
         "regex": "\\b([a-zA-Z.]*Exception)\\b",
-        "color": "#c36741"
-    },
-    {
-        "regex": "\\b[a-z]+://\\S+\\b/?",
-        "color": "#569cd6"
+        "color": "o"
     }
     
 ]

--- a/src/components/logs/app/index.html
+++ b/src/components/logs/app/index.html
@@ -157,10 +157,6 @@
                 <span class="tooltiptext">Long words should be broken and wrap onto the next line.</span>
             </div>  
             <vscode-checkbox id="wrap-chk"></vscode-checkbox>
-            <div class="tooltip ml-10 mr-2">Enable highlighting:
-                <span class="tooltiptext">Highlight logs words. Warning: it may slow the ui when working with a big log file (>40k rows).</span>
-            </div>  
-            <vscode-checkbox id="highlight-chk"></vscode-checkbox>
             
             <vscode-button id="bottomBtn" class="float-right mr-50">Scroll To Bottom</vscode-button>
         </div>

--- a/src/components/logs/app/index.html
+++ b/src/components/logs/app/index.html
@@ -112,7 +112,7 @@
                 <vscode-button id="runBtn" class="mr-2">Run</vscode-button>
                 <vscode-button id="stopBtn" class="display-none mr-2">Stop</vscode-button>
                 <vscode-button id="clearBtn" class="display-none mr-2">Clear</vscode-button>
-                <vscode-button id="resetBtn mr-2">Reset</vscode-button>                
+                <vscode-button id="resetBtn" class="mr-2">Reset</vscode-button>                
             </div>
             <div class="tooltip ml-10 mr-2">To terminal:
                 <span class="tooltiptext">Redirect logs to terminal.</span>

--- a/src/components/logs/app/index.html
+++ b/src/components/logs/app/index.html
@@ -32,6 +32,9 @@
         .mr-50 {
             margin-right: 50px;
         }
+        .position-relative {
+            position: relative;
+        }
         .display-inline-block {
             display: inline-block;
         }
@@ -89,7 +92,7 @@
     </style>
 </head>
 <body>
-    <div style='position: fixed; top: 15px; left: 2%; width: 100%; z-index: 9999'>
+    <div style='position: fixed; top: 15px; left: 2%; width: 100%; z-index: 9999;'>
         <div>
             <div id="containers-panel" class="mr-10 display-none">
                 <div class="tooltip mr-2">Container:
@@ -97,7 +100,7 @@
                 </div>
             </div>
            
-            <div class="tooltip mr-2">Follow Logs:
+            <div id="follow-lbl" class="tooltip mr-2">Follow Logs:
                 <span class="tooltiptext">Logs should be streamed.</span>
             </div>  
             <vscode-checkbox id="follow-chk"></vscode-checkbox>
@@ -165,9 +168,11 @@
     </div>
     <div style='position: absolute; top: 90px; bottom: 10px; width: 97%'>
         <div id="logPanel" style="overflow-y: scroll; height: 100%">
-            <code id='content' class='white-space-pre'>           
-            </code>             
-            <a id='bottom'></a>    
+            <div id="innerLogPanel">
+                <code id='content' class='white-space-pre position-relative'>           
+                </code>
+            </div>
+            <a id='bottom'></a> 
         </div>
     </div>
     </body>

--- a/src/components/logs/app/index.html
+++ b/src/components/logs/app/index.html
@@ -68,6 +68,24 @@
         #content {
             color: var(--vscode-foreground)
         }
+        .gl {
+            color: #b5cea8;
+        }
+        .g {
+            color: #6a9955;
+        }
+        .b {
+            color: #569cd6;
+        }
+        .ol {
+            color: #ce9178;
+        }
+        .r {
+            color: #c50313;
+        }
+        .o {
+            color: #c36741;
+        }
     </style>
 </head>
 <body>
@@ -136,6 +154,10 @@
                 <span class="tooltiptext">Long words should be broken and wrap onto the next line.</span>
             </div>  
             <vscode-checkbox id="wrap-chk"></vscode-checkbox>
+            <div class="tooltip ml-10 mr-2">Enable highlighting:
+                <span class="tooltiptext">Highlight logs words. Warning: it may slow the ui when working with a big log file (>40k rows).</span>
+            </div>  
+            <vscode-checkbox id="highlight-chk"></vscode-checkbox>
             
             <vscode-button id="bottomBtn" class="float-right mr-50">Scroll To Bottom</vscode-button>
         </div>
@@ -143,10 +165,9 @@
     </div>
     <div style='position: absolute; top: 90px; bottom: 10px; width: 97%'>
         <div id="logPanel" style="overflow-y: scroll; height: 100%">
-            <code>
-            <div id='content' class='white-space-pre'></div>
-            <a id='bottom'></a>
-            </code>
+            <code id='content' class='white-space-pre'>           
+            </code>             
+            <a id='bottom'></a>    
         </div>
     </div>
     </body>

--- a/src/components/logs/app/main.js
+++ b/src/components/logs/app/main.js
@@ -79,10 +79,15 @@ function beautifyLines(contentLines) {
     if (!contentLines) {
         return '';
     }
-    let content = contentLines.join('\n');
-    if (content) {
-        content = content.match(/\n$/) ? content : content + '\n';
-        content = highlightWords(content);
+    const isToBeHighlighted = contentLines.length < 50000;
+    let content = '';
+    for (let row of contentLines) {
+        row = row.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+        if (isToBeHighlighted) {
+            row = highlightWords(row);
+        }
+        row = /\n$/.test(row) ? row : `${row}\n`;
+        content += row;
     }
     return content;
 }
@@ -99,18 +104,17 @@ function highlightWords(content) {
     return content;
 }
 
-function repl(match, _word, offset, originalString) {
+function repl() {
+    const match = arguments[0];
+    const offset = arguments[arguments.length - 2];
+    const originalString = arguments[arguments.length - 1];
     if (!originalString) {
         return match;
     }
     const indexOpenSpan = originalString.substring(0, offset + match.length).lastIndexOf("<span");
     const indexCloseSpan = originalString.substring(0, offset + match.length).lastIndexOf("</span>");
-    if (indexOpenSpan === -1) {
+    if (indexOpenSpan === -1 || indexOpenSpan < indexCloseSpan) {
         return `<span style="color:#ruleColor">${match}</span>`;
-    } else if (indexOpenSpan !== -1 && indexCloseSpan === -1) {
-        return match;
-    } else if (indexOpenSpan < indexCloseSpan) {
-            return `<span style="color:#ruleColor">${match}</span>`;
     } else {
         return match;
     }

--- a/src/components/logs/app/main.js
+++ b/src/components/logs/app/main.js
@@ -255,7 +255,6 @@ function reset() {
     document.getElementById('since-select').selectedIndex = 0;
     document.getElementById('tail-input').value = '-1';
     document.getElementById('terminal-chk').checked = false;
-    document.getElementById('highlight-chk').checked = false;
 }
 
 function updateContent(newContent) {
@@ -485,9 +484,7 @@ function beautifyLines(contentLines) {
             continue;
         }
         value = value.replace(/</g, "&lt;").replace(/>/g, "&gt;");
-        if (isHighlightEnabled()) {
-            value = highlightWords(value);
-        }
+        value = highlightWords(value);
         value = /\n$/.test(value) ? value : `${value}\n`;
         content[key] = `<div id="${key}" style="min-height: ${heightDiv}px">${value}</div>`;
     }
@@ -604,10 +601,6 @@ function getTail() {
 
 function getToTerminal() {
     return document.getElementById('terminal-chk').checked;
-}
-
-function isHighlightEnabled() {
-    return document.getElementById('highlight-chk').checked;
 }
 
 function isWrapEnabled() {

--- a/src/components/logs/app/main.js
+++ b/src/components/logs/app/main.js
@@ -83,6 +83,7 @@ function init() {
 
     const stopBtn = document.getElementById('stopBtn');
     stopBtn.addEventListener('click', (_event) => {
+        isFollowRun = false;
         changeVisibilityAfterStop();
         stopLog();
     });
@@ -235,6 +236,10 @@ function stopLog() {
 }
 
 function clear() {
+    if (!isFollowRun) {
+        resetContent();
+        resetFilter();
+    }
     setHeightContentPanel(true);
     emptyContent();
 }


### PR DESCRIPTION
it fixes #942 

This patch fixes some performance issues discovered while reading big logs (>80k rows, size 10MB).
The content loaded is now calculated based on where the user is reading and only a part of the full content is displayed (~500rows). This prevent the UI from freezing while highlighting all the content.

After the user stops scrolling the viewer calculate which rows should be displayed and render them.

All schemas have been merged based on their final highlighting color to reduce their numbers (and so the loops), switched from inline-style to css classes and replaced arrays with objects.
