### PR TITLE
Use `/bin/sh` to run debugCommand in dotnet (#1002)

### DIFF
--- a/src/debug/dotNetDebugProvider.ts
+++ b/src/debug/dotNetDebugProvider.ts
@@ -41,10 +41,10 @@ export class DotNetDebugProvider implements IDebugProvider {
             processId: processId,
             pipeTransport: {
                 pipeProgram: "kubectl",
-                pipeArgs: [ "exec", "-i", pod, "--" ],
+                pipeArgs: [ "exec", "-i", pod, "--", "/bin/sh", "-c" ],
                 debuggerPath: extensionConfig.getDotnetVsdbgPath(),
                 pipeCwd: workspaceFolder,
-                quoteArgs: false
+                quoteArgs: true
             }
         };
         const map = extensionConfig.getDotnetDebugSourceFileMap();


### PR DESCRIPTION
Using shell allows expanding `~`.