### PR TITLE
Ingress snippet: replace "http" with "- http"

### DIFF
--- a/snippets/ingress.yaml
+++ b/snippets/ingress.yaml
@@ -11,7 +11,7 @@ body: |2
   spec:
     rules:
     - host: ${2:<Host>}
-      http:
+    - http:
         paths:
         - pathType: Prefix
           path: "/"


### PR DESCRIPTION
Ingress didn't worked for me as expected, resulting in nginx "404" error, changing ```http``` to ```- http``` solved the problem for me.