### PR TITLE
Provide ability to config path to vsdbg

### DIFF
--- a/debug-on-kubernetes.md
+++ b/debug-on-kubernetes.md
@@ -19,6 +19,7 @@ One of the key features of VS Code Kubernetes Extension is its one-click debuggi
       * `vs-kubernetes.nodejs-autodetect-remote-root` - This flag controls how the extension locates the root of the source code in the container. If true will try to automatically get the root location of the source code in the container, by getting the CWD of the nodejs process. If false, the `remoteRoot` setting in the debug configuration will be set to the value of the `vs-kubernetes.nodejs-remote-root` setting.
       * `vs-kubernetes.nodejs-remote-root` - User specified root location of the source code in the container. Remote root is passed to the debug configuration to allow vscode to map local files to files in the container. If `vs-kubernetes.nodejs-autodetect-remote-root` is set to `false` and `vs-kubernetes.nodejs-remote-root` is empty, no remoteRoot is set in the debug configuration. For more info on Node.js remote debugging see [vscode documentation](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_remote-debugging)
       * `vs-kubernetes.nodejs-debug-port` - Sets the nodejs remote debugging port. The default for node is 9229.
+      * `vs-kubernetes.dotnet-vsdbg-path` - Sets the path to the vsdbg debugger in the container
       * `vs-kubernetes.dotnet-source-file-map` - Sets the compilation root for the vsdbg debugger in order to have a sourceFileMap in the attach configuration
 
    * `vsdocker.imageUser` - Image prefix for docker images e.g. 'docker.io/brendanburns'.

--- a/package.json
+++ b/package.json
@@ -234,6 +234,10 @@
                             "type": "number",
                             "description": "Remote debugging port for Python. Usually 5678."
                         },
+                        "vs-kubernetes.dotnet-source-file-map": {
+                            "type": "string",
+                            "description": "The compilation root for the vsdbg debugger in order to have a sourceFileMap in the attach configuration of debug (.NET)."
+                        },
                         "vs-kubernetes.resources-to-watch": {
                             "type": "array",
                             "description": "List of resources to be watched."

--- a/package.json
+++ b/package.json
@@ -234,6 +234,10 @@
                             "type": "number",
                             "description": "Remote debugging port for Python. Usually 5678."
                         },
+                        "vs-kubernetes.dotnet-vsdbg-path": {
+                            "type": "string",
+                            "description": "The path to the vsdbg debugger in the container (.NET)."
+                        },
                         "vs-kubernetes.dotnet-source-file-map": {
                             "type": "string",
                             "description": "The compilation root for the vsdbg debugger in order to have a sourceFileMap in the attach configuration of debug (.NET)."
@@ -276,6 +280,7 @@
                         "vs-kubernetes.nodejs-autodetect-remote-root": true,
                         "vs-kubernetes.nodejs-remote-root": "",
                         "vs-kubernetes.nodejs-debug-port": 9229,
+                        "vs-kubernetes.dotnet-vsdbg-path": "~/vsdbg/vsdbg",
                         "vs-kubernetes.local-tunnel-debug-provider": "",
                         "checkForMinikubeUpgrade": true,
                         "imageBuildTool": "Docker"

--- a/src/components/config/config.ts
+++ b/src/components/config/config.ts
@@ -261,6 +261,10 @@ export function getPythonDebugPort(): number | undefined {
     return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.python-debug-port'];
 }
 
+// remote debugging path to dotnet debugger (vsdbg)
+export function getDotnetVsdbgPath(): string {
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_KEY)['vs-kubernetes.dotnet-vsdbg-path'];
+}
 
 // remote debugging sourceFileMap for dotnet. An entry "sourceFileMap": {"<vs-kubernetes.dotnet-source-file-map>":"$workspaceFolder"} will be added to the debug configuration
 export function getDotnetDebugSourceFileMap(): string | undefined {

--- a/src/debug/dotNetDebugProvider.ts
+++ b/src/debug/dotNetDebugProvider.ts
@@ -42,7 +42,7 @@ export class DotNetDebugProvider implements IDebugProvider {
             pipeTransport: {
                 pipeProgram: "kubectl",
                 pipeArgs: [ "exec", "-i", pod, "--" ],
-                debuggerPath: "/vsdbg/vsdbg",
+                debuggerPath: extensionConfig.getDotnetVsdbgPath(),
                 pipeCwd: workspaceFolder,
                 quoteArgs: false
             }


### PR DESCRIPTION
Fixes #962

* add new option `vs-kubernetes.dotnet-vsdbg-path` to set path to vsdbg inside container
* change default path to `vsdbg` from `/vsdbg/vsdbg` to `~/vsdbg/vsdbg`