### PR TITLE
Add maintainer list

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,14 @@ All members of the Open Source Community are welcome to contribute to this proje
 
 When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+## Code of Conduct
+
+See [Code of Conduct](CODE_OF_CONDUCT.md) for the standards by which we ask community members
+to abide.
 
 ## Contributors and Committers
 
-Individuals who are interested in directly affecting repository content may request the privilege in becoming a committer. After an individual has made number of high quality contributions that demonstrate that they understand how the project works, they can request commit access or be nominated by another member of the community. All requests for committer status will be reviewed and decided by existing committers transparently.
+See [Governance](GOVERNANCE.md) for information about contributor and committer roles.
 
 ## Prerequisites
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,25 @@
+# VS Code Kubernetes Tools Project Goveranance
+
+This document outlines how the Kubernetes extension project governs itself.  This
+comprises the extension itself, the API package and the API samples.
+
+Everyone who interacts with the project must abide by our [Code of Conduct].
+
+## Legal
+
+The Kubernetes extension project is in the CNCF.
+
+## Roles
+
+Individuals who are interested in directly affecting repository content may request the privilege in becoming a committer. After an individual has made number of high quality contributions that demonstrate that they understand how the project works, they can request commit access or be nominated by another member of the community. All requests for committer status will be reviewed and decided by existing committers transparently.
+
+The [OWNERS] file defines the current maintainers of the project.
+
+## Release Process
+
+Maintainers create the next release when the main branch is stable and related
+groupings of work is complete. We do not have a fixed cadence and prefer to release
+smaller batches of work more often.
+
+[Code of Conduct]: /CODE_OF_CONDUCT.md
+[OWNERS]: /OWNERS.md

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,9 @@
+# VS Code Kubernetes Tools Project Ownership
+
+## Maintainers
+
+The following people are current maintainers of the Kubernetes extension project:
+
+* [Ivan Towlson](https://github.com/itowlson)
+* [Luca Stocchi](https://github.com/lstocchi)
+* [Bhargav Nookala](https://github.com/bnookala)

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Here are the various linters, you can enable or disable them individually using 
 
   * `Kubernetes: Debug` command currently works only with Go, Node.js, Java, Python and .NET applications
   * For deeply nested Helm charts, template previews are generated against highest (umbrella) chart values (though for `Helm: Template` calls you can pick your chart)
-  * When installing VS Code and/or kubectl through `snap` on a Linux system, you may face some permissions error which will prevent this extension to work correctly. As a workaround you can set up the `vs-kubernetes.enable-snap-flag` setting to `true` in your user or workspace settings. 
+  * When installing VS Code and/or kubectl through `snap` on a Linux system, you may face some permissions error which will prevent this extension to work correctly. As a workaround you can set up the `vs-kubernetes.enable-snap-flag` setting to `true` in your user or workspace settings.
 
 ## Release notes
 
@@ -290,9 +290,8 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
 provided by the bot. You will only need to do this once across all repos using our CLA.
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+See [Code of Conduct](CODE_OF_CONDUCT.md) for the standards by which we ask community members
+to abide.
 
 For technical information about contributing, see [CONTRIBUTING.md](CONTRIBUTING.md).
 


### PR DESCRIPTION
CNCF commented that we did not have a readily available maintainer list.  This PR captures the current state in `OWNERS.md` and also adds some rudimentary governance info in `GOVERNANCE.md`.

These are substantially copied from the Porter project so reviewers please double-check in case I left mentions of Porter in there!

cc @gorkem for additional Red Hat perspective and because I know this is something you've tried to nudge us to do better in the past (some of the governance doc is cribbed from your contributor documentation - thanks!).